### PR TITLE
Name-based removal, and a guard a project cannot lift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+**v3.9.6**
+
+Added:
+- **`allow_destructive_commands`, the one setting a project cannot reach.** `project:remove` ends in a recursive delete of the project directory and `prune` — which sounds like tidying — is `docker compose down` for the current project, with `--with-volumes` its data volumes and images as well. Neither had anything in front of it but a `--force` flag. The setting sits at the **top level** of `~/.madock/config.xml`, outside `<scopes>`, and that placement is the feature: everything under `<scopes>` is overridable by a project's own `.madock/config.xml` and writable by `config:set`, so a guard put there would be switchable by the very thing it protects against. A copy of the key in a project's config, or inside `<scopes>`, is ignored — an e2e test makes the attempt through the real binary rather than trusting the resolver
+- The default stays `true`, because a laptop creates and removes projects all day and a guard that gets in the way is one people learn to switch off. madock-pro ships it `false`: that edition is the one that runs on servers. The installation's own file has the last word in both directions, so a machine that needs the command back does not need a different binary
+- It is a guard rail and not a security control, and the refusal says so: the file is writable by the same user who runs the command. It stops a mistake, not a person
+
 **v3.9.5**
 
 Upgrading:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Added:
 - The default stays `true`, because a laptop creates and removes projects all day and a guard that gets in the way is one people learn to switch off. madock-pro ships it `false`: that edition is the one that runs on servers. The installation's own file has the last word in both directions, so a machine that needs the command back does not need a different binary
 - It is a guard rail and not a security control, and the refusal says so: the file is writable by the same user who runs the command. It stops a mistake, not a person
 
+Fixed:
+- **A comment in `config.xml` could make the key test report nonsense.** `TestEveryKeyIsAKeyMadockHas` reads the config with a regexp over tag names, and it had no idea what a comment was — a tag mentioned inside one was pushed onto its stack and, having no closing half, never left it. Every key after that point was then computed one level too deep, so the test said madock has no setting called `restart_policy` and listed forty more, none of them the comment that caused it. Latent until now only because the two commented-out blocks in the file (`<hosts>`, `<jobs>`) happen to be balanced
+
 **v3.9.5**
 
 Upgrading:

--- a/config.xml
+++ b/config.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
     <activeScope>default</activeScope>
+    <!-- Whether commands that delete a project's data may run here.
+
+         Outside <scopes> on purpose. Everything below describes a project: a
+         project's own file overrides it and `config:set` writes it. A guard a
+         project can switch off is not a guard, and `config:set` writes to the
+         project — so the switch would be reachable by the very command it
+         protects against. Here it can only be changed by editing this file.
+
+         It is a guard rail, not a security control: the file sits beside the
+         binary and is writable by the same user. It stops a mistake, not a
+         person. The mistakes are real — `project:remove` ends with a recursive
+         delete of the working directory, and `prune` is `docker compose down`
+         for the current project rather than the tidy-up its name suggests.
+
+         true here, false in madock-pro, which is the edition that runs on
+         servers. -->
+    <allow_destructive_commands>true</allow_destructive_commands>
     <scopes>
         <default>
             <name>default</name>

