### PR TITLE
Skip the Shopware platform test, and a golden file for the shared proxy

### DIFF
--- a/src/helper/configs/aruntime/nginx/golden_test.go
+++ b/src/helper/configs/aruntime/nginx/golden_test.go
@@ -1,0 +1,64 @@
+package nginx
+
+import (
+	"flag"
+	"path/filepath"
+	"testing"
+
+	"github.com/faradey/madock/v3/src/helper/testenv"
+)
+
+// Run with -count=1: the input is docker/, plain data files the test cache knows
+// nothing about, so without it editing a template and re-running reports `ok
+// (cached)` and proves nothing.
+//
+//	go test -count=1 ./src/helper/configs/aruntime/nginx/... -run Golden -update
+var updateGolden = flag.Bool("update", false, "rewrite golden files")
+
+// TestGoldenProxyConf pins the configuration of the shared proxy — the file every
+// project's traffic passes through, and until now the one generated file nothing
+// covered at all.
+//
+// Three defects found in August lived in it and were each found by hand: a literal
+// `Connection: upgrade` sent on every request, `Host $host` dropping the port on
+// the way to the project, and `worker_priority -10` that a container cannot apply,
+// logging two alerts per start for years. The generator is three hundred lines of
+// branching, and a unit test on the preamble covers the first ten.
+//
+// It renders one project, because the interesting part is not how many blocks there
+// are but what each contains: the upstreams, the http and https servers, the
+// forwarded headers, the tool subpaths, and the livereload and vite listeners that
+// only exist here.
+func TestGoldenProxyConf(t *testing.T) {
+	projectName := "golden"
+	env := testenv.SetupWith(t, projectName, "golden.test", nil)
+
+	MakeConf(projectName)
+
+	rendered := testenv.Collect(t, filepath.Join(env.ExecDir, "aruntime", "ctx"), env)
+	if len(rendered) == 0 {
+		t.Fatal("MakeConf produced no proxy configuration")
+	}
+	if _, ok := rendered["proxy.conf"]; !ok {
+		t.Fatalf("proxy.conf is not among the generated files: %v", keys(rendered))
+	}
+
+	// Only proxy.conf: the certificate and the key beside it are regenerated on
+	// every run and are not text a golden file can hold.
+	only := map[string]string{"proxy.conf": rendered["proxy.conf"]}
+
+	goldenDir := filepath.Join("testdata", "golden", "proxy")
+	if *updateGolden {
+		testenv.WriteGolden(t, goldenDir, only)
+		return
+	}
+	testenv.CompareGolden(t, goldenDir, only)
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/src/helper/configs/aruntime/nginx/golden_test.go
+++ b/src/helper/configs/aruntime/nginx/golden_test.go
@@ -3,6 +3,8 @@ package nginx
 import (
 	"flag"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/faradey/madock/v3/src/helper/testenv"
@@ -45,7 +47,15 @@ func TestGoldenProxyConf(t *testing.T) {
 
 	// Only proxy.conf: the certificate and the key beside it are regenerated on
 	// every run and are not text a golden file can hold.
-	only := map[string]string{"proxy.conf": rendered["proxy.conf"]}
+	//
+	// Port numbers go too, and that one cost a red CI run. Allocation skips ports
+	// already in use on the machine, so this laptop's registry handed out 17003
+	// where a fresh runner handed out 17000 — and the proxy configuration carries
+	// the number in every upstream name and every proxy_pass. The names still have
+	// to agree with the passes, so the substitution is by position: the first
+	// distinct port becomes <PORT1>, the second <PORT2>, and a block that pointed
+	// at the wrong one would still show up as a difference.
+	only := map[string]string{"proxy.conf": maskPorts(rendered["proxy.conf"])}
 
 	goldenDir := filepath.Join("testdata", "golden", "proxy")
 	if *updateGolden {
@@ -53,6 +63,24 @@ func TestGoldenProxyConf(t *testing.T) {
 		return
 	}
 	testenv.CompareGolden(t, goldenDir, only)
+}
+
+// allocatedPort matches the ports madock hands out, which are five digits from
+// 17000 up. The proxy's own listeners — 80, 443, 35729, 5173 — are fixed and stay
+// as they are, which is why the pattern is anchored on the range rather than on
+// "any number".
+var allocatedPort = regexp.MustCompile(`\b1[78]\d{3}\b`)
+
+func maskPorts(content string) string {
+	seen := map[string]string{}
+	return allocatedPort.ReplaceAllStringFunc(content, func(port string) string {
+		if name, ok := seen[port]; ok {
+			return name
+		}
+		name := "<PORT" + strconv.Itoa(len(seen)+1) + ">"
+		seen[port] = name
+		return name
+	})
 }
 
 func keys(m map[string]string) []string {

--- a/src/helper/configs/aruntime/nginx/golden_test.go
+++ b/src/helper/configs/aruntime/nginx/golden_test.go
@@ -69,7 +69,15 @@ func TestGoldenProxyConf(t *testing.T) {
 // 17000 up. The proxy's own listeners — 80, 443, 35729, 5173 — are fixed and stay
 // as they are, which is why the pattern is anchored on the range rather than on
 // "any number".
-var allocatedPort = regexp.MustCompile(`\b1[78]\d{3}\b`)
+//
+// No \b around it, and that is the point: the number appears as
+// `upstreamm_madock_17003`, where an underscore is a word character, so a word
+// boundary never falls between it and the first digit. The first version of this
+// pattern had them, matched only the `host.docker.internal:17003` form, and left
+// every upstream name with a live port in it — and the grep that was supposed to
+// catch that used the same pattern, so it agreed. Go's regexp has no lookbehind to
+// express it more tightly; the five-digit range is distinctive enough here.
+var allocatedPort = regexp.MustCompile(`1[78]\d{3}`)
 
 func maskPorts(content string) string {
 	seen := map[string]string{}

--- a/src/helper/configs/aruntime/nginx/nginx.go
+++ b/src/helper/configs/aruntime/nginx/nginx.go
@@ -72,9 +72,8 @@ func setPorts(projectName string) {
 // directives that must exist exactly once for all projects.
 //
 // A function of its configuration and nothing else, so the branches here can be
-// asserted without generating a whole installation. There are no golden files for
-// the shared proxy.conf — the harness that renders one belongs to another package —
-// and this is where its conditionals live.
+// asserted without generating a whole installation, which the golden file beside
+// this package does end to end.
 func proxyPreamble(generalConfig map[string]string) string {
 	// worker_priority used to be set to -10 here and never worked: lowering a nice
 	// value needs CAP_SYS_NICE, which is not in a container's default capability

--- a/src/helper/configs/aruntime/nginx/testdata/golden/proxy/proxy.conf
+++ b/src/helper/configs/aruntime/nginx/testdata/golden/proxy/proxy.conf
@@ -27,14 +27,14 @@ log_format main '$remote_addr - $host [$time_local] "$request" '
                 '"$http_user_agent" $request_time';
 access_log /var/log/nginx/access.log main;
 
-upstream upstreamm_madock_17003 {
+upstream upstreamm_madock_<PORT1> {
   keepalive 512;
   server host.docker.internal:<PORT1> max_fails=3 fail_timeout=30s;
 }
-upstream upstreamm_madock_17008 {
+upstream upstreamm_madock_<PORT2> {
   server host.docker.internal:<PORT2> max_fails=3 fail_timeout=30s;
 }
-upstream upstreamm_madock_17009 {
+upstream upstreamm_madock_<PORT3> {
   server host.docker.internal:<PORT3> max_fails=3 fail_timeout=30s;
 }
 
@@ -60,7 +60,7 @@ server {
             proxy_buffers              256 16k;
             proxy_busy_buffers_size    256k;
             proxy_temp_file_write_size 256k;
-            proxy_pass         http://upstreamm_madock_17003;
+            proxy_pass         http://upstreamm_madock_<PORT1>;
         }
 
         location /phpmyadmin/ {
@@ -207,7 +207,7 @@ server {
             proxy_buffers              256 16k;
             proxy_busy_buffers_size    256k;
             proxy_temp_file_write_size 256k;
-            proxy_pass         http://upstreamm_madock_17003;
+            proxy_pass         http://upstreamm_madock_<PORT1>;
         }
 
         location /phpmyadmin/ {
@@ -341,7 +341,7 @@ server {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $http_host;
             proxy_read_timeout 86400;
-            proxy_pass http://upstreamm_madock_17008/;
+            proxy_pass http://upstreamm_madock_<PORT2>/;
         }
 }
 
@@ -354,7 +354,7 @@ server {
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $http_host;
             proxy_read_timeout 86400;
-            proxy_pass http://upstreamm_madock_17009/;
+            proxy_pass http://upstreamm_madock_<PORT3>/;
         }
 }
 

--- a/src/helper/configs/aruntime/nginx/testdata/golden/proxy/proxy.conf
+++ b/src/helper/configs/aruntime/nginx/testdata/golden/proxy/proxy.conf
@@ -1,0 +1,372 @@
+worker_processes 2;
+worker_rlimit_nofile 200000;
+events {
+    worker_connections 4096;
+use epoll;
+}
+http {
+server_names_hash_bucket_size  128;
+server_names_hash_max_size 1024;
+# Rate limiting (protection against infinite loops)
+limit_req_zone $binary_remote_addr zone=general:10m rate=1000r/s;
+# Gzip compression
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_min_length 1000;
+gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml;
+# WebSocket upgrade map
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' '';
+}
+# Access log format
+log_format main '$remote_addr - $host [$time_local] "$request" '
+                '$status $body_bytes_sent "$http_referer" '
+                '"$http_user_agent" $request_time';
+access_log /var/log/nginx/access.log main;
+
+upstream upstreamm_madock_17003 {
+  keepalive 512;
+  server host.docker.internal:17003 max_fails=3 fail_timeout=30s;
+}
+upstream upstreamm_madock_17008 {
+  server host.docker.internal:17008 max_fails=3 fail_timeout=30s;
+}
+upstream upstreamm_madock_17009 {
+  server host.docker.internal:17009 max_fails=3 fail_timeout=30s;
+}
+
+server {
+        listen 80;
+        server_name  golden.test;
+        location / {
+            limit_req zone=general burst=2000 nodelay;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   Host      $http_host;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            client_max_body_size       2G;
+            client_body_buffer_size    512k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+            send_timeout 60s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+            proxy_pass         http://upstreamm_madock_17003;
+        }
+
+        location /phpmyadmin/ {
+            proxy_pass         http://host.docker.internal:17010/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /phpmyadmin2/ {
+            proxy_pass         http://host.docker.internal:17014/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /kibana/ {
+            proxy_pass         http://host.docker.internal:17015/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /opensearch-dashboard/ {
+            proxy_pass         http://host.docker.internal:17016/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /grafana/ {
+            proxy_pass         http://host.docker.internal:17023/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /grafana/api/live/ {
+            rewrite ^/grafana/(.*) /$1 break;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_pass http://host.docker.internal:17023;
+        }
+}
+
+server {
+        listen 443 ssl;
+        http2 on;
+        server_name  golden.test;
+        location / {
+            limit_req zone=general burst=2000 nodelay;
+            proxy_set_header   X-Real-IP $remote_addr;
+            # $http_host, not $host: the latter drops the port, and this stack
+            # is regularly published somewhere other than 443. The unsecure
+            # server above has always done it this way.
+            proxy_set_header   Host      $http_host;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            client_max_body_size       2G;
+            client_body_buffer_size    512k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+            send_timeout 60s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+            proxy_pass         http://upstreamm_madock_17003;
+        }
+
+        location /phpmyadmin/ {
+            proxy_pass         http://host.docker.internal:17010/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /phpmyadmin2/ {
+            proxy_pass         http://host.docker.internal:17014/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /kibana/ {
+            proxy_pass         http://host.docker.internal:17015/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /opensearch-dashboard/ {
+            proxy_pass         http://host.docker.internal:17016/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /grafana/ {
+            proxy_pass         http://host.docker.internal:17023/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       2G;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /grafana/api/live/ {
+            rewrite ^/grafana/(.*) /$1 break;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_pass http://host.docker.internal:17023;
+        }
+
+        ssl_certificate /sslcert/fullchain.crt;
+        ssl_certificate_key /sslcert/madock.local.key;
+        include /sslcert/options-ssl-nginx.conf;
+}
+
+server {
+        listen 35729;
+        server_name  golden.test;
+        location / {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $http_host;
+            proxy_read_timeout 86400;
+            proxy_pass http://upstreamm_madock_17008/;
+        }
+}
+
+server {
+        listen 5173;
+        server_name  golden.test;
+        location / {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $http_host;
+            proxy_read_timeout 86400;
+            proxy_pass http://upstreamm_madock_17009/;
+        }
+}
+
+server {
+    listen       80  default_server;
+    listen 443 default_server ssl;
+    http2 on;
+    server_name  _;
+    return       444;
+    ssl_certificate /sslcert/fullchain.crt;
+    ssl_certificate_key /sslcert/madock.local.key;
+    include /sslcert/options-ssl-nginx.conf; 
+}
+
+}

--- a/src/helper/configs/aruntime/nginx/testdata/golden/proxy/proxy.conf
+++ b/src/helper/configs/aruntime/nginx/testdata/golden/proxy/proxy.conf
@@ -29,13 +29,13 @@ access_log /var/log/nginx/access.log main;
 
 upstream upstreamm_madock_17003 {
   keepalive 512;
-  server host.docker.internal:17003 max_fails=3 fail_timeout=30s;
+  server host.docker.internal:<PORT1> max_fails=3 fail_timeout=30s;
 }
 upstream upstreamm_madock_17008 {
-  server host.docker.internal:17008 max_fails=3 fail_timeout=30s;
+  server host.docker.internal:<PORT2> max_fails=3 fail_timeout=30s;
 }
 upstream upstreamm_madock_17009 {
-  server host.docker.internal:17009 max_fails=3 fail_timeout=30s;
+  server host.docker.internal:<PORT3> max_fails=3 fail_timeout=30s;
 }
 
 server {
@@ -64,7 +64,7 @@ server {
         }
 
         location /phpmyadmin/ {
-            proxy_pass         http://host.docker.internal:17010/;
+            proxy_pass         http://host.docker.internal:<PORT4>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -85,7 +85,7 @@ server {
         }
 
         location /phpmyadmin2/ {
-            proxy_pass         http://host.docker.internal:17014/;
+            proxy_pass         http://host.docker.internal:<PORT5>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -106,7 +106,7 @@ server {
         }
 
         location /kibana/ {
-            proxy_pass         http://host.docker.internal:17015/;
+            proxy_pass         http://host.docker.internal:<PORT6>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -127,7 +127,7 @@ server {
         }
 
         location /opensearch-dashboard/ {
-            proxy_pass         http://host.docker.internal:17016/;
+            proxy_pass         http://host.docker.internal:<PORT7>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -148,7 +148,7 @@ server {
         }
 
         location /grafana/ {
-            proxy_pass         http://host.docker.internal:17023/;
+            proxy_pass         http://host.docker.internal:<PORT8>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -175,7 +175,7 @@ server {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
-            proxy_pass http://host.docker.internal:17023;
+            proxy_pass http://host.docker.internal:<PORT8>;
         }
 }
 
@@ -211,7 +211,7 @@ server {
         }
 
         location /phpmyadmin/ {
-            proxy_pass         http://host.docker.internal:17010/;
+            proxy_pass         http://host.docker.internal:<PORT4>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -233,7 +233,7 @@ server {
         }
 
         location /phpmyadmin2/ {
-            proxy_pass         http://host.docker.internal:17014/;
+            proxy_pass         http://host.docker.internal:<PORT5>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -255,7 +255,7 @@ server {
         }
 
         location /kibana/ {
-            proxy_pass         http://host.docker.internal:17015/;
+            proxy_pass         http://host.docker.internal:<PORT6>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -276,7 +276,7 @@ server {
         }
 
         location /opensearch-dashboard/ {
-            proxy_pass         http://host.docker.internal:17016/;
+            proxy_pass         http://host.docker.internal:<PORT7>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -297,7 +297,7 @@ server {
         }
 
         location /grafana/ {
-            proxy_pass         http://host.docker.internal:17023/;
+            proxy_pass         http://host.docker.internal:<PORT8>/;
             proxy_redirect     off;
 
             proxy_set_header   Host             $host;
@@ -324,7 +324,7 @@ server {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_set_header Host $host;
-            proxy_pass http://host.docker.internal:17023;
+            proxy_pass http://host.docker.internal:<PORT8>;
         }
 
         ssl_certificate /sslcert/fullchain.crt;

--- a/src/helper/configs/aruntime/project/golden_test.go
+++ b/src/helper/configs/aruntime/project/golden_test.go
@@ -2,12 +2,10 @@ package project
 
 import (
 	"flag"
-	"io/fs"
-	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"testing"
+
+	"github.com/faradey/madock/v3/src/helper/testenv"
 )
 
 // Run these with -count=1, always:
@@ -183,246 +181,21 @@ func TestGoldenGeneratedConfig(t *testing.T) {
 	for _, testCase := range goldenCases() {
 		t.Run(testCase.name, func(t *testing.T) {
 			projectName := "golden"
-			env := setupTestEnvironmentWith(t, projectName, "golden.test", testCase.overrides)
+			env := testenv.SetupWith(t, projectName, "golden.test", testCase.overrides)
 
 			MakeConf(projectName)
 
-			rendered := collectGenerated(t, filepath.Join(env.execDir, "aruntime", "projects", projectName), env)
+			rendered := testenv.Collect(t, filepath.Join(env.ExecDir, "aruntime", "projects", projectName), env)
 			if len(rendered) == 0 {
 				t.Fatal("MakeConf produced no files")
 			}
 
 			goldenDir := filepath.Join("testdata", "golden", testCase.name)
 			if *updateGolden {
-				writeGolden(t, goldenDir, rendered)
+				testenv.WriteGolden(t, goldenDir, rendered)
 				return
 			}
-			compareGolden(t, goldenDir, rendered)
+			testenv.CompareGolden(t, goldenDir, rendered)
 		})
-	}
-}
-
-// collectGenerated reads every generated file, with the machine-specific parts
-// replaced so the same output is expected on any machine.
-func collectGenerated(t *testing.T, root string, env *testEnv) map[string]string {
-	t.Helper()
-
-	files := map[string]string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		// The runtime directory holds symlinks to the project source, the
-		// composer home and ~/.ssh. Following them would pull the whole
-		// working tree into the comparison.
-		if d.Type()&fs.ModeSymlink != 0 || d.IsDir() {
-			return nil
-		}
-		content, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
-		rel, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			return relErr
-		}
-		files[filepath.ToSlash(rel)] = normalise(string(content), env)
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("reading generated files: %v", err)
-	}
-	return files
-}
-
-var (
-	// Only a ports mapping, and only where compose writes one: a list entry.
-	// Matching every `"NNNN:` in the file swallowed `user: "1001:1001"` on a
-	// Linux runner, where a uid happens to be four digits.
-	publishedPort = regexp.MustCompile(`- "\d{4,5}:`)
-
-	// uid and gid are normalised where they are *used*, not wherever their
-	// digits appear. Replacing the values themselves looked simpler and was
-	// wrong twice over: a macOS gid of 20 rewrote unrelated numbers inside the
-	// Grafana dashboards ("2093" became "<GID>93"), and on a CI runner where
-	// uid == gid the second replacement found nothing left to replace, so
-	// `groupmod -g` came out as `<UID>`. Both produced golden files that could
-	// only ever match the machine that wrote them.
-	composeUser = regexp.MustCompile(`user: "\d+:\d+"`)
-	usermodUid  = regexp.MustCompile(`usermod -u \d+`)
-	groupmodGid = regexp.MustCompile(`groupmod -g \d+`)
-	chownPair   = regexp.MustCompile(`chown (-R )?\d+:\d+`)
-
-	// The loader URL carries the host architecture, so an arm64 laptop and an
-	// amd64 runner render different files from the same template.
-	loaderArch = regexp.MustCompile(`ioncube_loaders_lin_[\w-]+\.tar\.gz`)
-)
-
-// normalise removes what differs between machines and runs.
-//
-// Ports are allocated by probing the host for something free, so they depend on
-// what else is listening; uid, gid and the CPU architecture come from whoever
-// runs the tests. None of that is what these tests are about — the shape of the
-// rendered file is.
-func normalise(content string, env *testEnv) string {
-	content = strings.ReplaceAll(content, env.execDir, "<EXEC_DIR>")
-	content = strings.ReplaceAll(content, env.runDir, "<RUN_DIR>")
-	content = publishedPort.ReplaceAllString(content, `- "<PORT>:`)
-	content = composeUser.ReplaceAllString(content, `user: "<UID>:<GID>"`)
-	content = usermodUid.ReplaceAllString(content, "usermod -u <UID>")
-	content = groupmodGid.ReplaceAllString(content, "groupmod -g <GID>")
-	content = chownPair.ReplaceAllString(content, "chown ${1}<UID>:<GID>")
-	content = loaderArch.ReplaceAllString(content, "ioncube_loaders_lin_<ARCH>.tar.gz")
-
-	return content
-}
-
-func writeGolden(t *testing.T, goldenDir string, rendered map[string]string) {
-	t.Helper()
-
-	if err := os.RemoveAll(goldenDir); err != nil {
-		t.Fatalf("clearing %s: %v", goldenDir, err)
-	}
-	for name, content := range rendered {
-		path := filepath.Join(goldenDir, filepath.FromSlash(name))
-		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-			t.Fatalf("creating %s: %v", filepath.Dir(path), err)
-		}
-		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-			t.Fatalf("writing %s: %v", path, err)
-		}
-	}
-	t.Logf("wrote %d golden files to %s — read the diff before committing", len(rendered), goldenDir)
-}
-
-func compareGolden(t *testing.T, goldenDir string, rendered map[string]string) {
-	t.Helper()
-
-	expected := map[string]string{}
-	err := filepath.WalkDir(goldenDir, func(path string, d fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if d.IsDir() {
-			return nil
-		}
-		content, readErr := os.ReadFile(path)
-		if readErr != nil {
-			return readErr
-		}
-		rel, _ := filepath.Rel(goldenDir, path)
-		expected[filepath.ToSlash(rel)] = string(content)
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("no golden files in %s (%v) — run with -update", goldenDir, err)
-	}
-
-	for name, want := range expected {
-		got, rendered_ok := rendered[name]
-		if !rendered_ok {
-			t.Errorf("%s is no longer generated", name)
-			continue
-		}
-		if got != want {
-			t.Errorf("%s differs from the golden copy:\n%s", name, firstDifference(want, got))
-		}
-	}
-
-	for name := range rendered {
-		if _, known := expected[name]; !known {
-			t.Errorf("%s is generated but has no golden copy — new output, or a file that moved", name)
-		}
-	}
-}
-
-// firstDifference reports the first differing line with a little context, which
-// is what a reader needs; a full diff of a 200-line compose file is not.
-func firstDifference(want, got string) string {
-	wantLines := strings.Split(want, "\n")
-	gotLines := strings.Split(got, "\n")
-
-	for i := 0; i < len(wantLines) || i < len(gotLines); i++ {
-		wantLine := ""
-		if i < len(wantLines) {
-			wantLine = wantLines[i]
-		}
-		gotLine := ""
-		if i < len(gotLines) {
-			gotLine = gotLines[i]
-		}
-		if wantLine != gotLine {
-			return "  line " + itoa(i+1) + "\n    want: " + wantLine + "\n    got:  " + gotLine
-		}
-	}
-	return "  (files differ only in trailing content)"
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	digits := ""
-	for n > 0 {
-		digits = string(rune('0'+n%10)) + digits
-		n /= 10
-	}
-	return digits
-}
-
-// TestNormalise pins the thing the golden files depend on and nothing else
-// checks: that two different machines normalise to the same text.
-//
-// Both cases here are real. macOS gives a gid of 20, which the old
-// value-substitution normaliser found inside unrelated numbers; a GitHub runner
-// gives uid == gid, where replacing the uid first left the gid with nothing to
-// match. Either one produced golden files that only the machine that wrote them
-// could reproduce.
-func TestNormalise(t *testing.T) {
-	env := &testEnv{execDir: "/exec", runDir: "/run"}
-
-	// The same rendered file as three machines would write it: an arm64 laptop
-	// (uid 501, gid 20), an amd64 runner (uid 1001, gid 1001), and a Linux
-	// desktop (uid 1000, gid 1000).
-	render := func(uid, gid, arch string) string {
-		return strings.Join([]string{
-			`    user: "` + uid + `:` + gid + `"`,
-			`      - "34500:80"`,
-			`RUN usermod -u ` + uid + ` -o www-data && groupmod -g ` + gid + ` -o www-data`,
-			`RUN mkdir /var/www/.npm && chown ` + uid + `:` + gid + ` /var/www/.npm`,
-			`    && chown -R ` + uid + `:` + gid + ` /var/www`,
-			`    && curl -o ioncube.tar.gz http://x/ioncube_loaders_lin_` + arch + `.tar.gz \\`,
-			`RUN sed -i 's/session.cookie_lifetime = 0/session.cookie_lifetime = 2592000/g' php.ini`,
-			`        "uid": "PBFA97CFB590B2093"`,
-			`  ingestion_burst_size_mb: 20`,
-		}, "\n")
-	}
-
-	mac := normalise(render("501", "20", "aarch64"), env)
-	ci := normalise(render("1001", "1001", "x86-64"), env)
-	linux := normalise(render("1000", "1000", "x86-64"), env)
-
-	if mac != ci {
-		t.Errorf("macOS and CI normalise differently:\n%s\n---\n%s", mac, ci)
-	}
-	if ci != linux {
-		t.Errorf("two Linux machines normalise differently:\n%s\n---\n%s", ci, linux)
-	}
-
-	// The numbers that are not ids must survive, and the ids must not.
-	for _, want := range []string{
-		`user: "<UID>:<GID>"`,
-		`- "<PORT>:80"`,
-		"usermod -u <UID> -o www-data && groupmod -g <GID> -o www-data",
-		"chown <UID>:<GID> /var/www/.npm",
-		"chown -R <UID>:<GID> /var/www",
-		"ioncube_loaders_lin_<ARCH>.tar.gz",
-		"session.cookie_lifetime = 2592000",
-		`"uid": "PBFA97CFB590B2093"`,
-		"ingestion_burst_size_mb: 20",
-	} {
-		if !strings.Contains(mac, want) {
-			t.Errorf("normalised output is missing %q:\n%s", want, mac)
-		}
 	}
 }

--- a/src/helper/configs/aruntime/project/project_e2e_test.go
+++ b/src/helper/configs/aruntime/project/project_e2e_test.go
@@ -12,16 +12,17 @@ import (
 
 	"github.com/faradey/madock/v3/src/helper/configs"
 	"github.com/faradey/madock/v3/src/helper/ports"
+	"github.com/faradey/madock/v3/src/helper/testenv"
 )
 
 // setupE2EEnvironment creates a test environment with redis enabled on top of the base setup.
-func setupE2EEnvironment(t *testing.T, projectName, hostName string) *testEnv {
+func setupE2EEnvironment(t *testing.T, projectName, hostName string) *testenv.Env {
 	t.Helper()
 
-	env := setupTestEnvironment(t, projectName, hostName)
+	env := testenv.Setup(t, projectName, hostName)
 
 	// Enable redis in the project config via SaveInFile (merges into existing XML)
-	projectConfigPath := filepath.Join(env.execDir, "projects", projectName, "config.xml")
+	projectConfigPath := filepath.Join(env.ExecDir, "projects", projectName, "config.xml")
 	configs.SaveInFile(projectConfigPath, map[string]string{
 		"redis/enabled": "true",
 	}, "default")
@@ -68,7 +69,7 @@ func TestE2E_Magento2_ContainersStart(t *testing.T) {
 	// Generate all docker config files
 	MakeConf(projectName)
 
-	runtimeDir := filepath.Join(env.execDir, "aruntime", "projects", projectName)
+	runtimeDir := filepath.Join(env.ExecDir, "aruntime", "projects", projectName)
 
 	// Create the external docker network (ignore error if it already exists)
 	exec.Command("docker", "network", "create", "madock-proxy").Run()

--- a/src/helper/configs/aruntime/project/project_integration_test.go
+++ b/src/helper/configs/aruntime/project/project_integration_test.go
@@ -3,226 +3,19 @@ package project
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/faradey/madock/v3/src/helper/configs"
-	"github.com/faradey/madock/v3/src/helper/ports"
+	"github.com/faradey/madock/v3/src/helper/testenv"
 )
 
-// findProjectRoot locates the madock project root by walking up from the current test file.
-func findProjectRoot(t *testing.T) string {
-	t.Helper()
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("cannot determine test file path")
-	}
-	dir := filepath.Dir(filename)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("cannot find project root (go.mod)")
-		}
-		dir = parent
-	}
-}
-
-// testEnv holds paths for the test environment and cleanup function.
-type testEnv struct {
-	execDir     string
-	runDir      string
-	projectName string
-}
-
-// setupTestEnvironment creates a temp directory structure that MakeConf can work with.
-// It symlinks docker/ and scripts/ from the real project, copies config.xml,
-// and creates a project config via SaveInFile.
-func setupTestEnvironment(t *testing.T, projectName, hostName string) *testEnv {
-	t.Helper()
-	return setupTestEnvironmentWith(t, projectName, hostName, nil)
-}
-
-// setupTestEnvironmentWith is setupTestEnvironment with the project config
-// opened up: overrides are applied on top of the Magento defaults below, so a
-// test can describe a different platform, language or database without
-// restating the ninety keys it does not care about.
-func setupTestEnvironmentWith(t *testing.T, projectName, hostName string, overrides map[string]string) *testEnv {
-	t.Helper()
-	realRoot := findProjectRoot(t)
-
-	tmpDir, err := os.MkdirTemp("", "madock-integration-*")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(tmpDir) })
-
-	execDir := filepath.Join(tmpDir, "exec")
-	runDir := filepath.Join(tmpDir, "run")
-
-	// Create directory structure
-	dirs := []string{
-		execDir,
-		filepath.Join(execDir, "projects", projectName, "docker", "ctx"),
-		filepath.Join(execDir, "aruntime", "projects", projectName, "ctx"),
-		filepath.Join(execDir, "cache"),
-		filepath.Join(execDir, "scripts"),
-		runDir,
-	}
-	for _, d := range dirs {
-		if err := os.MkdirAll(d, 0755); err != nil {
-			t.Fatalf("Failed to create dir %s: %v", d, err)
-		}
-	}
-
-	// Symlink docker/ from real project
-	if err := os.Symlink(filepath.Join(realRoot, "docker"), filepath.Join(execDir, "docker")); err != nil {
-		t.Fatalf("Failed to symlink docker/: %v", err)
-	}
-
-	// Copy config.xml (global config template)
-	srcConfig, err := os.ReadFile(filepath.Join(realRoot, "config.xml"))
-	if err != nil {
-		t.Fatalf("Failed to read config.xml: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(execDir, "config.xml"), srcConfig, 0644); err != nil {
-		t.Fatalf("Failed to write config.xml: %v", err)
-	}
-
-	// Set env vars
-	t.Setenv("MADOCK_EXEC_DIR", execDir)
-	t.Setenv("MADOCK_RUN_DIR", runDir)
-
-	// Clean config cache so the new env vars are picked up
-	configs.CleanCache()
-
-	// Create project config via SaveInFile with Magento 2.4.8 settings
-	projectConfigPath := filepath.Join(execDir, "projects", projectName, "config.xml")
-	projectConfigData := map[string]string{
-		"platform":                     "magento2",
-		"language":                     "php",
-		"path":                         runDir,
-		"php/enabled":                  "true",
-		"php/version":                  "8.4",
-		"php/composer/version":         "2",
-		"php/xdebug/version":           "3.4.4",
-		"php/xdebug/remote_host":       "host.docker.internal",
-		"php/xdebug/ide_key":           "PHPSTORM",
-		"php/xdebug/enabled":           "false",
-		"php/xdebug/mode":              "debug",
-		"php/ioncube/enabled":          "false",
-		"php/nodejs/enabled":           "false",
-		"timezone":                     "UTC",
-		"workdir":                      "/var/www/html",
-		"public_dir":                   "pub",
-		"composer_dir":                 "",
-		"db/repository":                "mariadb",
-		"db/version":                   "11.4",
-		"db/root_password":             "password",
-		"db/user":                      "magento",
-		"db/password":                  "magento",
-		"db/database":                  "magento",
-		"db/phpmyadmin/enabled":        "false",
-		"db2/enabled":                  "false",
-		"search/engine":                "OpenSearch",
-		"search/elasticsearch/enabled": "false",
-		"search/elasticsearch/version": "8.17.6",
-		"search/elasticsearch/repository": "elasticsearch",
-		"search/opensearch/enabled":    "true",
-		"search/opensearch/version":    "2.19.0",
-		"search/opensearch/repository": "opensearchproject/opensearch",
-		"search/opensearch/dashboard/enabled":    "false",
-		"search/opensearch/dashboard/repository": "opensearchproject/opensearch-dashboards",
-		"search/elasticsearch/dashboard/enabled":    "false",
-		"search/elasticsearch/dashboard/repository": "kibana",
-		"redis/enabled":                "false",
-		"redis/repository":             "redis",
-		"redis/version":                "8.0",
-		"valkey/enabled":               "false",
-		"valkey/repository":            "valkey/valkey",
-		"valkey/version":               "8.1.3",
-		"rabbitmq/enabled":             "false",
-		"rabbitmq/repository":          "rabbitmq",
-		"rabbitmq/version":             "4.1",
-		"nodejs/enabled":               "false",
-		"nodejs/repository":            "node",
-		"nodejs/version":               "18.15.0",
-		"nodejs/major_version":         "18",
-		"nodejs/yarn/enabled":          "false",
-		"cron/enabled":                 "false",
-		"nginx/ssl/enabled":            "true",
-		"nginx/http/version":           "http2",
-		"nginx/run_type":               "website",
-		"nginx/default_host_first_level": ".test",
-		"nginx/port/unsecure":          "80",
-		"nginx/port/secure":            "443",
-		"nginx/port/internal":          "80",
-		"nginx/interface_ip":           "",
-		"os/name":                      "ubuntu",
-		"os/version":                   "22.04",
-		"container_name_prefix":        "madock_",
-		"restart_policy":               "no",
-		"proxy/enabled":                "true",
-		"proxy/timeout/connect":        "60",
-		"proxy/timeout/send":           "300",
-		"proxy/timeout/read":           "300",
-		"proxy/gzip/enabled":           "true",
-		"proxy/rate_limit/enabled":     "true",
-		"proxy/rate_limit/rate":        "1000",
-		"proxy/rate_limit/burst":       "2000",
-		"isolation/enabled":            "false",
-		"varnish/enabled":              "false",
-		"grafana/enabled":              "false",
-		"claude/enabled":               "false",
-		"claude/nodejs_repository":     "node",
-		"claude/nodejs_version":        "22.19.0",
-		"ssh/auth_type":                "key",
-		"ssh/port":                     "22",
-		"magento/admin_user":           "admin",
-		"magento/admin_password":       "admin123",
-		"magento/admin_first_name":     "admin",
-		"magento/admin_last_name":      "admin",
-		"magento/admin_email":          "admin@admin.com",
-		"magento/admin_frontname":      "admin",
-		"magento/locale":               "en_US",
-		"magento/currency":             "USD",
-		"magento/timezone":             "America/Chicago",
-		"magento/cloud/enabled":        "false",
-		"magento/mftf/enabled":         "false",
-		"magento/n98magerun/enabled":   "false",
-	}
-
-	if hostName != "" {
-		projectConfigData["nginx/hosts/base/name"] = hostName
-	}
-
-	for key, value := range overrides {
-		projectConfigData[key] = value
-	}
-
-	configs.SaveInFile(projectConfigPath, projectConfigData, "default")
-
-	// Clean cache again after writing config
-	configs.CleanCache()
-	// Reset global port registry so it re-reads from the new execDir
-	ports.ResetRegistry()
-
-	return &testEnv{
-		execDir:     execDir,
-		runDir:      runDir,
-		projectName: projectName,
-	}
-}
-
 func TestMakeConfMagento2Integration(t *testing.T) {
-	env := setupTestEnvironment(t, "testproject", "magento248.test")
+	env := testenv.Setup(t, "testproject", "magento248.test")
 
-	MakeConf(env.projectName)
+	MakeConf(env.ProjectName)
 
-	runtimeDir := filepath.Join(env.execDir, "aruntime", "projects", env.projectName)
+	runtimeDir := filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName)
 	ctxDir := filepath.Join(runtimeDir, "ctx")
 
 	// Verify expected files exist
@@ -262,22 +55,22 @@ func TestMakeConfMagento2Integration(t *testing.T) {
 }
 
 func TestMakeConfMagento2_NginxHostConfig(t *testing.T) {
-	env := setupTestEnvironment(t, "hostproject", "magento248.test")
+	env := testenv.Setup(t, "hostproject", "magento248.test")
 
-	MakeConf(env.projectName)
+	MakeConf(env.ProjectName)
 
-	ctxDir := filepath.Join(env.execDir, "aruntime", "projects", env.projectName, "ctx")
+	ctxDir := filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName, "ctx")
 	nginxConf := filepath.Join(ctxDir, "nginx.conf")
 
 	assertFileContains(t, nginxConf, "magento248.test")
 }
 
 func TestMakeConfMagento2_DockerComposeServices(t *testing.T) {
-	env := setupTestEnvironment(t, "svcproject", "magento248.test")
+	env := testenv.Setup(t, "svcproject", "magento248.test")
 
-	MakeConf(env.projectName)
+	MakeConf(env.ProjectName)
 
-	runtimeDir := filepath.Join(env.execDir, "aruntime", "projects", env.projectName)
+	runtimeDir := filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName)
 	composeFile := filepath.Join(runtimeDir, "docker-compose.yml")
 
 	content, err := os.ReadFile(composeFile)
@@ -319,9 +112,9 @@ func assertFileContains(t *testing.T, path, substr string) {
 // evaluateCondition sees an unsubstituted {{{db/enabled}}} placeholder, treats
 // it as false, and the database container silently disappears.
 func TestMakeConf_DbServiceEnabledByDefault(t *testing.T) {
-	env := setupTestEnvironment(t, "dbdefaultproject", "dbdefault.test")
+	env := testenv.Setup(t, "dbdefaultproject", "dbdefault.test")
 
-	MakeConf(env.projectName)
+	MakeConf(env.ProjectName)
 
 	composeStr := readCompose(t, env)
 
@@ -336,13 +129,13 @@ func TestMakeConf_DbServiceEnabledByDefault(t *testing.T) {
 // TestMakeConf_DbServiceDisabled checks the flag actually removes the container
 // and its volume, and that nothing else goes with them.
 func TestMakeConf_DbServiceDisabled(t *testing.T) {
-	env := setupTestEnvironment(t, "dbdisabledproject", "dbdisabled.test")
+	env := testenv.Setup(t, "dbdisabledproject", "dbdisabled.test")
 
-	projectConfigPath := filepath.Join(env.execDir, "projects", env.projectName, "config.xml")
+	projectConfigPath := filepath.Join(env.ExecDir, "projects", env.ProjectName, "config.xml")
 	configs.SaveInFile(projectConfigPath, map[string]string{"db/enabled": "false"}, "default")
 	configs.CleanCache()
 
-	MakeConf(env.projectName)
+	MakeConf(env.ProjectName)
 
 	composeStr := readCompose(t, env)
 
@@ -368,9 +161,9 @@ func TestMakeConf_DbServiceDisabled(t *testing.T) {
 // included in every platform's compose file, so a wrong default would add an
 // idle container to every existing project on the next rebuild.
 func TestMakeConf_MemcachedDisabledByDefault(t *testing.T) {
-	env := setupTestEnvironment(t, "memcdefaultproject", "memcdefault.test")
+	env := testenv.Setup(t, "memcdefaultproject", "memcdefault.test")
 
-	MakeConf(env.projectName)
+	MakeConf(env.ProjectName)
 
 	composeStr := readCompose(t, env)
 
@@ -387,13 +180,13 @@ func TestMakeConf_MemcachedDisabledByDefault(t *testing.T) {
 // size and connection limit must come from the embedded defaults; an unresolved
 // placeholder would land in docker-compose.yml verbatim and break the stack.
 func TestMakeConf_MemcachedEnabled(t *testing.T) {
-	env := setupTestEnvironment(t, "memcenabledproject", "memcenabled.test")
+	env := testenv.Setup(t, "memcenabledproject", "memcenabled.test")
 
-	projectConfigPath := filepath.Join(env.execDir, "projects", env.projectName, "config.xml")
+	projectConfigPath := filepath.Join(env.ExecDir, "projects", env.ProjectName, "config.xml")
 	configs.SaveInFile(projectConfigPath, map[string]string{"memcached/enabled": "true"}, "default")
 	configs.CleanCache()
 
-	MakeConf(env.projectName)
+	MakeConf(env.ProjectName)
 
 	composeStr := readCompose(t, env)
 
@@ -416,9 +209,9 @@ func TestMakeConf_MemcachedEnabled(t *testing.T) {
 	}
 }
 
-func readPhpDockerfile(t *testing.T, env *testEnv) string {
+func readPhpDockerfile(t *testing.T, env *testenv.Env) string {
 	t.Helper()
-	dockerfile := filepath.Join(env.execDir, "aruntime", "projects", env.projectName, "ctx", "php.Dockerfile")
+	dockerfile := filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName, "ctx", "php.Dockerfile")
 	content, err := os.ReadFile(dockerfile)
 	if err != nil {
 		t.Fatalf("Failed to read php.Dockerfile: %v", err)
@@ -426,9 +219,9 @@ func readPhpDockerfile(t *testing.T, env *testEnv) string {
 	return string(content)
 }
 
-func readCompose(t *testing.T, env *testEnv) string {
+func readCompose(t *testing.T, env *testenv.Env) string {
 	t.Helper()
-	composeFile := filepath.Join(env.execDir, "aruntime", "projects", env.projectName, "docker-compose.yml")
+	composeFile := filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName, "docker-compose.yml")
 	content, err := os.ReadFile(composeFile)
 	if err != nil {
 		t.Fatalf("Failed to read docker-compose.yml: %v", err)
@@ -442,9 +235,9 @@ func readCompose(t *testing.T, env *testEnv) string {
 // optional, so gating dbdata as well lets the section render as a bare
 // "volumes:" and compose refuses the file with "volumes must be a mapping".
 func TestMakeConf_VolumesNeverEmpty(t *testing.T) {
-	env := setupTestEnvironment(t, "novolumesproject", "novolumes.test")
+	env := testenv.Setup(t, "novolumesproject", "novolumes.test")
 
-	projectConfigPath := filepath.Join(env.execDir, "projects", env.projectName, "config.xml")
+	projectConfigPath := filepath.Join(env.ExecDir, "projects", env.ProjectName, "config.xml")
 	configs.SaveInFile(projectConfigPath, map[string]string{
 		"db/enabled":                   "false",
 		"db2/enabled":                  "false",
@@ -455,7 +248,7 @@ func TestMakeConf_VolumesNeverEmpty(t *testing.T) {
 	}, "default")
 	configs.CleanCache()
 
-	MakeConf(env.projectName)
+	MakeConf(env.ProjectName)
 
 	composeStr := readCompose(t, env)
 

--- a/src/helper/testenv/testenv.go
+++ b/src/helper/testenv/testenv.go
@@ -1,0 +1,399 @@
+// Package testenv builds a madock installation in a temporary directory so that
+// generation can be tested against the real templates, and compares the result
+// against committed golden files.
+//
+// It is a package of its own rather than a set of test helpers because two
+// packages need it and Go does not let one package import another's test files:
+// a project's generated configuration is rendered by the project package, while
+// the shared proxy configuration is rendered by the nginx package — which imports
+// project, so the test cannot live there either.
+//
+// Nothing in madock imports this, so testing never reaches the shipped binary.
+package testenv
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/faradey/madock/v3/src/helper/configs"
+	"github.com/faradey/madock/v3/src/helper/ports"
+)
+
+// ProjectRoot locates the madock project root by walking up from the current test file.
+func ProjectRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine test file path")
+	}
+	dir := filepath.Dir(filename)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("cannot find project root (go.mod)")
+		}
+		dir = parent
+	}
+}
+
+// Env holds paths for the test environment and cleanup function.
+type Env struct {
+	ExecDir     string
+	RunDir      string
+	ProjectName string
+}
+
+// Setup creates a temp directory structure that MakeConf can work with.
+// It symlinks docker/ and scripts/ from the real project, copies config.xml,
+// and creates a project config via SaveInFile.
+func Setup(t *testing.T, projectName, hostName string) *Env {
+	t.Helper()
+	return SetupWith(t, projectName, hostName, nil)
+}
+
+// SetupWith is Setup with the project config
+// opened up: overrides are applied on top of the Magento defaults below, so a
+// test can describe a different platform, language or database without
+// restating the ninety keys it does not care about.
+func SetupWith(t *testing.T, projectName, hostName string, overrides map[string]string) *Env {
+	t.Helper()
+	realRoot := ProjectRoot(t)
+
+	tmpDir, err := os.MkdirTemp("", "madock-integration-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+	execDir := filepath.Join(tmpDir, "exec")
+	runDir := filepath.Join(tmpDir, "run")
+
+	// Create directory structure
+	dirs := []string{
+		execDir,
+		filepath.Join(execDir, "projects", projectName, "docker", "ctx"),
+		filepath.Join(execDir, "aruntime", "projects", projectName, "ctx"),
+		filepath.Join(execDir, "cache"),
+		filepath.Join(execDir, "scripts"),
+		runDir,
+	}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("Failed to create dir %s: %v", d, err)
+		}
+	}
+
+	// Symlink docker/ from real project
+	if err := os.Symlink(filepath.Join(realRoot, "docker"), filepath.Join(execDir, "docker")); err != nil {
+		t.Fatalf("Failed to symlink docker/: %v", err)
+	}
+
+	// Copy config.xml (global config template)
+	srcConfig, err := os.ReadFile(filepath.Join(realRoot, "config.xml"))
+	if err != nil {
+		t.Fatalf("Failed to read config.xml: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(execDir, "config.xml"), srcConfig, 0644); err != nil {
+		t.Fatalf("Failed to write config.xml: %v", err)
+	}
+
+	// Set env vars
+	t.Setenv("MADOCK_EXEC_DIR", execDir)
+	t.Setenv("MADOCK_RUN_DIR", runDir)
+
+	// Clean config cache so the new env vars are picked up
+	configs.CleanCache()
+
+	// Create project config via SaveInFile with Magento 2.4.8 settings
+	projectConfigPath := filepath.Join(execDir, "projects", projectName, "config.xml")
+	projectConfigData := map[string]string{
+		"platform":                                  "magento2",
+		"language":                                  "php",
+		"path":                                      runDir,
+		"php/enabled":                               "true",
+		"php/version":                               "8.4",
+		"php/composer/version":                      "2",
+		"php/xdebug/version":                        "3.4.4",
+		"php/xdebug/remote_host":                    "host.docker.internal",
+		"php/xdebug/ide_key":                        "PHPSTORM",
+		"php/xdebug/enabled":                        "false",
+		"php/xdebug/mode":                           "debug",
+		"php/ioncube/enabled":                       "false",
+		"php/nodejs/enabled":                        "false",
+		"timezone":                                  "UTC",
+		"workdir":                                   "/var/www/html",
+		"public_dir":                                "pub",
+		"composer_dir":                              "",
+		"db/repository":                             "mariadb",
+		"db/version":                                "11.4",
+		"db/root_password":                          "password",
+		"db/user":                                   "magento",
+		"db/password":                               "magento",
+		"db/database":                               "magento",
+		"db/phpmyadmin/enabled":                     "false",
+		"db2/enabled":                               "false",
+		"search/engine":                             "OpenSearch",
+		"search/elasticsearch/enabled":              "false",
+		"search/elasticsearch/version":              "8.17.6",
+		"search/elasticsearch/repository":           "elasticsearch",
+		"search/opensearch/enabled":                 "true",
+		"search/opensearch/version":                 "2.19.0",
+		"search/opensearch/repository":              "opensearchproject/opensearch",
+		"search/opensearch/dashboard/enabled":       "false",
+		"search/opensearch/dashboard/repository":    "opensearchproject/opensearch-dashboards",
+		"search/elasticsearch/dashboard/enabled":    "false",
+		"search/elasticsearch/dashboard/repository": "kibana",
+		"redis/enabled":                             "false",
+		"redis/repository":                          "redis",
+		"redis/version":                             "8.0",
+		"valkey/enabled":                            "false",
+		"valkey/repository":                         "valkey/valkey",
+		"valkey/version":                            "8.1.3",
+		"rabbitmq/enabled":                          "false",
+		"rabbitmq/repository":                       "rabbitmq",
+		"rabbitmq/version":                          "4.1",
+		"nodejs/enabled":                            "false",
+		"nodejs/repository":                         "node",
+		"nodejs/version":                            "18.15.0",
+		"nodejs/major_version":                      "18",
+		"nodejs/yarn/enabled":                       "false",
+		"cron/enabled":                              "false",
+		"nginx/ssl/enabled":                         "true",
+		"nginx/http/version":                        "http2",
+		"nginx/run_type":                            "website",
+		"nginx/default_host_first_level":            ".test",
+		"nginx/port/unsecure":                       "80",
+		"nginx/port/secure":                         "443",
+		"nginx/port/internal":                       "80",
+		"nginx/interface_ip":                        "",
+		"os/name":                                   "ubuntu",
+		"os/version":                                "22.04",
+		"container_name_prefix":                     "madock_",
+		"restart_policy":                            "no",
+		"proxy/enabled":                             "true",
+		"proxy/timeout/connect":                     "60",
+		"proxy/timeout/send":                        "300",
+		"proxy/timeout/read":                        "300",
+		"proxy/gzip/enabled":                        "true",
+		"proxy/rate_limit/enabled":                  "true",
+		"proxy/rate_limit/rate":                     "1000",
+		"proxy/rate_limit/burst":                    "2000",
+		"isolation/enabled":                         "false",
+		"varnish/enabled":                           "false",
+		"grafana/enabled":                           "false",
+		"claude/enabled":                            "false",
+		"claude/nodejs_repository":                  "node",
+		"claude/nodejs_version":                     "22.19.0",
+		"ssh/auth_type":                             "key",
+		"ssh/port":                                  "22",
+		"magento/admin_user":                        "admin",
+		"magento/admin_password":                    "admin123",
+		"magento/admin_first_name":                  "admin",
+		"magento/admin_last_name":                   "admin",
+		"magento/admin_email":                       "admin@admin.com",
+		"magento/admin_frontname":                   "admin",
+		"magento/locale":                            "en_US",
+		"magento/currency":                          "USD",
+		"magento/timezone":                          "America/Chicago",
+		"magento/cloud/enabled":                     "false",
+		"magento/mftf/enabled":                      "false",
+		"magento/n98magerun/enabled":                "false",
+	}
+
+	if hostName != "" {
+		projectConfigData["nginx/hosts/base/name"] = hostName
+	}
+
+	for key, value := range overrides {
+		projectConfigData[key] = value
+	}
+
+	configs.SaveInFile(projectConfigPath, projectConfigData, "default")
+
+	// Clean cache again after writing config
+	configs.CleanCache()
+	// Reset global port registry so it re-reads from the new execDir
+	ports.ResetRegistry()
+
+	return &Env{
+		ExecDir:     execDir,
+		RunDir:      runDir,
+		ProjectName: projectName,
+	}
+}
+
+// Collect reads every generated file, with the machine-specific parts
+// replaced so the same output is expected on any machine.
+func Collect(t *testing.T, root string, env *Env) map[string]string {
+	t.Helper()
+
+	files := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		// The runtime directory holds symlinks to the project source, the
+		// composer home and ~/.ssh. Following them would pull the whole
+		// working tree into the comparison.
+		if d.Type()&fs.ModeSymlink != 0 || d.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		files[filepath.ToSlash(rel)] = Normalise(string(content), env)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("reading generated files: %v", err)
+	}
+	return files
+}
+
+var (
+	// Only a ports mapping, and only where compose writes one: a list entry.
+	// Matching every `"NNNN:` in the file swallowed `user: "1001:1001"` on a
+	// Linux runner, where a uid happens to be four digits.
+	publishedPort = regexp.MustCompile(`- "\d{4,5}:`)
+
+	// uid and gid are normalised where they are *used*, not wherever their
+	// digits appear. Replacing the values themselves looked simpler and was
+	// wrong twice over: a macOS gid of 20 rewrote unrelated numbers inside the
+	// Grafana dashboards ("2093" became "<GID>93"), and on a CI runner where
+	// uid == gid the second replacement found nothing left to replace, so
+	// `groupmod -g` came out as `<UID>`. Both produced golden files that could
+	// only ever match the machine that wrote them.
+	composeUser = regexp.MustCompile(`user: "\d+:\d+"`)
+	usermodUid  = regexp.MustCompile(`usermod -u \d+`)
+	groupmodGid = regexp.MustCompile(`groupmod -g \d+`)
+	chownPair   = regexp.MustCompile(`chown (-R )?\d+:\d+`)
+
+	// The loader URL carries the host architecture, so an arm64 laptop and an
+	// amd64 runner render different files from the same template.
+	loaderArch = regexp.MustCompile(`ioncube_loaders_lin_[\w-]+\.tar\.gz`)
+)
+
+// Normalise removes what differs between machines and runs.
+//
+// Ports are allocated by probing the host for something free, so they depend on
+// what else is listening; uid, gid and the CPU architecture come from whoever
+// runs the tests. None of that is what these tests are about — the shape of the
+// rendered file is.
+func Normalise(content string, env *Env) string {
+	content = strings.ReplaceAll(content, env.ExecDir, "<EXEC_DIR>")
+	content = strings.ReplaceAll(content, env.RunDir, "<RUN_DIR>")
+	content = publishedPort.ReplaceAllString(content, `- "<PORT>:`)
+	content = composeUser.ReplaceAllString(content, `user: "<UID>:<GID>"`)
+	content = usermodUid.ReplaceAllString(content, "usermod -u <UID>")
+	content = groupmodGid.ReplaceAllString(content, "groupmod -g <GID>")
+	content = chownPair.ReplaceAllString(content, "chown ${1}<UID>:<GID>")
+	content = loaderArch.ReplaceAllString(content, "ioncube_loaders_lin_<ARCH>.tar.gz")
+
+	return content
+}
+
+func WriteGolden(t *testing.T, goldenDir string, rendered map[string]string) {
+	t.Helper()
+
+	if err := os.RemoveAll(goldenDir); err != nil {
+		t.Fatalf("clearing %s: %v", goldenDir, err)
+	}
+	for name, content := range rendered {
+		path := filepath.Join(goldenDir, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("creating %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("writing %s: %v", path, err)
+		}
+	}
+	t.Logf("wrote %d golden files to %s — read the diff before committing", len(rendered), goldenDir)
+}
+
+func CompareGolden(t *testing.T, goldenDir string, rendered map[string]string) {
+	t.Helper()
+
+	expected := map[string]string{}
+	err := filepath.WalkDir(goldenDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		rel, _ := filepath.Rel(goldenDir, path)
+		expected[filepath.ToSlash(rel)] = string(content)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("no golden files in %s (%v) — run with -update", goldenDir, err)
+	}
+
+	for name, want := range expected {
+		got, rendered_ok := rendered[name]
+		if !rendered_ok {
+			t.Errorf("%s is no longer generated", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s differs from the golden copy:\n%s", name, firstDifference(want, got))
+		}
+	}
+
+	for name := range rendered {
+		if _, known := expected[name]; !known {
+			t.Errorf("%s is generated but has no golden copy — new output, or a file that moved", name)
+		}
+	}
+}
+
+// firstDifference reports the first differing line with a little context, which
+// is what a reader needs; a full diff of a 200-line compose file is not.
+func firstDifference(want, got string) string {
+	wantLines := strings.Split(want, "\n")
+	gotLines := strings.Split(got, "\n")
+
+	for i := 0; i < len(wantLines) || i < len(gotLines); i++ {
+		wantLine := ""
+		if i < len(wantLines) {
+			wantLine = wantLines[i]
+		}
+		gotLine := ""
+		if i < len(gotLines) {
+			gotLine = gotLines[i]
+		}
+		if wantLine != gotLine {
+			return "  line " + itoa(i+1) + "\n    want: " + wantLine + "\n    got:  " + gotLine
+		}
+	}
+	return "  (files differ only in trailing content)"
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}

--- a/src/helper/testenv/testenv_test.go
+++ b/src/helper/testenv/testenv_test.go
@@ -1,0 +1,63 @@
+package testenv
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNormalise pins the thing the golden files depend on and nothing else
+// checks: that two different machines normalise to the same text.
+//
+// Both cases here are real. macOS gives a gid of 20, which the old
+// value-substitution normaliser found inside unrelated numbers; a GitHub runner
+// gives uid == gid, where replacing the uid first left the gid with nothing to
+// match. Either one produced golden files that only the machine that wrote them
+// could reproduce.
+func TestNormalise(t *testing.T) {
+	env := &Env{ExecDir: "/exec", RunDir: "/run"}
+
+	// The same rendered file as three machines would write it: an arm64 laptop
+	// (uid 501, gid 20), an amd64 runner (uid 1001, gid 1001), and a Linux
+	// desktop (uid 1000, gid 1000).
+	render := func(uid, gid, arch string) string {
+		return strings.Join([]string{
+			`    user: "` + uid + `:` + gid + `"`,
+			`      - "34500:80"`,
+			`RUN usermod -u ` + uid + ` -o www-data && groupmod -g ` + gid + ` -o www-data`,
+			`RUN mkdir /var/www/.npm && chown ` + uid + `:` + gid + ` /var/www/.npm`,
+			`    && chown -R ` + uid + `:` + gid + ` /var/www`,
+			`    && curl -o ioncube.tar.gz http://x/ioncube_loaders_lin_` + arch + `.tar.gz \\`,
+			`RUN sed -i 's/session.cookie_lifetime = 0/session.cookie_lifetime = 2592000/g' php.ini`,
+			`        "uid": "PBFA97CFB590B2093"`,
+			`  ingestion_burst_size_mb: 20`,
+		}, "\n")
+	}
+
+	mac := Normalise(render("501", "20", "aarch64"), env)
+	ci := Normalise(render("1001", "1001", "x86-64"), env)
+	linux := Normalise(render("1000", "1000", "x86-64"), env)
+
+	if mac != ci {
+		t.Errorf("macOS and CI normalise differently:\n%s\n---\n%s", mac, ci)
+	}
+	if ci != linux {
+		t.Errorf("two Linux machines normalise differently:\n%s\n---\n%s", ci, linux)
+	}
+
+	// The numbers that are not ids must survive, and the ids must not.
+	for _, want := range []string{
+		`user: "<UID>:<GID>"`,
+		`- "<PORT>:80"`,
+		"usermod -u <UID> -o www-data && groupmod -g <GID> -o www-data",
+		"chown <UID>:<GID> /var/www/.npm",
+		"chown -R <UID>:<GID> /var/www",
+		"ioncube_loaders_lin_<ARCH>.tar.gz",
+		"session.cookie_lifetime = 2592000",
+		`"uid": "PBFA97CFB590B2093"`,
+		"ingestion_burst_size_mb: 20",
+	} {
+		if !strings.Contains(mac, want) {
+			t.Errorf("normalised output is missing %q:\n%s", want, mac)
+		}
+	}
+}

--- a/test/e2e/shopware_platform_test.go
+++ b/test/e2e/shopware_platform_test.go
@@ -33,27 +33,44 @@ func TestShopwareInstallsAndAnswers(t *testing.T) {
 		t.Skip("platform tests are opt-in: ./test/e2e/e2e.sh run --platforms -run TestShopware")
 	}
 
+	// Skipped from 2026-08-14: no Shopware release installs at all, and the reason
+	// is neither ours nor a version we can pick around.
+	//
+	// Shopware declares its dependencies as exact versions, and packagist keeps
+	// publishing advisories against versions already released. Composer 2.8 and
+	// later refuse to install a package that has one — the container's composer is
+	// 2.10.2 — and an exact requirement leaves it nothing else to choose. So every
+	// release stops at a different wall, verified by resolving each one with that
+	// composer rather than by reading metadata:
+	//
+	//   6.7.13.0            mcp/sdk ^0.6.0, and 0.6.0 is the only match: advisory
+	//                       PKSA-p9gd-j6gr-6f9t, published 2026-08-14 06:19 UTC
+	//   6.7.12.2, .1, 11.1  symfony/mcp-bundle ~0.9.0, which wants mcp/sdk ^0.5 —
+	//                       the same advisory by another path
+	//   6.7.11.0            dompdf/dompdf pinned at 3.1.4, which carries six
+	//
+	// Pinning an older release was tried and is what proved the shape of this: each
+	// one fails on its own blocked package, and the older it is the more advisories
+	// its pins have collected. The test was green sixteen hours before the first
+	// failure, on the same code.
+	//
+	// Composer can install it — `--no-security-blocking` resolves 6.7.13.0 to the
+	// last package — so the choice was between installing packages with known
+	// advisories onto every stand this test stands in for, and not installing. We
+	// chose not to install, and to leave the platform job honest about Medusa
+	// rather than red about something upstream.
+	//
+	// Re-enable when a Shopware release resolves with blocking on. That needs one of
+	// mcp/sdk 0.7.1 (which is out) to become acceptable to shopware/core's
+	// constraint, or the advisories against dompdf's pinned version to be answered
+	// by a release Shopware allows.
+	t.Skip("no Shopware release currently installs: composer blocks its exact dependency pins over advisories — see the comment above")
+
 	p := newProject(t, "e2eshopware")
 
-	// 6.7.12.2 rather than the newest release, and the reason is upstream rather
-	// than here. shopware/core v6.7.13.0 is the only one of its 209 releases that
-	// requires mcp/sdk, as `^0.6.0` — which for a 0.x version means 0.6.0 and
-	// nothing else. On 2026-08-14 at 06:19 UTC, advisory PKSA-p9gd-j6gr-6f9t
-	// (CVE-2026-53965, an unbounded SSE buffer in that package's client) was
-	// published against >=0.5.0,<0.7.1, so composer refuses to install the only
-	// version the constraint allows and `create-project` dies with exit status 2
-	// after three hundred lines of version candidates. This test was green sixteen
-	// hours earlier on the same code.
-	//
-	// Not worked around by relaxing composer's advisory policy: that would install
-	// a package with a CVE onto every stand this test stands in for. 6.7.12.2 does
-	// not require mcp/sdk at all.
-	//
-	// Move this back to the newest release once shopware/core constrains mcp/sdk to
-	// something that includes 0.7.1.
 	p.run(45*time.Minute, "setup", "-y", "-d", "-i",
 		"--platform=shopware",
-		"--platform-version=6.7.12.2",
+		"--platform-version=6.7.13.0",
 		"--php=8.3",
 		"--hosts=e2eshopware.test",
 	)

--- a/test/e2e/shopware_platform_test.go
+++ b/test/e2e/shopware_platform_test.go
@@ -35,9 +35,25 @@ func TestShopwareInstallsAndAnswers(t *testing.T) {
 
 	p := newProject(t, "e2eshopware")
 
+	// 6.7.12.2 rather than the newest release, and the reason is upstream rather
+	// than here. shopware/core v6.7.13.0 is the only one of its 209 releases that
+	// requires mcp/sdk, as `^0.6.0` — which for a 0.x version means 0.6.0 and
+	// nothing else. On 2026-08-14 at 06:19 UTC, advisory PKSA-p9gd-j6gr-6f9t
+	// (CVE-2026-53965, an unbounded SSE buffer in that package's client) was
+	// published against >=0.5.0,<0.7.1, so composer refuses to install the only
+	// version the constraint allows and `create-project` dies with exit status 2
+	// after three hundred lines of version candidates. This test was green sixteen
+	// hours earlier on the same code.
+	//
+	// Not worked around by relaxing composer's advisory policy: that would install
+	// a package with a CVE onto every stand this test stands in for. 6.7.12.2 does
+	// not require mcp/sdk at all.
+	//
+	// Move this back to the newest release once shopware/core constrains mcp/sdk to
+	// something that includes 0.7.1.
 	p.run(45*time.Minute, "setup", "-y", "-d", "-i",
 		"--platform=shopware",
-		"--platform-version=6.7.13.0",
+		"--platform-version=6.7.12.2",
 		"--php=8.3",
 		"--hosts=e2eshopware.test",
 	)


### PR DESCRIPTION
Three things, and the first CI run today with all three jobs green.

**The Shopware platform test is skipped.** No Shopware release installs at all: it declares dependencies as exact versions, packagist keeps publishing advisories against versions already released, and composer 2.8+ refuses to install a package that has one. Resolved with the container's composer, one release at a time — 6.7.13.0 stops on `mcp/sdk`, 6.7.12.x on `symfony/mcp-bundle` which wants the same package, 6.7.11.0 on `dompdf` with six advisories against its pinned version. Pinning an older release was tried first and is what proved the shape: older is worse, not better. Composer *can* install it with `--no-security-blocking`, which makes this a choice between putting packages with known advisories on every stand the test stands in for, and not installing — we chose not to. The comment in the test says what has to become true upstream to lift the skip, and a weekly watcher outside this repository looks for a new release.

**A golden file for `aruntime/ctx/proxy.conf`.** The file every project's traffic passes through had no coverage at all, and three of this week's defects lived in it. The harness that renders an installation moved from the project package's test files to `src/helper/testenv` first, because Go will not let another package import test files and the nginx package cannot host the test either — it imports project. The eleven existing fixtures render byte-identical after the move, which is the acceptance criterion; nothing in madock imports testenv, so `testing` stays out of the binary.

**Two commits of mine fixing my own test.** The new fixture held allocated port numbers, which differ per machine because allocation skips ports already in use — it passed here and failed on the runner twice. Masked by position now, and the second attempt fixed the pattern: `\b` never matches inside `upstreamm_madock_17003`, an underscore being a word character, and the grep that was supposed to catch that used the same pattern.

No version bump and no changelog entry: nothing in the shipped binary changed. Merge as a merge commit.