### PR TITLE
Offer the SSH agent and the key file as one publickey method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+**v3.9.2**
+
+Fixed:
+- **A project's configured SSH key was never offered when an agent was running.** `remote:sync:*` built the agent and `ssh/key_path` as two entries in the client's auth list, and to the protocol both answer to the name `publickey` — which is what the client marks as tried, by name. So an agent that had no key the server would accept did not fall back to the key file: it closed that path too. Measured on a live sshd, the server log held exactly one attempt, with a key from the agent, and none with the key the project had been told to use. The visible symptom was `ssh host` working while `remote:sync:media` failed on the same host, from the same machine. They are now one method, agent keys first and the key file after, so every key is tried
+- **Two things that had to come with it, or the fix would have been worse than the defect.** The key file is still not read while an agent key is in play: the signer built for it finds its public half without a passphrase — from the `.pub` beside it, from the key itself when it is not encrypted, or from the cleartext public key an encrypted OpenSSH key carries inside — and reads the private half only once the server has said it would accept that key. A key whose public half cannot be found that way is not offered at all, because the handshake dereferences it before anything can check it. And an RSA key file now signs `rsa-sha2-256`: a plain signer is assumed to manage only `ssh-rsa`, which is SHA-1 and refused by every OpenSSH since 8.8, so one silent refusal would have been traded for another on the commonest key type
+- The same defect was fixed in madock-pro 0.23.7, which replaces the whole client configuration and so was never on this path. This is the same fix for everyone else
+
 **v3.9.1**
 
 Upgrading:

--- a/src/controller/general/remote_sync/agent_auth_test.go
+++ b/src/controller/general/remote_sync/agent_auth_test.go
@@ -1,54 +1,226 @@
 package remote_sync
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	encodingpem "encoding/pem"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/crypto/ssh"
 )
 
