### PR TITLE
Ask the template tree whether it is source, not the module file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v3.9.4**
+
+Fixed:
+- **An installation could stop receiving templates altogether, and look healthy doing it.** The guard added in 3.9.3 skips extraction when the installation directory holds a `go.mod`, on the reasoning that such an install is a clone and git delivers `docker/`. That is true of madock and false of an installation that imports it: madock-pro's install directory is a clone with `go.mod` at the root, but its `docker/` is in `.gitignore` on purpose, because the assets belong to the imported module and arrive by extraction. So extraction switched itself off in the one installation where nothing else brings the templates in, and the tree stopped moving — measured on the development install, `.embedded_version` read **3.6.7** against a **3.9.3** module, with 47 templates still written in the syntax the engine replaced in 3.9.1. Nothing announced it, because the renderer converts the old syntax on the fly and warns: every command worked, from templates two years old. A customer install, being a bare binary with no `go.mod`, was unaffected — so the breakage was confined to the installation the paid edition is developed and tested on, which is the worst place for it to hide
+- The test is now a file in the tree it is a statement about: `docker/embed.go`, the embed declaration. It exists wherever the templates are source, and it appears in no `//go:embed` pattern — those name asset directories — so extraction cannot write it and cannot make an extracted tree pass for a checkout. A test pins the path, because a rename would turn the guard off silently and bring back the reverted-edits defect it was written for
+
 **v3.9.3**
 
 Added:

--- a/src/helper/embedded/extract.go
+++ b/src/helper/embedded/extract.go
@@ -56,14 +56,34 @@ func ExtractIfNeeded(appVersion string) {
 	os.WriteFile(markerFile, []byte(appVersion), 0644)
 }
 
-// isSourceCheckout reports whether the installation directory is madock's own
-// source tree.
+// sourceSentinel is the file that says the docker tree in this directory is
+// source rather than an extraction: the embed declaration itself. It is listed
+// in no //go:embed pattern — those name asset directories — so it exists in a
+// clone and never in an extracted tree.
+const sourceSentinel = "docker/embed.go"
+
+// isSourceCheckout reports whether the docker tree in the installation
+// directory is source that git delivers, rather than one extraction is
+// responsible for keeping current.
 //
-// go.mod is the test because it is what tells the two installations apart:
-// install.sh clones the repository, so the templates there are files git owns,
-// while a release binary is unpacked on its own with nothing beside it.
+// The question is about the templates, so the test is a file in the template
+// tree — not go.mod, which was the first answer and the wrong one. go.mod says
+// "this directory is a Go module", and that is true of madock-pro as well:
+// pro's installation is a clone with go.mod at the root, but its docker/ is in
+// .gitignore on purpose, because the assets belong to the imported madock
+// module and arrive by extraction. Testing go.mod therefore switched extraction
+// off in the one installation where nothing else brings the templates in, and
+// that tree simply stopped moving — measured 2026-08-17, `.embedded_version`
+// read 3.6.7 against a 3.9.3 module, with 47 templates still in the syntax the
+// engine replaced in 3.9.1. Nothing announced it: the renderer converts the old
+// syntax on the fly, so everything worked, from templates two years old.
+//
+// `docker/embed.go` is the honest signal. It is the embed declaration, so it
+// exists wherever the tree is source, and it appears in no //go:embed pattern —
+// those name asset directories — so extraction never writes it and cannot make
+// an extracted tree look like a checkout.
 func isSourceCheckout(execDir string) bool {
-	_, err := os.Stat(filepath.Join(execDir, "go.mod"))
+	_, err := os.Stat(filepath.Join(execDir, filepath.FromSlash(sourceSentinel)))
 	return err == nil
 }
 

--- a/src/helper/embedded/extract_test.go
+++ b/src/helper/embedded/extract_test.go
@@ -3,6 +3,7 @@ package embedded
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"testing/fstest"
 )
