### PR TITLE
Guard the flag, not the command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v3.9.7**
+
+Fixed:
+- **The guard added in 3.9.6 covered `prune`, and `prune` is not destructive.** It is `docker compose down` for the current project: containers and the network go, the volumes stay, the images stay, the project directory and its registry entry are untouched, and `madock start` puts it all back. Guarding it obstructed without protecting anything — and inconsistently, since `stop` takes the same site down with nothing in front of it. Only `prune --with-volumes` is covered now, which is `down -v --rmi all`: the data volumes and the images, with nothing to bring the database back. `project:remove` is unchanged
+
 **v3.9.6**
 
 Added:

--- a/config.xml
+++ b/config.xml
@@ -11,9 +11,16 @@
 
          It is a guard rail, not a security control: the file sits beside the
          binary and is writable by the same user. It stops a mistake, not a
-         person. The mistakes are real — `project:remove` ends with a recursive
-         delete of the working directory, and `prune` is `docker compose down`
-         for the current project rather than the tidy-up its name suggests.
+         person.
+
+         What it covers is what cannot be undone: `project:remove`, which ends
+         with a recursive delete of the working directory, and `prune` when it
+         is asked to take the volumes, which destroys the database with them.
+         Plain `prune` is `docker compose down` and is deliberately not covered,
+         because `start` puts that back.
+
+         (No double hyphen anywhere above: XML forbids one inside a comment, and
+         naming the flag here cost a test run to find that out.)
 
          true here, false in madock-pro, which is the edition that runs on
          servers. -->