--- a/docker/keys_test.go
+++ b/docker/keys_test.go
@@ -139,7 +139,7 @@ func xmlPaths(body string) []string {
 	var stack []string
 	var paths []string
 
-	for _, match := range tag.FindAllStringSubmatch(body, -1) {
+	for _, match := range tag.FindAllStringSubmatch(withoutComments(body), -1) {
 		if match[1] == "/" {
 			if len(stack) > 0 {
 				stack = stack[:len(stack)-1]
@@ -155,6 +155,23 @@ func xmlPaths(body string) []string {
 	}
 
 	return paths
+}
+
+// withoutComments removes XML comments before the tags are counted.
+//
+// The scanner below is a regexp over tag names and has no idea what a comment
+// is, so a tag mentioned inside one is pushed onto the stack and — having no
+// closing half — never leaves it. Every key after that point is computed one
+// level deep and the test reports that madock has no setting called
+// `restart_policy`, which is forty lines of nonsense pointing nowhere near the
+// comment that caused it.
+//
+// It was already latent: config_defaults.xml carries commented-out `<hosts>`
+// and `<jobs>` blocks, which happen to be balanced and so cancel out. A comment
+// that merely names a tag in prose does not.
+func withoutComments(body string) string {
+	comment := regexp.MustCompile(`(?s)<!--.*?-->`)
+	return comment.ReplaceAllString(body, "")
 }
 
 func repoRoot(t *testing.T) string {
@@ -173,4 +190,39 @@ func sorted(m map[string][]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// TestXmlPathsIgnoresComments pins the above. Without it the failure lands on
+// every key in the file except the one that caused it.
+func TestXmlPathsIgnoresComments(t *testing.T) {
+	keys := xmlPaths(`<?xml version="1.0"?>
+<config>
+    <!-- Outside <scopes> on purpose, and this sentence used to break the scan.
+         So did a commented-out block:
+         <hosts>
+             <host>example.test</host> -->
+    <allow_destructive_commands>true</allow_destructive_commands>
+    <scopes>
+        <default>
+            <restart_policy>no</restart_policy>
+            <php>
+                <version>8.2</version>
+            </php>
+        </default>
+    </scopes>
+</config>`)
+
+	found := map[string]bool{}
+	for _, key := range keys {
+		found[key] = true
+	}
+
+	for _, want := range []string{"restart_policy", "php/version"} {
+		if !found[want] {
+			t.Errorf("%q was not read; the comment shifted the scan: %v", want, keys)
+		}
+	}
+	if found["allow_destructive_commands"] {
+		t.Error("a top-level key was read as a setting; it lives outside <scopes> and is not one")
+	}
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -84,6 +84,43 @@ Settings are inherited in this order (later overrides earlier):
 3. `~/.madock/projects/{project_name}/config.xml` (project settings)
 4. `{project_root}/.madock/config.xml` (local project settings)
 
+## Settings that belong to the installation, not the project
+
+One setting is deliberately outside that chain, and outside `<scopes>`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <allow_destructive_commands>true</allow_destructive_commands>
+    <scopes>
+        ...
+    </scopes>
+</config>
+```
+
+`allow_destructive_commands` decides whether the commands that delete a
+project's data may run on this machine — `project:remove`, which ends in a
+recursive delete of the project directory, and `prune`, which is `docker compose
+down` for the current project and, with `--with-volumes`, its data volumes and
+images as well. Set it to `false` and both refuse, naming the file to edit.
+
+It sits at the top level because everything under `<scopes>` is reachable from a
+project: the project's own `.madock/config.xml` overrides it and `config:set`
+writes it. A guard a project can switch off is not a guard, so this one is
+readable only from `~/.madock/config.xml` — the file belonging to whoever
+administers the installation. A copy of the key inside a project's config, or
+inside `<scopes>`, is ignored.
+
+It is a guard rail, not a security control. The file sits beside the binary and
+is writable by the same user, so anyone who can run the command can also edit the
+file first. It stops a mistake, not a person.
+
+The default is `true`: on a laptop, projects are created and removed all day, and
+a guard that gets in the way there is a guard people learn to switch off.
+madock-pro ships it as `false`, because that edition is the one that runs on
+servers — and the file still has the last word there, so a machine that needs it
+does not need a different binary.
+
 ## Key Configuration Options
 
 | Key | Description | Default |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -235,6 +235,9 @@ This command shows you the following items:
 
 * `project:remove`   Remove project (project folder, madock project configuration, volumes, images, containers)
 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;An installation can forbid this command, and `prune` with it — see
+`allow_destructive_commands` in [config.md](config.md). madock-pro ships it forbidden
+
 * `proxy:start`   Start a proxy server
 
 

--- a/src/controller/all/global_commands_test.go
+++ b/src/controller/all/global_commands_test.go
@@ -23,7 +23,12 @@ import (
 // usually that something about the registry is wrong; template:convert because a
 // directory of templates is a directory of templates — refusing to run it outside
 // a project would be refusing it in exactly the place somebody keeps a copy of
-// their overrides.
+// their overrides; and project:remove because an orphan — a registry entry whose
+// source directory is gone — has nowhere to be removed from. project:list has been
+// able to name those since 3.8.50 and nothing could act on them: the tool described
+// a problem it could not fix. The exemption is narrow in the handler, not here —
+// without --name it still requires a project directory, so the protection that
+// keeps it from destroying the wrong one is unchanged.
 func TestGlobalCommands(t *testing.T) {
 	want := []string{
 		"--version",
@@ -32,6 +37,7 @@ func TestGlobalCommands(t *testing.T) {
 		"mcp",
 		"project:clone",
 		"project:list",
+		"project:remove",
 		"proxy:logs",
 		"setup",
 		"template:convert",

--- a/src/controller/general/project/remove/remove.go
+++ b/src/controller/general/project/remove/remove.go
@@ -30,11 +30,28 @@ func init() {
 		Help:     "Remove project",
 		Category: "project",
 		ArgsType: new(ArgsStruct),
+		// Runs outside a project on purpose, and only for --name.
+		//
+		// The scope check refuses a project command run anywhere else, which is
+		// right for every other one and wrong for this: an orphan is an entry
+		// whose source directory is gone, so there is nowhere to stand to remove
+		// it. project:list names such entries and nothing could remove them —
+		// the tool could describe the problem and not act on it.
+		//
+		// Without --name the handler still requires a project directory, so the
+		// protection that refuses to destroy the wrong one is unchanged.
+		Global: true,
 	})
 }
 
 func Execute() {
 	args := attr.Parse(new(ArgsStruct)).(*ArgsStruct)
+
+	// A name is answered by the registry, not by the working directory.
+	if args.Name != "" && args.Name != configs.GetProjectName() {
+		removeNamed(args.Name, args.Force)
+		return
+	}
 
 	projectName := configs.GetProjectName()
 
@@ -140,6 +157,23 @@ func removeProject(projectName string) {
 	fmtc.WarningLn("  " + paths.GetRunDirPath())
 	fmtc.WarningLn("  containers, images and volumes of the project")
 
+	removeRegistered(projectName)
+
+	// The project's own directory, and only when standing in it. Split out so
+	// that removing an entry by name — where the source is gone and the caller
+	// is standing somewhere else entirely — cannot reach this line.
+	if err := os.RemoveAll(paths.GetRunDirPath()); err != nil {
+		logger.Fatal(err)
+	}
+}
+
+// removeRegistered takes down everything the installation holds for a project:
+// its containers, its registry entry, its generated runtime, its block in the
+// shared proxy and its port reservation. Everything except the project's own
+// directory, which is the caller's to decide about.
+func removeRegistered(projectName string) {
+	pp := paths.NewProjectPaths(projectName)
+
 	// Before the containers go: anything they wrote as root has to be handed
 	// back, or the deletion below stops at the first such file and leaves the
 	// project half removed.
@@ -147,18 +181,11 @@ func removeProject(projectName string) {
 
 	docker.Down(projectName, true)
 
-	err := os.RemoveAll(paths.GetExecDirPath() + "/projects/" + projectName + "/")
-	if err != nil {
+	if err := os.RemoveAll(paths.GetExecDirPath() + "/projects/" + projectName + "/"); err != nil {
 		logger.Fatal(err)
 	}
 
-	err = os.RemoveAll(pp.RuntimeDir())
-	if err != nil {
-		logger.Fatal(err)
-	}
-
-	err = os.RemoveAll(paths.GetRunDirPath())
-	if err != nil {
+	if err := os.RemoveAll(pp.RuntimeDir()); err != nil {
 		logger.Fatal(err)
 	}
 
@@ -192,4 +219,72 @@ func removeProject(projectName string) {
 
 	fmtc.SuccessLn("Project was removed successfully")
 	fmtc.SuccessLn("!!! Close the terminal for the changes to take effect !!!")
+}
+
+// removeNamed removes a registry entry from anywhere, by name.
+//
+// It exists for the orphan: an entry whose source directory is gone. project:list
+// has been able to name those since 3.8.50 and nothing could remove them, because
+// this command asked the working directory who the project was — and for an
+// orphan there is no directory to stand in. The workaround was to recreate the
+// directory with a copy of its config.xml and delete from there, which is a
+// strange thing for a tool to require of the person cleaning up after it.
+//
+// A project whose source still exists is refused and told where it is. That keeps
+// the protection this command is built around: removeProject ends with RemoveAll
+// on the working directory, so removing a live project from somewhere else would
+// take that somewhere else with it.
+func removeNamed(projectName string, force bool) {
+	var entry *configs.ProjectEntry
+	for _, candidate := range configs.ListProjects() {
+		if candidate.Name == projectName {
+			found := candidate
+			entry = &found
+			break
+		}
+	}
+
+	if entry == nil {
+		fmtc.ErrorLn("No project named '" + projectName + "' is registered in this installation")
+		fmtc.ToDoLn("madock project:list")
+		os.Exit(1)
+	}
+
+	if entry.State == configs.ProjectOk {
+		fmtc.ErrorLn("Project '" + projectName + "' still has its source directory: " + entry.Path)
+		fmtc.ToDoLn("Remove it from there, so the directory goes with it:")
+		fmtc.ToDoLn("  cd " + entry.Path + " && madock project:remove --force --name=" + projectName)
+		os.Exit(1)
+	}
+
+	fmtc.WarningLn("Removing the registry entry '" + projectName + "':")
+	fmtc.WarningLn("  " + paths.GetExecDirPath() + "/projects/" + projectName + "/")
+	fmtc.WarningLn("  " + paths.NewProjectPaths(projectName).RuntimeDir())
+	fmtc.WarningLn("  containers, images and volumes of the project")
+	if entry.Path != "" {
+		fmtc.WarningLn("  its source directory is already gone: " + entry.Path)
+	}
+
+	if !force {
+		fmt.Println("")
+		fmt.Println("Enter the project name \"" + projectName + "\" to confirm")
+		fmt.Print("> ")
+		buf := bufio.NewReader(os.Stdin)
+		sentence, err := buf.ReadBytes('\n')
+		if err != nil {
+			logger.Fatalln(err)
+		}
+		if strings.TrimSpace(string(sentence)) != projectName {
+			fmtc.WarningLn("The project was not removed. The entered value does not match the project name.")
+			return
+		}
+	}
+
+	removeRegistered(projectName)
+}
+
+// definition returns this command's registration, for tests that assert on it.
+func definition() *command.Definition {
+	def, _ := command.Get("project:remove")
+	return def
 }

--- a/src/controller/general/project/remove/remove.go
+++ b/src/controller/general/project/remove/remove.go
@@ -47,6 +47,15 @@ func init() {
 func Execute() {
 	args := attr.Parse(new(ArgsStruct)).(*ArgsStruct)
 
+	// Before anything is read, decided or printed: this command deletes a
+	// project's data, and an installation may forbid that.
+	if !configs.AllowsDestructiveCommands() {
+		for _, line := range configs.DestructiveRefusal("project:remove") {
+			fmtc.ErrorLn(line)
+		}
+		os.Exit(1)
+	}
+
 	// A name is answered by the registry, not by the working directory.
 	if args.Name != "" && args.Name != configs.GetProjectName() {
 		removeNamed(args.Name, args.Force)

--- a/src/controller/general/project/remove/remove_test.go
+++ b/src/controller/general/project/remove/remove_test.go
@@ -1,0 +1,74 @@
+package remove
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/faradey/madock/v3/src/helper/configs"
+)
+
+// registryWith builds an installation holding one project entry, with the
+// recorded source path pointing where the caller says.
+func registryWith(t *testing.T, name, sourcePath string) string {
+	t.Helper()
+
+	execDir := t.TempDir()
+	dir := filepath.Join(execDir, "projects", name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	config := `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <scopes>
+        <default>
+            <path>` + sourcePath + `</path>
+        </default>
+    </scopes>
+</config>
+`
+	if err := os.WriteFile(filepath.Join(dir, "config.xml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return execDir
+}
+
+// The orphan is the case the whole thing exists for: an entry whose source
+// directory is gone. project:list has been able to name those since 3.8.50, and
+// nothing could remove them — the command asked the working directory who the
+// project was, and for an orphan there is no directory to stand in.
+func TestListProjects_NamesTheOrphan(t *testing.T) {
+	execDir := registryWith(t, "ghost", filepath.Join(t.TempDir(), "gone"))
+
+	entries := configs.ListProjectsIn(execDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(entries))
+	}
+	if entries[0].State != configs.ProjectMissingSource {
+		t.Fatalf("expected the entry to be an orphan, got state %q", entries[0].State)
+	}
+}
+
+// A project whose source is still there must not be removable from somewhere
+// else: removeProject ends with RemoveAll on the working directory, so that
+// would take the caller's directory with it.
+func TestListProjects_LiveProjectIsNotAnOrphan(t *testing.T) {
+	source := t.TempDir()
+	execDir := registryWith(t, "alive", source)
+
+	entries := configs.ListProjectsIn(execDir)
+	if entries[0].State != configs.ProjectOk {
+		t.Fatalf("a project with its source present should be ok, got %q", entries[0].State)
+	}
+}
+
+// The command has to be reachable outside a project, or --name can never run:
+// the scope check refuses project commands elsewhere, and it runs before the
+// handler that would decide.
+func TestCommandIsReachableOutsideAProject(t *testing.T) {
+	if !definition().Global {
+		t.Fatal("project:remove is refused outside a project, so an orphan cannot be removed at all")
+	}
+}

--- a/src/controller/general/prune/prune.go
+++ b/src/controller/general/prune/prune.go
@@ -1,6 +1,8 @@
 package prune
 
 import (
+	"os"
+
 	"github.com/faradey/madock/v3/src/command"
 	"github.com/faradey/madock/v3/src/controller/general/proxy"
 	"github.com/faradey/madock/v3/src/helper/cli/arg_struct"
@@ -23,6 +25,17 @@ func init() {
 
 func Execute() {
 	args := attr.Parse(new(arg_struct.ControllerGeneralPrune)).(*arg_struct.ControllerGeneralPrune)
+
+	// The name promises `docker system prune` and the body is `docker compose
+	// down` for the current project — with --with-volumes, its data volumes and
+	// images as well. Whatever it is called, it destroys, so the installation's
+	// answer applies here too.
+	if !configs.AllowsDestructiveCommands() {
+		for _, line := range configs.DestructiveRefusal("prune") {
+			fmtc.ErrorLn(line)
+		}
+		os.Exit(1)
+	}
 
 	if configs.IsHasConfig("") {
 		projectname := configs.GetProjectName()

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -1,6 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
     <activeScope>default</activeScope>
+    <!-- Whether commands that delete a project's data may run here.
+
+         Outside <scopes> on purpose. Everything below describes a project: a
+         project's own file overrides it and `config:set` writes it. A guard a
+         project can switch off is not a guard, and `config:set` writes to the
+         project — so the switch would be reachable by the very command it
+         protects against. Here it can only be changed by editing this file.
+
+         It is a guard rail, not a security control: the file sits beside the
+         binary and is writable by the same user. It stops a mistake, not a
+         person. The mistakes are real — `project:remove` ends with a recursive
+         delete of the working directory, and `prune` is `docker compose down`
+         for the current project rather than the tidy-up its name suggests.
+
+         true here, false in madock-pro, which is the edition that runs on
+         servers. -->
+    <allow_destructive_commands>true</allow_destructive_commands>
     <scopes>
         <default>
             <name>default</name>

--- a/src/helper/configs/destructive.go
+++ b/src/helper/configs/destructive.go
@@ -1,0 +1,95 @@
+package configs
+
+import (
+	"os"
+	"strings"
+
+	"github.com/faradey/madock/v3/src/helper/paths"
+)
+
+// DestructiveKey is the one setting that lives outside the scopes, and the
+// placement is the whole point.
+//
+// Everything else in config.xml describes a project: it sits under
+// scopes/<scope>/, a project's own file overrides it, and `config:set` writes
+// it. That layering is right for what a project is, and wrong for a guard
+// against destroying one — a guard a project can switch off is not a guard, and
+// `config:set` now writes to the project, so the switch would be reachable by
+// the very command it protects against.
+//
+// getConfigByScope drops every key that is not under scopes/, so a key at the
+// top level cannot be reached by a project's config, by a scope, or by
+// `config:set`. Changing it means editing the installation's own file, which is
+// what "only the person who administers this machine" means in practice.
+const DestructiveKey = "allow_destructive_commands"
+
+// AllowsDestructiveCommands reports whether commands that delete a project's
+// data may run on this installation.
+//
+// It is a guard rail and not a security control, and the difference matters
+// enough to write down: the file sits beside the binary and is writable by the
+// same user, so anyone who can run the command can also edit the file first. It
+// stops a mistake, not a person.
+//
+// What it stops is worth stopping. `project:remove` ends with RemoveAll on the
+// working directory, and the release runbook records that running it in the
+// installation directory would have taken madock, its repository and every
+// other project's configuration with it. `prune` sounds like tidying and is
+// `docker compose down` for the current project — with --with-volumes, the data
+// volumes and the images too.
+func AllowsDestructiveCommands() bool {
+	return !strings.EqualFold(strings.TrimSpace(destructiveSetting()), "false")
+}
+
+// destructiveSetting resolves the value through the same three layers every
+// other setting uses, minus the two that would defeat it: embedded default,
+// then the edition's answer, then the installation's own file. No project, no
+// scope.
+func destructiveSetting() string {
+	value := ""
+
+	if len(defaultConfigXML) > 0 {
+		value = topLevel(ParseXmlBytes(defaultConfigXML), DestructiveKey, value)
+	}
+
+	// An edition may disagree with the community default. madock-pro is the one
+	// that runs on servers and says no there.
+	if override, ok := defaultOverrides[DestructiveKey]; ok {
+		value = override
+	}
+
+	// The installation's own file has the last word, because turning this back
+	// on must never require a different binary.
+	configPath := paths.GetExecDirPath() + "/config.xml"
+	if _, err := os.Stat(configPath); err == nil {
+		value = topLevel(ParseXmlFile(configPath), DestructiveKey, value)
+	}
+
+	return value
+}
+
+// topLevel reads a key that sits directly under <config>, returning fallback
+// when the file does not carry it.
+func topLevel(parsed map[string]string, key, fallback string) string {
+	if value, ok := parsed[key]; ok && strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
+}
+
+// DestructiveRefusal is the message a refused command prints.
+//
+// One text for every such command, because the reader's next question is always
+// the same — what do I edit — and answering it differently in each place is how
+// half of them end up not answering it at all.
+func DestructiveRefusal(commandName string) []string {
+	return []string{
+		"'" + commandName + "' deletes a project's data, and this installation does not allow that.",
+		"",
+		"To allow it, set " + DestructiveKey + " to true in:",
+		"  " + paths.GetExecDirPath() + "/config.xml",
+		"",
+		"It sits at the top of the file, outside <scopes>, and no project or",
+		"'madock config:set' can change it — which is the point of it.",
+	}
+}

--- a/src/helper/configs/destructive_test.go
+++ b/src/helper/configs/destructive_test.go
@@ -1,0 +1,114 @@
+package configs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// installationWith writes an installation config.xml holding the given body
+// inside <config> and points madock at that directory.
+func installationWith(t *testing.T, body string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("MADOCK_EXEC_DIR", dir)
+
+	xml := "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<config>\n" + body + "\n</config>\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.xml"), []byte(xml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	CleanCache()
+	t.Cleanup(CleanCache)
+
+	return dir
+}
+
+// The shipped answer: a laptop removes projects all day, and a guard that gets
+// in the way there is a guard people learn to switch off.
+func TestAllowsDestructiveCommands_DefaultsToAllowed(t *testing.T) {
+	installationWith(t, "    <activeScope>default</activeScope>")
+
+	if !AllowsDestructiveCommands() {
+		t.Fatal("the community default should allow destructive commands")
+	}
+}
+
+func TestAllowsDestructiveCommands_FileSaysNo(t *testing.T) {
+	installationWith(t, "    <"+DestructiveKey+">false</"+DestructiveKey+">")
+
+	if AllowsDestructiveCommands() {
+		t.Fatal("the installation said false and was not believed")
+	}
+}
+
+// An edition may disagree with the default — madock-pro runs on servers and
+// says no there — and the file still has the last word, or turning it back on
+// would require a different binary.
+func TestAllowsDestructiveCommands_EditionThenFile(t *testing.T) {
+	installationWith(t, "    <activeScope>default</activeScope>")
+
+	SetDefaultOverride(DestructiveKey, "false")
+	t.Cleanup(func() { delete(defaultOverrides, DestructiveKey) })
+
+	if AllowsDestructiveCommands() {
+		t.Fatal("the edition's answer was ignored")
+	}
+
+	installationWith(t, "    <"+DestructiveKey+">true</"+DestructiveKey+">")
+	if !AllowsDestructiveCommands() {
+		t.Fatal("the file must override the edition, or a machine cannot re-enable it")
+	}
+}
+
+// The property the placement exists for. A guard a project can switch off is
+// not a guard — and config:set writes to the project, so a scoped key would be
+// reachable by the very command this protects against.
+func TestDestructiveKey_IsNotReachableFromAProject(t *testing.T) {
+	scoped := ParseXmlBytes([]byte(`<?xml version="1.0"?>
+<config>
+    <scopes>
+        <default>
+            <` + DestructiveKey + `>true</` + DestructiveKey + `>
+        </default>
+    </scopes>
+</config>`))
+
+	project := getConfigByScope(scoped, "default")
+	if _, ok := project[DestructiveKey]; !ok {
+		t.Skip("a scoped copy of the key does reach a project map — that is expected; the check below is the real one")
+	}
+
+	// Reaching a project map is one thing; being believed is another. The
+	// resolver reads the top level only, so a scoped value changes nothing.
+	dir := installationWith(t, `    <`+DestructiveKey+`>false</`+DestructiveKey+`>
+    <scopes>
+        <default>
+            <`+DestructiveKey+`>true</`+DestructiveKey+`>
+        </default>
+    </scopes>`)
+	_ = dir
+
+	if AllowsDestructiveCommands() {
+		t.Fatal("a value inside <scopes> overrode the installation's own answer")
+	}
+}
+
+// And the top-level key is where the parser leaves it: unprefixed, so
+// getConfigByScope — which every project-facing reader goes through — drops it.
+func TestDestructiveKey_IsDroppedByScopeExtraction(t *testing.T) {
+	parsed := ParseXmlBytes([]byte(`<?xml version="1.0"?>
+<config>
+    <` + DestructiveKey + `>false</` + DestructiveKey + `>
+    <scopes><default><platform>magento2</platform></default></scopes>
+</config>`))
+
+	if _, ok := parsed[DestructiveKey]; !ok {
+		t.Fatalf("the parser did not keep the top-level key: %v", parsed)
+	}
+
+	if _, ok := getConfigByScope(parsed, "default")[DestructiveKey]; ok {
+		t.Fatal("the key survived scope extraction, so a project would inherit it")
+	}
+}

--- a/src/helper/configs/destructive_test.go
+++ b/src/helper/configs/destructive_test.go
@@ -112,3 +112,36 @@ func TestDestructiveKey_IsDroppedByScopeExtraction(t *testing.T) {
 		t.Fatal("the key survived scope extraction, so a project would inherit it")
 	}
 }
+
+// The guard has to survive madock writing the file for other reasons.
+//
+// SaveInFile rewrites config.xml whole: it parses what is there, merges the
+// incoming keys into a scope and writes the result back. A top-level key is not
+// part of any scope, so it travels through that merge as itself — and if it did
+// not, an installation that allowed the command would quietly stop allowing it
+// the next time anything wrote a password or a setting, with no diff a person
+// would think to look at.
+func TestDestructiveKey_SurvivesAWriteToTheSameFile(t *testing.T) {
+	dir := installationWith(t, `    <`+DestructiveKey+`>true</`+DestructiveKey+`>
+    <scopes>
+        <default>
+            <platform>magento2</platform>
+        </default>
+    </scopes>`)
+
+	path := filepath.Join(dir, "config.xml")
+	SaveInFile(path, map[string]string{"db/password": "written-later"}, "default")
+	CleanCache()
+
+	written := ParseXmlFile(path)
+	if written[DestructiveKey] != "true" {
+		t.Fatalf("the guard's key did not survive a write to the same file: %v", written)
+	}
+	if written["scopes/default/db/password"] != "written-later" {
+		t.Errorf("the write itself did not land: %v", written)
+	}
+
+	if !AllowsDestructiveCommands() {
+		t.Fatal("the installation's answer changed because something else wrote to the file")
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.5"
+const Version = "3.9.6"

--- a/test/e2e/destructive_test.go
+++ b/test/e2e/destructive_test.go
@@ -1,0 +1,170 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDestructiveCommandsObeyTheInstallation covers the guard that stops
+// `project:remove` and `prune` on an installation that has said they may not
+// run — and, more importantly, covers the half that makes it worth having:
+// that a project cannot lift it.
+//
+// The unit tests pin the resolver. This one pins the binary, because the two
+// can disagree in exactly one way that matters. Every other setting in
+// config.xml is reachable from a project — its own file overrides it and
+// `config:set` writes it — so a key that ended up under <scopes> would look
+// identical in review and be switchable by the very thing it protects against.
+// Here the attempt is actually made, through the real command, and the refusal
+// has to survive it.
+//
+// Nothing is started: the guard runs before the command touches Docker, and a
+// test that started a project would pay twenty minutes to prove something the
+// refusal makes unnecessary.
+func TestDestructiveCommandsObeyTheInstallation(t *testing.T) {
+	install := newInstallation(t)
+	p := install.project("e2eguarded")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2eguarded.test",
+	)
+
+	registry := filepath.Join(p.execDir, "projects", "e2eguarded")
+
+	// Restored before the harness cleans up, which removes the project the way
+	// every other test does. Cleanups run last-registered-first, so this one is
+	// ahead of the harness's, which was registered when the project was made.
+	t.Cleanup(func() { writeInstallationConfig(t, p.execDir, "true") })
+	writeInstallationConfig(t, p.execDir, "false")
+
+	for _, refused := range [][]string{
+		{"project:remove", "--force", "--name=e2eguarded"},
+		{"prune"},
+	} {
+		out, err := p.tryRun(2*time.Minute, refused...)
+		if err == nil {
+			t.Errorf("`%s` ran on an installation that forbids it:\n%s", strings.Join(refused, " "), out)
+		}
+		// The refusal is only useful if it says what to edit. Somebody meets
+		// this message on a server, in a hurry, and the next question is always
+		// the same one.
+		requireContains(t, out, "allow_destructive_commands", "the refusal should name the setting")
+		requireContains(t, out, filepath.Join(p.execDir, "config.xml"), "the refusal should name the file to edit")
+	}
+
+	if _, err := os.Stat(registry); err != nil {
+		t.Fatalf("the project was removed despite the refusal: %v", err)
+	}
+
+	// Now try to lift it, by every route a project has.
+	//
+	// The first is the strongest result available: `config:set` does not know
+	// the key at all, because it only writes what is in the project's own
+	// option set and this key is never in it. An error here is the assertion,
+	// not a problem with the test.
+	out, err := p.tryRun(2*time.Minute, "config:set", "-n", "allow_destructive_commands", "-v", "true")
+	if err == nil {
+		t.Errorf("config:set accepted a key that belongs to the installation:\n%s", out)
+	}
+	requireContains(t, out, "doesn't exist", "config:set should say the option is not a project option")
+
+	// The other two are hand-edited files, which is what somebody does when a
+	// command refuses. Both sit in the inheritance chain and neither is read
+	// for this key.
+	claimTheKey(t, filepath.Join(p.execDir, "projects", "e2eguarded", "config.xml"))
+	claimTheKey(t, projectLocalConfig(t, p))
+
+	out, err = p.tryRun(2*time.Minute, "project:remove", "--force", "--name=e2eguarded")
+	if err == nil {
+		t.Fatalf("a project turned the guard off for itself:\n%s", out)
+	}
+	if _, err := os.Stat(registry); err != nil {
+		t.Fatalf("the project was removed after a project-level override: %v", err)
+	}
+
+	// And the installation's own file still has the last word, or turning the
+	// guard back on would mean installing a different binary.
+	writeInstallationConfig(t, p.execDir, "true")
+
+	install.destroyProxy(p)
+	p.run(5*time.Minute, "project:remove", "--force", "--name=e2eguarded")
+
+	if _, err := os.Stat(registry); !os.IsNotExist(err) {
+		t.Errorf("the project survived a removal the installation allows: %s", registry)
+	}
+}
+
+// writeInstallationConfig writes {execDir}/config.xml carrying one answer.
+//
+// Written whole rather than edited: madock does not create this file on a fresh
+// install, so a test that edited it would only ever run against a state that
+// does not exist on a new machine.
+func writeInstallationConfig(t *testing.T, execDir, allow string) {
+	t.Helper()
+
+	body := `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <allow_destructive_commands>` + allow + `</allow_destructive_commands>
+</config>
+`
+	if err := os.WriteFile(filepath.Join(execDir, "config.xml"), []byte(body), 0o644); err != nil {
+		t.Fatalf("writing the installation config: %v", err)
+	}
+}
+
+// projectLocalConfig creates the project's own .madock/config.xml the way the
+// documentation tells a user to: a copy of the registry's config, in the
+// project directory, under version control.
+//
+// `setup` does not create it — it is opt-in — so a test that only edited an
+// existing file would silently skip this route entirely.
+func projectLocalConfig(t *testing.T, p *project) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(p.execDir, "projects", p.name, "config.xml"))
+	if err != nil {
+		t.Fatalf("reading the registry config: %v", err)
+	}
+
+	dir := filepath.Join(p.runDir, ".madock")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", dir, err)
+	}
+
+	path := filepath.Join(dir, "config.xml")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+
+	return path
+}
+
+// claimTheKey writes the guard's key into a config file, in both places a
+// person would plausibly put it: at the top level, and inside the scope where
+// every other setting lives.
+func claimTheKey(t *testing.T, path string) {
+	t.Helper()
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	claim := "<allow_destructive_commands>true</allow_destructive_commands>"
+	edited := strings.Replace(string(body), "<config>", "<config>\n    "+claim, 1)
+	edited = strings.Replace(edited, "<default>", "<default>\n            "+claim, 1)
+
+	if edited == string(body) {
+		t.Fatalf("%s had neither <config> nor <default> to write into:\n%s", path, body)
+	}
+	if err := os.WriteFile(path, []byte(edited), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
Three commits.

**`project:remove --name`** now answers from the registry rather than the working directory, so a project can be removed from anywhere — and only the cwd path still deletes the run directory it is standing in.

**`allow_destructive_commands`** sits at the top level of the installation's `config.xml`, outside `<scopes>`, and that placement is the point: every key under `<scopes>` is overridden by a project's own `.madock/config.xml` and written by `config:set`, so a guard put there would be switchable by the very command it protects against. Default stays `true`; madock-pro will ship it `false`, and the file wins over the edition in both directions.

The e2e test makes the attempt through the real binary rather than trusting the resolver: `config:set` does not know the key, and a copy of it in the registry config and in the project's own `.madock/config.xml` changes nothing. Verified against a build with the guard stripped, where the project was removed and the test failed.

**The key scanner** in `TestEveryKeyIsAKeyMadockHas` had no idea what an XML comment was — a tag named inside one was pushed onto its stack and never popped, so every key after it was computed one level too deep. Latent until the guard's comment mentioned `<scopes>` in prose.