### PR TITLE
v3.8.51: follow a symlinked registry entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v3.8.51**
+
+Fixed:
+- **`project:list` was blind to exactly the projects it was written to find.** It listed the registry with `os.ReadDir` and kept the entries whose `IsDir()` was true — and that answers about the entry, not its target, so an entry that is a symlink to its project reported false and was dropped before anything read its configuration. On a cluster VM with four projects running, one release after the command shipped, it answered "No projects are registered in this installation": the single wrong answer that reads as good news. Symlinked entries are how an installation looks whenever a project was set up from a temporary checkout, which is also where forgotten entries come from — so `--stale`, whose whole purpose is finding what nobody remembers, could not see the likeliest cases. The predicate now stats the target, and a symlink pointing at nothing is skipped rather than reported, which is right for an entry whose directory is gone
+- **Same predicate, same blindness, in `paths.GetDirs`** — and everything that walks `projects/` is built on it: the migrations from v1.4 to v2.4, `project:clone`'s name check, and the project list itself. A symlinked project silently missed a migration. Fixed in the one place, with a test for a real directory, a symlink to one, a plain file and a broken symlink
+
 **v3.8.50**
 
 Added:

--- a/src/helper/configs/projects.go
+++ b/src/helper/configs/projects.go
@@ -433,7 +433,14 @@ func ListProjectsIn(execDir string) []ProjectEntry {
 
 	var out []ProjectEntry
 	for _, entry := range entries {
-		if !entry.IsDir() {
+		// Stat rather than entry.IsDir(): os.ReadDir answers about the entry, and a
+		// symlink to a directory says false. Registry entries are symlinks wherever
+		// a project was set up from a temporary checkout, and on a cluster VM with
+		// four such projects this command answered "No projects are registered" —
+		// the one wrong answer that reads as good news. A broken symlink fails the
+		// Stat and is skipped, which is right for an entry pointing at nothing.
+		info, statErr := os.Stat(filepath.Join(execDir, "projects", entry.Name()))
+		if statErr != nil || !info.IsDir() {
 			continue
 		}
 		configPath := filepath.Join(execDir, "projects", entry.Name(), "config.xml")

--- a/src/helper/configs/projects_registry_test.go
+++ b/src/helper/configs/projects_registry_test.go
@@ -48,6 +48,30 @@ func TestListProjectsIn(t *testing.T) {
 	live := t.TempDir()
 	write("alive", config(live))
 	write("deleted", config(filepath.Join(execDir, "not-here")))
+
+	// A registry entry that is a symlink to its project, which is how every
+	// installation set up from a temporary checkout looks. os.ReadDir answers about
+	// the entry rather than its target, so this case was dropped before anything
+	// looked at its configuration: on a cluster VM with four such projects running,
+	// project:list said "No projects are registered". The first version of this test
+	// built only real directories, which is exactly why it passed.
+	linked := t.TempDir()
+	linkedRegistry := filepath.Join(t.TempDir(), "linked-entry")
+	if err := os.MkdirAll(linkedRegistry, 0755); err != nil {
+		t.Fatalf("creating the symlink target: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(linkedRegistry, "config.xml"), []byte(config(linked)), 0644); err != nil {
+		t.Fatalf("writing the linked config: %v", err)
+	}
+	if err := os.Symlink(linkedRegistry, filepath.Join(execDir, "projects", "linked")); err != nil {
+		t.Fatalf("linking the registry entry: %v", err)
+	}
+
+	// And one pointing at nothing, which must be skipped rather than reported: an
+	// entry whose own directory is gone is not an entry.
+	if err := os.Symlink(filepath.Join(execDir, "gone"), filepath.Join(execDir, "projects", "broken-link")); err != nil {
+		t.Fatalf("linking the broken registry entry: %v", err)
+	}
 	write("legacy", `<?xml version="1.0" encoding="UTF-8"?>
 <config>
     <scopes>
@@ -67,6 +91,7 @@ func TestListProjectsIn(t *testing.T) {
 		"alive":   ProjectOk,
 		"deleted": ProjectMissingSource,
 		"legacy":  ProjectNoPath,
+		"linked":  ProjectOk,
 	}
 
 	if len(got) != len(want) {

--- a/src/helper/paths/paths.go
+++ b/src/helper/paths/paths.go
@@ -81,6 +81,18 @@ func GetRunDirNameWithHash() string {
 	return filepath.Base(GetRunDirPath()) + "__" + strconv.Itoa(int(hash.Hash(GetRunDirPath())))
 }
 
+// GetDirs lists the directories inside a path, following symlinks.
+//
+// os.ReadDir answers about the entry, not its target, so a symlink to a directory
+// has IsDir() false and used to be dropped here. Registry entries are symlinks on
+// every machine that sets a project up from a temporary checkout — a cluster VM had
+// four of them — and everything that walks projects/ goes through this function:
+// the migrations, project:clone, and the project list. On such a machine
+// `project:list` answered "No projects are registered" while four were running,
+// which reads as "all clean" rather than as "I cannot see".
+//
+// A broken symlink fails the Stat and is skipped, which is what should happen to a
+// registry entry pointing at nothing.
 func GetDirs(path string) (dirs []string) {
 	items, err := os.ReadDir(path)
 	if err != nil {
@@ -88,9 +100,11 @@ func GetDirs(path string) (dirs []string) {
 	}
 
 	for _, file := range items {
-		if file.IsDir() {
-			dirs = append(dirs, file.Name())
+		info, statErr := os.Stat(filepath.Join(path, file.Name()))
+		if statErr != nil || !info.IsDir() {
+			continue
 		}
+		dirs = append(dirs, file.Name())
 	}
 
 	return dirs

--- a/src/helper/paths/paths_test.go
+++ b/src/helper/paths/paths_test.go
@@ -349,3 +349,51 @@ func TestMakeDirsByPathEmpty(t *testing.T) {
 		t.Errorf("MakeDirsByPath(\"\") = %q, want empty string", result)
 	}
 }
+
+// TestGetDirsFollowsSymlinks pins the predicate every walk of projects/ depends on.
+//
+// os.ReadDir answers about the entry, not its target, so a symlink to a directory
+// reports IsDir() false — and this function used to drop it. Registry entries are
+// symlinks on any installation whose projects were set up from a temporary
+// checkout: a cluster VM had four, and everything that walks projects/ is built on
+// this call, from the migrations to project:clone to the project list. There, the
+// list answered "No projects are registered" with four projects running, which
+// reads as good news rather than as blindness.
+//
+// A symlink pointing at nothing is skipped: a registry entry whose directory is
+// gone is not an entry.
+func TestGetDirsFollowsSymlinks(t *testing.T) {
+	root := t.TempDir()
+	target := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(root, "real"), 0755); err != nil {
+		t.Fatalf("creating a real directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "file"), []byte("x"), 0644); err != nil {
+		t.Fatalf("creating a file: %v", err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "linked")); err != nil {
+		t.Fatalf("linking a directory: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "gone"), filepath.Join(root, "broken")); err != nil {
+		t.Fatalf("linking nothing: %v", err)
+	}
+
+	got := map[string]bool{}
+	for _, dir := range GetDirs(root) {
+		got[dir] = true
+	}
+
+	if !got["real"] {
+		t.Error("a real directory is missing")
+	}
+	if !got["linked"] {
+		t.Error("a symlink to a directory is missing — this is the defect this test exists for")
+	}
+	if got["file"] {
+		t.Error("a plain file was reported as a directory")
+	}
+	if got["broken"] {
+		t.Error("a symlink pointing at nothing was reported as a directory")
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.8.50"
+const Version = "3.8.51"


### PR DESCRIPTION
project:list shipped in 3.8.50 and was reported blind one release later: on a cluster VM with four projects running it answered "No projects are registered in this installation". `os.ReadDir` answers about the entry rather than its target, so an entry that is a symlink to its project has `IsDir()` false and was dropped before anything read its config.xml.

That is the wrong answer to give — it reads as good news — and it lands where the command is supposed to earn its keep: a symlinked entry is what an installation looks like when a project was set up from a temporary checkout, which is also where forgotten entries come from, so `--stale` could not see the likeliest orphans.

`paths.GetDirs` had the same predicate, and every other walk of `projects/` is built on it — the migrations from v1.4 through v2.4, `project:clone`'s name check, the runtime project list. A symlinked project silently skipped a migration. Fixed there too, in one place. Both stat the target now, and a symlink pointing at nothing is skipped, which is right for an entry whose directory is gone.

The test that shipped with the command built only real directories, which is exactly why it passed. It now covers a symlinked entry and a dangling one, checked the way it should have been the first time — reverted to the old predicate, watched it fail, put the fix back — and `GetDirs` has its own test for a directory, a symlink to one, a plain file and a broken link.

Reported by the shiplab side from a VM; the first half of their document, the `status` error, landed in 3.8.50.

Merge as a merge commit.