--- a/docs/config.md
+++ b/docs/config.md
@@ -98,11 +98,21 @@ One setting is deliberately outside that chain, and outside `<scopes>`:
 </config>
 ```
 
-`allow_destructive_commands` decides whether the commands that delete a
-project's data may run on this machine — `project:remove`, which ends in a
-recursive delete of the project directory, and `prune`, which is `docker compose
-down` for the current project and, with `--with-volumes`, its data volumes and
-images as well. Set it to `false` and both refuse, naming the file to edit.
+`allow_destructive_commands` decides whether the commands that destroy a
+project's data may run on this machine:
+
+- **`project:remove`** — the registry entry, the generated runtime, the ports,
+  the volumes, the images, and a recursive delete of the project directory.
+- **`prune --with-volumes`** — `docker compose down -v --rmi all`: the data
+  volumes and the images. The database is gone and nothing brings it back.
+
+Set it to `false` and both refuse, naming the file to edit.
+
+**Plain `prune` is not covered**, deliberately. It is `docker compose down`:
+containers and the network go, the volumes and images stay, the project
+directory and its registry entry are untouched, and `madock start` puts it back.
+Guarding it would obstruct without protecting — and inconsistently, since `stop`
+takes the same site down with nothing in front of it.
 
 It sits at the top level because everything under `<scopes>` is reachable from a
 project: the project's own `.madock/config.xml` overrides it and `config:set`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -235,8 +235,8 @@ This command shows you the following items:
 
 * `project:remove`   Remove project (project folder, madock project configuration, volumes, images, containers)
 
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;An installation can forbid this command, and `prune` with it — see
-`allow_destructive_commands` in [config.md](config.md). madock-pro ships it forbidden
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;An installation can forbid this command, and `prune --with-volumes` with it —
+see `allow_destructive_commands` in [config.md](config.md). madock-pro ships it forbidden
 
 * `proxy:start`   Start a proxy server
 

--- a/src/controller/general/prune/prune.go
+++ b/src/controller/general/prune/prune.go
@@ -26,12 +26,20 @@ func init() {
 func Execute() {
 	args := attr.Parse(new(arg_struct.ControllerGeneralPrune)).(*arg_struct.ControllerGeneralPrune)
 
-	// The name promises `docker system prune` and the body is `docker compose
-	// down` for the current project — with --with-volumes, its data volumes and
-	// images as well. Whatever it is called, it destroys, so the installation's
-	// answer applies here too.
-	if !configs.AllowsDestructiveCommands() {
-		for _, line := range configs.DestructiveRefusal("prune") {
+	// Only the flag is destructive, and the difference is the whole of it.
+	//
+	// Plain `prune` is `docker compose down`: containers and the network go,
+	// the volumes stay, the images stay, the project directory and its registry
+	// entry are not touched. `madock start` puts it back. That is `stop` with
+	// the containers removed, and guarding it would be both an obstacle and
+	// inconsistent — `stop` takes the same site down and nothing stands in
+	// front of it.
+	//
+	// `--with-volumes` is `down -v --rmi all`: the data volumes and the images.
+	// The database is gone and nothing brings it back, which is what the
+	// installation's answer is about.
+	if args.WithVolumes && !configs.AllowsDestructiveCommands() {
+		for _, line := range configs.DestructiveRefusal("prune --with-volumes") {
 			fmtc.ErrorLn(line)
 		}
 		os.Exit(1)

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -11,9 +11,16 @@
 
          It is a guard rail, not a security control: the file sits beside the
          binary and is writable by the same user. It stops a mistake, not a
-         person. The mistakes are real — `project:remove` ends with a recursive
-         delete of the working directory, and `prune` is `docker compose down`
-         for the current project rather than the tidy-up its name suggests.
+         person.
+
+         What it covers is what cannot be undone: `project:remove`, which ends
+         with a recursive delete of the working directory, and `prune` when it
+         is asked to take the volumes, which destroys the database with them.
+         Plain `prune` is `docker compose down` and is deliberately not covered,
+         because `start` puts that back.
+
+         (No double hyphen anywhere above: XML forbids one inside a comment, and
+         naming the flag here cost a test run to find that out.)
 
          true here, false in madock-pro, which is the edition that runs on
          servers. -->

--- a/src/helper/configs/destructive.go
+++ b/src/helper/configs/destructive.go
@@ -31,12 +31,18 @@ const DestructiveKey = "allow_destructive_commands"
 // same user, so anyone who can run the command can also edit the file first. It
 // stops a mistake, not a person.
 //
-// What it stops is worth stopping. `project:remove` ends with RemoveAll on the
-// working directory, and the release runbook records that running it in the
-// installation directory would have taken madock, its repository and every
-// other project's configuration with it. `prune` sounds like tidying and is
-// `docker compose down` for the current project — with --with-volumes, the data
-// volumes and the images too.
+// What it stops is only what cannot be undone. `project:remove` ends with
+// RemoveAll on the working directory, and the release runbook records that
+// running it in the installation directory would have taken madock, its
+// repository and every other project's configuration with it.
+// `prune --with-volumes` is `down -v --rmi all`: the data volumes and the
+// images, with nothing to bring the database back.
+//
+// Plain `prune` is deliberately not covered. It is `docker compose down` —
+// containers and the network, with the volumes, the images, the project
+// directory and its registry entry all untouched — so `start` puts it back.
+// Guarding it would obstruct without protecting, and inconsistently at that,
+// since `stop` takes the same site down unguarded.
 func AllowsDestructiveCommands() bool {
 	return !strings.EqualFold(strings.TrimSpace(destructiveSetting()), "false")
 }

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.6"
+const Version = "3.9.7"

--- a/test/e2e/destructive_test.go
+++ b/test/e2e/destructive_test.go
@@ -46,7 +46,7 @@ func TestDestructiveCommandsObeyTheInstallation(t *testing.T) {
 
 	for _, refused := range [][]string{
 		{"project:remove", "--force", "--name=e2eguarded"},
-		{"prune"},
+		{"prune", "--with-volumes"},
 	} {
 		out, err := p.tryRun(2*time.Minute, refused...)
 		if err == nil {
@@ -61,6 +61,15 @@ func TestDestructiveCommandsObeyTheInstallation(t *testing.T) {
 
 	if _, err := os.Stat(registry); err != nil {
 		t.Fatalf("the project was removed despite the refusal: %v", err)
+	}
+
+	// And the line the guard must not cross. Plain `prune` is `docker compose
+	// down`: containers and the network go, the volumes and images stay, the
+	// project directory and its registry entry are untouched, and `start` puts
+	// it back. Guarding it would be an obstacle rather than a guard — and an
+	// inconsistent one, since `stop` takes the same site down unguarded.
+	if out, err := p.tryRun(2*time.Minute, "prune"); err != nil {
+		t.Errorf("plain prune was refused; only --with-volumes destroys anything:\n%s", out)
 	}
 
 	// Now try to lift it, by every route a project has.


### PR DESCRIPTION
A correction on 3.9.6, which is one tag old and consumed by nothing.

`prune` is not destructive. It is `docker compose down` for the current project: containers and the network go, the volumes stay, the images stay, the project directory and its registry entry are untouched, and `madock start` puts it back. Guarding it obstructed without protecting anything — and inconsistently, since `stop` takes the same site down with nothing in front of it.

`prune --with-volumes` is the destructive half (`down -v --rmi all`): the data volumes and the images, with nothing to bring the database back. That is now all the guard covers here. `project:remove` is unchanged.

The e2e test asserts both directions — the flag refused, the bare command not.

Also: the config comment named the flags, and XML forbids a double hyphen inside a comment. The parser test caught it.