@@ -17,6 +18,14 @@ func TestExtractIfNeeded_LeavesASourceCheckoutAlone(t *testing.T) {
 	t.Setenv("MADOCK_EXEC_DIR", dir)
 
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The signal is the embed declaration in the template tree, not go.mod —
+	// see isSourceCheckout for why the module file was the wrong question.
+	if err := os.MkdirAll(filepath.Join(dir, "docker"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(sourceSentinel)), []byte("package dockerassets\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -45,6 +54,72 @@ func TestExtractIfNeeded_LeavesASourceCheckoutAlone(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(dir, ".embedded_version")); err == nil {
 		t.Error("a source checkout should not be stamped with an embedded version either")
+	}
+}
+
+// The other half of the same question, and the one go.mod got wrong: an
+// installation can be a Go module and still have no other way to get its
+// templates. madock-pro is a clone with go.mod at its root, but docker/ is in
+// its .gitignore on purpose — the assets belong to the imported module and are
+// extracted at runtime. Testing go.mod therefore skipped extraction in the one
+// installation where nothing else delivers the tree, and it froze: measured
+// 2026-08-17, .embedded_version said 3.6.7 while the module was 3.9.3, and 47
+// templates were still in the pre-3.9.1 syntax. A customer install, being a
+// bare binary, was fine — so the breakage was confined to the installation pro
+// is developed and tested on.
+func TestExtractIfNeeded_FillsAModuleThatDoesNotShipItsTemplates(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MADOCK_EXEC_DIR", dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// What an earlier binary left behind, with the stamp to match.
+	stale := filepath.Join(dir, "docker", "snippets", "probe.yml")
+	if err := os.MkdirAll(filepath.Dir(stale), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stale, []byte("from an old binary\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".embedded_version"), []byte("3.6.7"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	DockerFS = fstest.MapFS{
+		"snippets/probe.yml": {Data: []byte("from the binary\n")},
+	}
+	t.Cleanup(func() { DockerFS = nil })
+
+	ExtractIfNeeded("9.9.9")
+
+	body, err := os.ReadFile(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "from the binary\n" {
+		t.Fatalf("the stale tree was left in place: %q", string(body))
+	}
+
+	stamp, err := os.ReadFile(filepath.Join(dir, ".embedded_version"))
+	if err != nil || string(stamp) != "9.9.9" {
+		t.Fatalf("the version stamp was not updated: %q, %v", string(stamp), err)
+	}
+}
+
+// The sentinel is a path, so a rename would turn the guard off silently and the
+// reverted-edits defect would come back with nothing failing. This is the only
+// test that knows where the repository root is, and that is the point.
+func TestSourceSentinelIsWhereTheGuardExpectsIt(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("no caller information")
+	}
+	root := filepath.Join(filepath.Dir(thisFile), "..", "..", "..")
+	if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(sourceSentinel))); err != nil {
+		t.Fatalf("%s is gone from the repository, so isSourceCheckout now answers false "+
+			"for madock's own tree and a development binary will revert edited templates again: %v",
+			sourceSentinel, err)
 	}
 }
 

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.3"
+const Version = "3.9.4"


### PR DESCRIPTION
The 3.9.3 guard skips extraction when the install directory holds a `go.mod`, reading that as "this is a clone, git delivers docker/". True for madock, false for anything that imports it: madock-pro's install is a clone with `go.mod` at the root, and its `docker/` is gitignored on purpose, because the assets belong to the imported module and arrive by extraction.

So extraction switched itself off in the one installation where nothing else brings the templates in. Measured on the development install 2026-08-17: `.embedded_version` read **3.6.7** against a **3.9.3** module, and 47 templates were still written in the syntax the engine replaced in 3.9.1. Nothing announced it — the renderer converts the old syntax on the fly and warns, so every command worked, from templates two years old. A customer install is a bare binary with no `go.mod` and was unaffected, which means the breakage was confined to the tree the paid edition is developed and tested on.

The test is now `docker/embed.go`, a file in the tree it is a statement about. It exists wherever the templates are source, and no `//go:embed` pattern names it — those name asset directories — so extraction can never write it and make an extracted tree pass for a checkout.

Three tests, and the first one fails against master:

- `TestExtractIfNeeded_FillsAModuleThatDoesNotShipItsTemplates` — go.mod present, stale tree, stale stamp; expects extraction. Fails on master with `the stale tree was left in place`.
- `TestExtractIfNeeded_LeavesASourceCheckoutAlone` — unchanged in intent, now creates the sentinel; still proves an edited template survives a differently-versioned binary.
- `TestSourceSentinelIsWhereTheGuardExpectsIt` — pins the path, because a rename would turn the guard off silently and bring back the reverted-edits defect 3.9.3 was written for.