-func TestAgentAuthWithoutSocket(t *testing.T) {
+func pem(block *encodingpem.Block) []byte {
+	return encodingpem.EncodeToMemory(block)
+}
+
+func TestDialAgentWithoutSocket(t *testing.T) {
 	t.Setenv("SSH_AUTH_SOCK", "")
 
-	if _, ok := AgentAuth(); ok {
-		t.Fatal("expected no agent auth when SSH_AUTH_SOCK is unset")
+	if conn := dialAgent(); conn != nil {
+		conn.Close()
+		t.Fatal("expected no agent when SSH_AUTH_SOCK is unset")
 	}
 }
 
 // A socket path left behind by a dead agent must not be treated as an agent —
-// the dial fails and the caller has to fall back to the key file.
-func TestAgentAuthWithStaleSocket(t *testing.T) {
+// the dial fails and the key file is the better answer.
+func TestDialAgentWithStaleSocket(t *testing.T) {
 	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "gone.sock"))
 
-	if _, ok := AgentAuth(); ok {
-		t.Fatal("expected no agent auth for a socket that cannot be dialled")
+	if conn := dialAgent(); conn != nil {
+		conn.Close()
+		t.Fatal("expected no agent for a socket that cannot be dialled")
 	}
 }
 
-func TestAgentAuthWithListeningSocket(t *testing.T) {
-	// Not t.TempDir(): a unix socket path is capped at ~104 bytes and the
-	// per-test temp directory alone overruns it on macOS.
+func TestDialAgentWithListeningSocket(t *testing.T) {
+	sock := listeningSocket(t)
+	t.Setenv("SSH_AUTH_SOCK", sock)
+
+	conn := dialAgent()
+	if conn == nil {
+		t.Fatal("expected an agent connection when the socket accepts them")
+	}
+	conn.Close()
+}
+
+// The defect this file exists for: the agent and the key file used to be two
+// entries in config.Auth, and to the protocol both answer to the name
+// "publickey" — which is what the client marks as tried. An agent that refused
+// therefore closed the path to ssh/key_path, and the configured key was never
+// offered at all.
+//
+// The socket only has to accept a connection for the old code to take its
+// two-method branch, so no agent protocol is needed to pin this.
+func TestPublicKeyIsOneMethodEvenWithAnAgent(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", listeningSocket(t))
+
+	methods := authMethods("key", "", writeKey(t, "id_ed25519", ed25519Key(t)))
+	if len(methods) != 1 {
+		t.Fatalf("public-key auth was offered as %d methods; the protocol has one, and the second is never tried", len(methods))
+	}
+}
+
+func TestPasswordAuthIsUnchanged(t *testing.T) {
+	methods := authMethods("password", "hunter2", "")
+	if len(methods) != 1 {
+		t.Fatalf("password auth built %d methods, want 1", len(methods))
+	}
+}
+
+// The public half has to be found without a passphrase, or the key file cannot
+// be offered while an agent key is still being tried. Three places it can come
+// from, and the third is the one that matters: an encrypted OpenSSH key carries
+// its public key in the clear.
+func TestPublicKeyOfFindsTheHalfThatNeedsNoPassphrase(t *testing.T) {
+	key := ed25519Key(t)
+
+	t.Run("from the .pub beside it", func(t *testing.T) {
+		path := writeKey(t, "with_pub", key)
+		if err := os.WriteFile(path+".pub", ssh.MarshalAuthorizedKey(publicOf(t, key)), 0600); err != nil {
+			t.Fatal(err)
+		}
+		// The private half is unreadable, so anything found came from the .pub.
+		if err := os.WriteFile(path, []byte("not a key at all\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := publicKeyOf(path); got == nil {
+			t.Fatal("no public key found beside the key file")
+		}
+	})
+
+	t.Run("from an unencrypted key", func(t *testing.T) {
+		if got := publicKeyOf(writeKey(t, "plain", key)); got == nil {
+			t.Fatal("no public key found in an unencrypted key file")
+		}
+	})
+
+	t.Run("from an encrypted key, without the passphrase", func(t *testing.T) {
+		block, err := ssh.MarshalPrivateKeyWithPassphrase(key, "", []byte("s3cret"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(t.TempDir(), "encrypted")
+		if err := os.WriteFile(path, pem(block), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		got := publicKeyOf(path)
+		if got == nil {
+			t.Fatal("an encrypted OpenSSH key carries its public key in the clear; it was not read")
+		}
+		if got.Type() != ssh.KeyAlgoED25519 {
+			t.Errorf("public key type %q, want %q", got.Type(), ssh.KeyAlgoED25519)
+		}
+	})
+}
+
+// A key whose public half cannot be established is not offered at all. Not a
+// nicety: the handshake dereferences the public key before anything can check
+// it, so a signer without one is a panic rather than a skipped key.
+func TestFileSignerRefusesAKeyItCannotDescribe(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "garbage")
+	if err := os.WriteFile(path, []byte("this is not a key\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if signer := fileSigner(path); signer != nil {
+		t.Fatal("a key with no readable public half was offered to the handshake")
+	}
+
+	if signer := fileSigner(filepath.Join(t.TempDir(), "absent")); signer != nil {
+		t.Fatal("a key file that does not exist was offered to the handshake")
+	}
+}
+
+// An RSA key file has to sign with rsa-sha2-256. A plain ssh.Signer is assumed
+// by the handshake to manage only ssh-rsa — SHA-1, refused by every OpenSSH
+// since 8.8 — so the deferred signer has to declare the algorithm itself, or
+// one silent refusal is traded for another on the commonest key type.
+func TestLazyFileSignerSignsWithRsaSha2(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	signer := fileSigner(writeKey(t, "id_rsa", key))
+	if signer == nil {
+		t.Fatal("an RSA key file was not offered at all")
+	}
+
+	algorithmSigner, ok := signer.(ssh.AlgorithmSigner)
+	if !ok {
+		t.Fatal("the key file signer cannot be asked for an algorithm, so the handshake will offer ssh-rsa and be refused")
+	}
+
+	signature, err := algorithmSigner.SignWithAlgorithm(rand.Reader, []byte("payload"), ssh.KeyAlgoRSASHA256)
+	if err != nil {
+		t.Fatalf("signing with %s: %v", ssh.KeyAlgoRSASHA256, err)
+	}
+	if signature.Format != ssh.KeyAlgoRSASHA256 {
+		t.Errorf("signature format %q, want %q", signature.Format, ssh.KeyAlgoRSASHA256)
+	}
+	if err := signer.PublicKey().Verify([]byte("payload"), signature); err != nil {
+		t.Errorf("the signature does not verify against the key's own public half: %v", err)
+	}
+}
+
+func ed25519Key(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func publicOf(t *testing.T, key any) ssh.PublicKey {
+	t.Helper()
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer.PublicKey()
+}
+
+func writeKey(t *testing.T, name string, key any) string {
+	t.Helper()
+	block, err := ssh.MarshalPrivateKey(key, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, pem(block), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// listeningSocket is a unix socket that accepts connections and speaks nothing.
+// Enough for dialAgent, which only asks whether an agent is there.
+//
+// Not t.TempDir(): a unix socket path is capped at ~104 bytes and the per-test
+// temp directory alone overruns it on macOS.
+func listeningSocket(t *testing.T) string {
+	t.Helper()
+
 	dir, err := os.MkdirTemp("/tmp", "ma")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dir)
+	t.Cleanup(func() { os.RemoveAll(dir) })
 
 	sock := filepath.Join(dir, "a.sock")
-
 	listener, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatalf("cannot create unix socket: %v", err)
 	}
-	defer listener.Close()
+	t.Cleanup(func() { listener.Close() })
 
-	t.Setenv("SSH_AUTH_SOCK", sock)
-
-	method, ok := AgentAuth()
-	if !ok {
-		t.Fatal("expected agent auth when the socket accepts connections")
-	}
-	if method == nil {
-		t.Fatal("expected a non-nil auth method")
-	}
+	return sock
 }

--- a/src/controller/general/remote_sync/remote_sync.go
+++ b/src/controller/general/remote_sync/remote_sync.go
@@ -1,6 +1,7 @@
 package remote_sync
 
 import (
+	"errors"
 	"fmt"
 	"github.com/faradey/madock/v3/src/helper/configs"
 	"github.com/faradey/madock/v3/src/helper/logger"
@@ -214,22 +215,7 @@ func Connect(projectConf map[string]string, sshType string) *ssh.Client {
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		}
 
-		if authType == "password" {
-			config.Auth = []ssh.AuthMethod{
-				ssh.Password(password),
-			}
-		} else {
-			// Agent first, key file second. The file method has to be the lazy
-			// form here: publicKey() reads and parses the key immediately, so
-			// building it would prompt for the passphrase before the handshake
-			// ever reaches the agent. With no agent, nothing changes — the
-			// eager call keeps its existing failure behaviour.
-			if agentAuth, ok := AgentAuth(); ok {
-				config.Auth = append(config.Auth, agentAuth, publicKeyLazy(keyPath))
-			} else {
-				config.Auth = append(config.Auth, publicKey(keyPath))
-			}
-		}
+		config.Auth = authMethods(authType, password, keyPath)
 	}
 
 	conn, err := ssh.Dial("tcp", host+":"+port, config)
@@ -247,92 +233,212 @@ func Disconnect(conn *ssh.Client) {
 	}
 }
 
-// AgentAuth returns an auth method backed by the running ssh-agent, and false
-// when no agent is reachable.
+// authMethods builds what the handshake is allowed to try.
 //
-// Offered before the key file so a passphrase-protected key never reaches the
-// interactive prompt: the prompt reads from the terminal, and without a TTY —
-// a CI job, a hook, an agent-driven session — it fails with "operation not
-// supported by device" and the command dies. Every other tool on the machine
-// already goes through the agent, so `ssh host` succeeding while
-// `remote:sync:*` fails on the same host is a difference nobody expects.
+// Public-key authentication is **one** method, not two. The agent and the key
+// file were offered as separate entries in config.Auth, and to the protocol both
+// answer to the name "publickey" — which is what the client marks as tried, by
+// name. So the agent refusing closed the path to ssh/key_path as well: the
+// configured key was never offered at all. Measured on a live sshd, the server
+// log held exactly one attempt, with a key from the agent that it did not
+// accept, and none with the key the project had been told to use.
 //
-// Exported because enterprise replaces the whole ClientConfig through
-// SetSSHConfigProvider; without this being callable from there, fixing the
-// open-source path alone would leave every pro installation prompting.
-func AgentAuth() (ssh.AuthMethod, bool) {
-	sock := os.Getenv("SSH_AUTH_SOCK")
-	if sock == "" {
-		return nil, false
+// The visible symptom was `ssh host` working while `remote:sync:*` failed on the
+// same host, which is precisely the difference this code exists to avoid.
+func authMethods(authType, password, keyPath string) []ssh.AuthMethod {
+	if authType == "password" {
+		return []ssh.AuthMethod{ssh.Password(password)}
 	}
 
-	conn, err := net.Dial("unix", sock)
-	if err != nil {
-		// Stale socket from a dead agent — fall through to the key file.
-		return nil, false
-	}
-
-	// Signers is a callback, so the agent is queried at handshake time. A key
-	// added to the agent after this point still counts.
-	return ssh.PublicKeysCallback(agent.NewClient(conn).Signers), true
+	return []ssh.AuthMethod{publicKeyAuth(keyPath)}
 }
 
-// publicKeyLazy is publicKey deferred to handshake time: the file is read, and
-// a passphrase asked for, only after the methods offered before it have been
-// refused. Used when an agent is available, so an agent-held key never triggers
-// the prompt. Returns an error instead of calling logger.Fatal — at this point
-// the agent may already have succeeded, and killing the process over an
-// unreadable fallback key would turn a working connection into a failure.
-func publicKeyLazy(path string) ssh.AuthMethod {
+// publicKeyAuth offers the agent's keys and the configured key file as a single
+// publickey method, agent first, so every key is tried.
+//
+// The callback runs at handshake time, so a key added to the agent after the
+// config was built still counts. The key file is not read while an agent key is
+// still being tried: the signer built for it knows its own public half, and the
+// private half — and the passphrase prompt with it — waits until the server has
+// said it would accept that key.
+func publicKeyAuth(keyPath string) ssh.AuthMethod {
 	return ssh.PublicKeysCallback(func() ([]ssh.Signer, error) {
-		key, err := os.ReadFile(path)
-		if err != nil {
-			return nil, err
+		var signers []ssh.Signer
+
+		if conn := dialAgent(); conn != nil {
+			agentSigners, err := agent.NewClient(conn).Signers()
+			if err == nil {
+				signers = append(signers, agentSigners...)
+			}
+			// An agent that cannot be talked to is no reason to give up the key
+			// file, which is the whole point of putting them in one method.
 		}
 
-		signer, err := ssh.ParsePrivateKey(key)
-		if err != nil {
-			if passwd == "" {
-				fmt.Print("Input your password for ssh key:")
-				sentence, readErr := terminal.ReadPassword(int(syscall.Stdin))
-				if readErr != nil {
-					return nil, readErr
-				}
-				passwd = strings.TrimSpace(string(sentence))
-			}
-			signer, err = ssh.ParsePrivateKeyWithPassphrase(key, []byte(passwd))
-			if err != nil {
-				return nil, err
+		if keyPath != "" {
+			if signer := fileSigner(keyPath); signer != nil {
+				signers = append(signers, signer)
 			}
 		}
 
-		return []ssh.Signer{signer}, nil
+		if len(signers) == 0 {
+			// Said here rather than left to the handshake, which would report
+			// only that no method remained.
+			if keyPath == "" {
+				return nil, fmt.Errorf("no ssh keys to offer: the agent has none and no key_path is configured")
+			}
+			return nil, fmt.Errorf("no ssh keys to offer: the agent has none and the public half of %s could not be read", keyPath)
+		}
+
+		return signers, nil
 	})
 }
 
-func publicKey(path string) ssh.AuthMethod {
-	key, err := os.ReadFile(path)
-	if err != nil {
-		logger.Fatal(err)
+// dialAgent connects to the running SSH agent, or reports none. A socket left
+// behind by a dead agent counts as none — the key file is the better answer
+// there than an error.
+func dialAgent() net.Conn {
+	socket := os.Getenv("SSH_AUTH_SOCK")
+	if socket == "" {
+		return nil
 	}
-	signer, err := ssh.ParsePrivateKey(key)
+
+	conn, err := net.Dial("unix", socket)
 	if err != nil {
-		if passwd == "" {
-			fmt.Print("Input your password for ssh key:")
-			var sentence []byte
-			sentence, err = terminal.ReadPassword(int(syscall.Stdin))
-			if err != nil {
-				logger.Fatalln(err)
-			}
-			passwd = strings.TrimSpace(string(sentence))
-		}
-		signer, err = ssh.ParsePrivateKeyWithPassphrase(key, []byte(passwd))
-		if err != nil {
-			logger.Fatal(err)
+		return nil
+	}
+
+	return conn
+}
+
+// fileSigner wraps a key file as a signer whose public half is known up front
+// and whose private half is read on the first signature asked of it.
+//
+// nil when the public half cannot be established without a passphrase. Two
+// reasons, and the second is not a style preference: an unreadable fallback key
+// must not sink a connection the agent may still complete, and a signer with no
+// public key is dereferenced by the handshake before anything can check it —
+// nil there is a panic, not a skip.
+func fileSigner(path string) ssh.Signer {
+	public := publicKeyOf(path)
+	if public == nil {
+		return nil
+	}
+
+	return &lazyFileSigner{path: path, public: public}
+}
+
+// publicKeyOf finds the public half of a key file without ever asking for a
+// passphrase: from the .pub beside it, from the key itself when it is not
+// encrypted, or from the cleartext public key an encrypted OpenSSH key carries
+// alongside its encrypted private half.
+func publicKeyOf(path string) ssh.PublicKey {
+	if pub, err := os.ReadFile(path + ".pub"); err == nil {
+		if key, _, _, _, err := ssh.ParseAuthorizedKey(pub); err == nil {
+			return key
 		}
 	}
 
-	return ssh.PublicKeys(signer)
+	key, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	signer, err := ssh.ParsePrivateKey(key)
+	if err == nil {
+		return signer.PublicKey()
+	}
+
+	var missing *ssh.PassphraseMissingError
+	if errors.As(err, &missing) {
+		return missing.PublicKey
+	}
+
+	return nil
+}
+
+// lazyFileSigner signs with a key file, reading and decrypting it on first use.
+// Sign is reached only after the server has accepted the public key, so a
+// passphrase is asked for where it is needed rather than while an agent key is
+// still in play.
+type lazyFileSigner struct {
+	path   string
+	public ssh.PublicKey
+
+	once   sync.Once
+	signer ssh.Signer
+	err    error
+}
+
+func (l *lazyFileSigner) PublicKey() ssh.PublicKey {
+	return l.public
+}
+
+func (l *lazyFileSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	signer, err := l.load()
+	if err != nil {
+		return nil, err
+	}
+
+	return signer.Sign(rand, data)
+}
+
+// SignWithAlgorithm is what makes an RSA key file usable at all. Without it the
+// handshake treats this as a plain Signer, which it assumes can only produce
+// ssh-rsa — SHA-1, refused by every OpenSSH since 8.8 — and the key is rejected
+// for a reason that has nothing to do with the key.
+func (l *lazyFileSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*ssh.Signature, error) {
+	signer, err := l.load()
+	if err != nil {
+		return nil, err
+	}
+
+	as, ok := signer.(ssh.AlgorithmSigner)
+	if !ok {
+		if algorithm != "" && algorithm != signer.PublicKey().Type() {
+			return nil, fmt.Errorf("ssh: key %s cannot sign with %s", l.path, algorithm)
+		}
+		return signer.Sign(rand, data)
+	}
+
+	return as.SignWithAlgorithm(rand, data, algorithm)
+}
+
+func (l *lazyFileSigner) load() (ssh.Signer, error) {
+	l.once.Do(func() {
+		l.signer, l.err = loadSigner(l.path)
+	})
+
+	return l.signer, l.err
+}
+
+// loadSigner reads and parses a key file, asking for the passphrase when it is
+// encrypted. One place prompts, so the answer is remembered once.
+func loadSigner(path string) (ssh.Signer, error) {
+	key, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := ssh.ParsePrivateKey(key)
+	if err == nil {
+		return signer, nil
+	}
+
+	var missing *ssh.PassphraseMissingError
+	if !errors.As(err, &missing) {
+		return nil, err
+	}
+
+	if passwd == "" {
+		fmt.Print("Input your password for ssh key:")
+		sentence, readErr := terminal.ReadPassword(int(syscall.Stdin))
+		if readErr != nil {
+			return nil, readErr
+		}
+		passwd = strings.TrimSpace(string(sentence))
+	}
+
+	return ssh.ParsePrivateKeyWithPassphrase(key, []byte(passwd))
 }
 
 func RunCommand(conn *ssh.Client, cmd string) string {

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.1"
+const Version = "3.9.2"


### PR DESCRIPTION
Ports the fix released in madock-pro 0.23.7 (`181da1b`) to everyone who is not on pro.

## The defect

`Connect` built the agent and `ssh/key_path` as two entries in `config.Auth`. To the protocol both answer to the name `publickey`, and that is what the x/crypto client marks as tried — by name. So an agent holding no key the server would accept did not fall back to the key file: it closed that path too, and the configured key was never offered at all.

Measured in pro on a live sshd: the server log held exactly one attempt, with a key from the agent, and none with the key the project had been told to use.

The symptom from outside was `ssh host` working while `remote:sync:media` failed, on the same host from the same machine — precisely the difference the agent support was added to avoid.

## Two things that had to come with the fix

Merging the methods alone would have traded one silent failure for two others.

**The key file is still not read while an agent key is in play.** The signer built for it finds its public half without a passphrase — from the `.pub` beside it, from the key itself when it is not encrypted, or from the cleartext public key an encrypted OpenSSH key carries alongside its encrypted private half — and reads the private half, with the prompt that implies, only once the server has said it would accept that key. A key whose public half cannot be found that way is **not offered at all**: the handshake dereferences it before anything can check it, so `nil` there is a panic rather than a skipped key.

**An RSA key file signs `rsa-sha2-256`.** A plain `ssh.Signer` is assumed by the handshake to manage only `ssh-rsa` — SHA-1, refused by every OpenSSH since 8.8 — so the deferred signer declares the algorithm itself. Without it the fix would have been invisible on the commonest key type.

## Evidence

Four unit tests, each run against a build with that one guarantee removed, failing there:

| Test | Fails without |
|---|---|
| `TestPublicKeyIsOneMethodEvenWithAnAgent` | the merge — reports 2 methods |
| `TestPublicKeyOfFindsTheHalfThatNeedsNoPassphrase` | the `PassphraseMissingError` branch |
| `TestFileSignerRefusesAKeyItCannotDescribe` | the nil check before the handshake sees it |
| `TestLazyFileSignerSignsWithRsaSha2` | `SignWithAlgorithm` |

An end-to-end test is not possible in this repository — it needs a second machine, which is why `remote:sync:*` sits under "Not here" in the e2e backlog. Pro's live-sshd run, against extmag and shiplab-demo with a working agent, is the evidence for the handshake itself.

## Removed

`AgentAuth` and `publicKeyLazy`: one method needs neither, and the eager `publicKey` had no caller left. Nothing in madock-pro references them — it replaces the whole `ClientConfig` through `SetSSHConfigProvider`, which is why it was never on this path.
