### PR TITLE
v3.8.49: let the layer above madock answer for its own commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v3.8.49**
+
+Fixed:
+- **The project guard added in 3.8.48 refused madock-pro's machine commands.** That guard is a property of a command's definition, and a layer built on madock registers definitions madock never sees — around a hundred and ten of them in pro, whole families of which act on the host rather than on a project: `server:*`, `firewall:*`, `dns:*`, `disk:*`, the systemd `service:install|remove|status`, `webhook:*`, `mail:*`, `dashboard:tls:*`, `license:reset`, `init`, and the `:all` group. Measured on a pro binary built against 3.8.48: `firewall:status` and `version` both answered "This directory is not a madock project", and on a server nobody stands in a project directory. `command.AddScopeResolver` lets the layer that owns those commands answer for them, as a rule rather than a list of aliases; the flag stays the fallback, so an unmarked command of madock's own is still project-scoped and a forgotten check still fails loudly. A resolver may also pin a command as project-scoped, which matters where a family is shared: pro's `service:install` is the machine, madock's `service:enable` is a project's containers, and a prefix would have freed both
+
 **v3.8.48**
 
 Added:

--- a/src/app/app.go
+++ b/src/app/app.go
@@ -31,7 +31,7 @@ func Run(appVersion string) {
 	cmdName := strings.ToLower(os.Args[1])
 
 	if def, ok := command.Get(cmdName); ok {
-		if !def.Global && !configs.IsHasConfig("") {
+		if !command.IsGlobal(def) && !configs.IsHasConfig("") {
 			refuseOutsideProject(cmdName)
 			return
 		}

--- a/src/command/registry.go
+++ b/src/command/registry.go
@@ -33,6 +33,40 @@ type Definition struct {
 
 var registry = make(map[string]*Definition)
 var globalMiddlewares []Middleware
+var scopeResolvers []ScopeResolver
+
+// ScopeResolver answers whether a command belongs to a project, for a layer that
+// knows better than madock does. `decided` false means "no opinion".
+type ScopeResolver func(def *Definition) (global bool, decided bool)
+
+// AddScopeResolver registers such an answer.
+//
+// It exists because the Global flag is a property of a definition, and a layer
+// built on madock registers definitions madock never sees: madock-pro adds around
+// a hundred and ten aliases, and whole families of them — server:*, firewall:*,
+// dns:*, disk:*, service:*, the :all group — act on the machine rather than on a
+// project. Left to the default they would all be refused outside a project, which
+// is where they are actually run.
+//
+// A resolver keeps the strict default for madock's own commands, where forgetting
+// the flag has to fail loudly, while letting the layer that owns the knowledge
+// express it as a rule instead of a list of aliases nobody will maintain.
+func AddScopeResolver(resolver ScopeResolver) {
+	scopeResolvers = append(scopeResolvers, resolver)
+}
+
+// IsGlobal reports whether a command may run outside a project. Resolvers are
+// asked first, in registration order, and the flag on the definition is the
+// fallback.
+func IsGlobal(def *Definition) bool {
+	for _, resolver := range scopeResolvers {
+		if global, decided := resolver(def); decided {
+			return global
+		}
+	}
+
+	return def.Global
+}
 
 // Register adds a command definition to the registry
 func Register(def *Definition) {

--- a/src/command/registry_test.go
+++ b/src/command/registry_test.go
@@ -1,0 +1,61 @@
+package command
+
+import "testing"
+
+// TestIsGlobal covers the two ways a command can be excused from needing a project,
+// and the order between them.
+//
+// The flag is madock's own: unmarked means project-scoped, so a check forgotten
+// inside a project command cannot be forgotten silently. The resolver is for a layer
+// built on top — madock-pro registers around a hundred and ten aliases madock knows
+// nothing about, and whole families of them act on the machine. Without a way to say
+// so, its `firewall:status` was refused outside a project, which is the only place
+// anybody runs it.
+func TestIsGlobal(t *testing.T) {
+	t.Cleanup(func() { scopeResolvers = nil })
+
+	project := &Definition{Aliases: []string{"start"}}
+	global := &Definition{Aliases: []string{"help"}, Global: true}
+	layer := &Definition{Aliases: []string{"firewall:status"}}
+
+	if IsGlobal(project) {
+		t.Error("an unmarked command must be project-scoped")
+	}
+	if !IsGlobal(global) {
+		t.Error("the flag must be honoured")
+	}
+	if IsGlobal(layer) {
+		t.Error("a command no resolver has claimed is project-scoped")
+	}
+
+	AddScopeResolver(func(def *Definition) (bool, bool) {
+		for _, alias := range def.Aliases {
+			if alias == "firewall:status" {
+				return true, true
+			}
+		}
+		return false, false
+	})
+
+	if !IsGlobal(layer) {
+		t.Error("a resolver said this one is global and was not heard")
+	}
+	if IsGlobal(project) {
+		t.Error("an undecided resolver must leave the flag in charge")
+	}
+
+	// A resolver may also pin a command as project-scoped, which has to win over a
+	// flag set further down.
+	AddScopeResolver(func(def *Definition) (bool, bool) {
+		for _, alias := range def.Aliases {
+			if alias == "help" {
+				return false, true
+			}
+		}
+		return false, false
+	})
+
+	if IsGlobal(global) {
+		t.Error("a resolver's explicit answer must beat the flag")
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.8.48"
+const Version = "3.8.49"


### PR DESCRIPTION
The project guard added in 3.8.48 reads a flag on a command's definition, and madock-pro registers definitions madock never sees — around a hundred and ten aliases, whole families of which act on the host. Measured on a pro binary built against 3.8.48: `firewall:status` and `version` both answered "This directory is not a madock project", and on a server nobody stands in a project directory.

`command.AddScopeResolver` takes an answer from whoever owns those commands. Resolvers are asked first and may decline, so the flag stays in charge of madock's own commands and an unmarked one is still project-scoped — the loud default was the point and it survives. A resolver may also pin a command as project-scoped, which a shared family needs: pro's `service:install` is the systemd unit, madock's `service:enable` turns on a project's container, and a prefix rule would have excused both.

Verified against a pro binary built on this branch: `version`, `firewall:status`, `status:all` and `init` run outside a project; `backup:create`, `shared-db:info` and `start` are refused. `go build ./...`, `go test -count=1 ./...` (20 packages) and `go vet ./...` are clean.

Expect Platforms to fail as it did on #42, for the same reason and not this branch's: composer refuses `mcp/sdk v0.6.0` under advisory PKSA-p9gd-j6gr-6f9t, which `shopware/core v6.7.13.0` requires. Medusa passes in the same job.

Merge as a merge commit.