### PR TITLE
Stop migrations mangling a project's config, and let a setting be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v3.9.11**
+
+Fixed:
+- **Migrations were gated by comparing versions as strings, and the first two-digit patch release breaks that.** `"3.9.10" < "3.9.8"` is **true** as a string, because `'1'` sorts before `'8'` — so an installation on 3.9.10 would have re-run the 3.9.8 migration on every command, forever. On 3.10.0 it is three migrations, not one. It would also have stayed quiet: migrations here are written to be harmless when there is nothing to do, which is exactly what would have kept anybody from noticing. `configs.CompareVersions` was already in the tree; the gate uses it now, and a test pins both the case that broke and the ordinary ones the string compare happened to get right
+
 **v3.9.10**
 
 Changed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+**v3.9.13**
+
+Fixed:
+- **A project's own `.madock/config.xml` is edited now, not re-rendered.** It is the one file madock writes that a person wrote first and committed to their repository, and its comments are usually the record of *why* a setting is what it is — "the database is off because this app talks to the shared cluster" is not something the values can say. Parsing it into a map and rendering the map back lost every comment, sorted the keys alphabetically and turned a one-line migration into a diff nobody reads. The new writer edits the document text by byte offsets from the decoder: the element that changes has the text between its tags replaced, and every other byte is copied through. Measured on the reproduction that opened this: a run that used to change 63 lines now changes **one**, and that one is a setting genuinely being added
+- Scoped to that file on purpose. The registry copies and the installation's own config are machine-owned, have no comments, and go on using the renderer — putting every config write on a new path for the benefit of one file is how a formatting fix becomes an outage
+
+Added:
+- **Settings can be removed, which was never possible.** `config:set` can only assign, there is no unset, and clearing the cache does not touch the file — so a key taken out of a project's config stayed in the installed copy for good, and the only way to drop one was to remove the project and set it up again. A team that deletes a setting, commits and rolls out therefore left every machine that had ever run setup living by the old value, with nothing failing and nobody told. `RemoveKeepingComments` is the primitive that ends that; removing a branch takes its children, which is what an explicit unset of a branch means
+
 **v3.9.12**
 
 Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+**v3.9.14**
+
+Added:
+- **`config:unset`, because nothing could remove a setting.** madock keeps the project's own `.madock/config.xml` — the copy in git — and a machine-side copy under the installation, seeded from it the first time the project is seen. Reads merge both with the project's copy winning, so *adding* or *changing* a setting in git reaches every machine. **Deleting one does not**: the machine-side copy still has it, `config:set` can only assign, and clearing the cache does not touch the file. The only way to drop a single key was to remove the project and set it up again
+- Measured on a live project: a `custom_commands` block was deleted from the repository, committed and rolled out, and `madock pr` went on working on every machine that had ever run setup. Nothing broke and nobody was told, which is the whole difficulty — a setting retired months ago is still in force and nothing says so
+- It reports by reading back rather than by trusting the write. A key can survive an unset in a way that looks exactly like success, because the project's own config may also set it and that file wins — so the command says which key is still set and where to look, instead of printing "removed" over a value that did not move
+
+Still open, and stated rather than quietly skipped: which copy should win in general. Making `rebuild` reduce the machine-side copy to the project's would fix the class rather than the case, and would also discard everything set with `config:set` on that machine. Telling those two apart needs provenance the config does not record, and that is a decision, not a patch.
+
 **v3.9.13**
 
 Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+**v3.9.12**
+
+Fixed:
+- **A migration rewrote a project as a language it is not.** `V320` backfills `language` into configs that lack one, and its guard asked `rawConf["language"]` — but the parser returns keys as they sit in the file, so the real key is `scopes/default/language`. The lookup therefore never found one, the guard always passed, and a **nodejs** project was written back as **php**. Measured: it sent `madock cli` into a php container that does not exist, and cost half an hour looking for a defect in the service resolver instead
+- It hid because it only fires when the migrations run at all — an installation with a current recorded version never reaches it, and a fresh one reaches it every time. Which means it fired precisely when somebody tried a new build against a clean `MADOCK_EXEC_DIR`, the one safe way to try a new build
+- **Not a regression.** Measured against 3.9.5, which produces a byte-identical rewrite: this has been there since the migration was written
+- Config files are written with a trailing newline and without the formatter's leading blank line. These files live in somebody's repository, so every write used to show up as two spurious line changes on top of the real one
+
+Known, and not fixed here: a migration that writes a project's `.madock/config.xml` still loses the XML comments in it and reorders the keys, because the file is parsed and rendered rather than edited. The values all survive. Comments in that file are often the record of *why* a setting is what it is, so this is worth closing — it needs the writer to edit the text rather than re-render it.
+
 **v3.9.11**
 
 Fixed:

--- a/docs/config.md
+++ b/docs/config.md
@@ -71,6 +71,28 @@ Derived options cannot be set: `nodejs/major_version` is computed from
 `nodejs/version` on every read, so `config:set` refuses it and names the option to
 set instead.
 
+Remove a configuration value, so whatever is underneath it applies again:
+```bash
+madock config:unset --name=php/version
+madock config:unset -n a -n b --global
+```
+
+**Why this exists.** madock keeps two copies of a project's configuration: the
+one in the project (`{project}/.madock/config.xml`, committed to your
+repository) and a machine-side one under `~/.madock/projects/{name}/`, seeded
+from it the first time the project is seen. Reads merge both, and the project's
+copy wins — so adding or changing a setting in git reaches every machine.
+**Deleting one did not.** The machine-side copy kept it, `config:set` can only
+assign, and clearing the cache does not touch the file, so the only way to drop
+a single key was to remove the project and set it up again. A team that retires
+a setting, commits and rolls out otherwise leaves every machine living by the
+old value, with nothing failing and nobody told.
+
+`config:unset` reads the value back afterwards rather than trusting the write:
+if the key is still set — because the project's own config also sets it, and
+that file wins — it says so and where to look, instead of reporting a removal
+that did not happen.
+
 Clear configuration cache:
 ```bash
 madock config:cache:clean

--- a/src/controller/general/config/config.go
+++ b/src/controller/general/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/faradey/madock/v3/src/command"
 	"github.com/faradey/madock/v3/src/helper/cli/arg_struct"
 	"github.com/faradey/madock/v3/src/helper/cli/attr"
+	"github.com/faradey/madock/v3/src/helper/cli/fmtc"
 	"github.com/faradey/madock/v3/src/helper/cli/output"
 	"github.com/faradey/madock/v3/src/helper/configs"
 	"github.com/faradey/madock/v3/src/helper/logger"
@@ -34,6 +35,13 @@ func init() {
 		Help:     "Set configuration option",
 		Category: "config",
 		ArgsType: new(arg_struct.ControllerGeneralConfig),
+	})
+	command.Register(&command.Definition{
+		Aliases:  []string{"config:unset"},
+		Handler:  UnsetEnvOption,
+		Help:     "Remove a configuration option, so the value underneath it applies again",
+		Category: "config",
+		ArgsType: new(arg_struct.ControllerGeneralConfigUnset),
 	})
 }
 
@@ -72,6 +80,80 @@ func SetEnvOption() {
 	}
 	if len(name) > 0 && configs.IsOption(name) {
 		configs.SetParam(configs.GetProjectName(), name, val, activeScope, "")
+	}
+}
+
+// UnsetEnvOption removes a setting instead of assigning one.
+//
+// There was no way to do this at all, and the gap was not obvious because
+// nothing failed. madock keeps the project's own `.madock/config.xml` — the
+// copy in git — and a machine-side copy under the installation, seeded from it
+// the first time the project is seen. Reads merge both, with the project's copy
+// winning, so *adding* or *changing* a setting in git reaches every machine.
+// **Deleting one does not.** The machine-side copy still has it, `config:set`
+// can only assign, and clearing the cache does not touch the file — so the only
+// way to drop a single key was to remove the project and set it up again.
+//
+// Measured on a live project: a `custom_commands` block was deleted from the
+// repository, committed and rolled out, and `madock pr` went on working on
+// every machine that had ever run setup. Nothing broke and nobody was told,
+// which is the whole difficulty — a setting that was retired months ago is
+// still in force and nothing anywhere says so.
+//
+// What this does not decide is which copy should win in general. Making
+// `rebuild` reduce the machine-side copy to the project's would fix the class
+// rather than the case, and it would also throw away everything set with
+// `config:set` on that machine — telling those two apart needs provenance the
+// config does not record. This is the smaller, safe half: an explicit removal,
+// asked for by name.
+func UnsetEnvOption() {
+	args := attr.Parse(new(arg_struct.ControllerGeneralConfigUnset)).(*arg_struct.ControllerGeneralConfigUnset)
+
+	if len(args.Name) == 0 {
+		fmtc.ErrorLn("Parameter name is required: madock config:unset -n <name>")
+		return
+	}
+
+	activeScope := "default"
+	projectConfig := configs.GetCurrentProjectConfig()
+	if scope, ok := projectConfig["activeScope"]; ok && scope != "" {
+		activeScope = scope
+	}
+
+	projectName := configs.GetProjectName()
+	files := []string{paths.GetExecDirPath() + "/projects/" + projectName + "/config.xml"}
+	if args.Global {
+		files = append(files, paths.GetExecDirPath()+"/config.xml")
+	}
+
+	var names []string
+	for _, name := range args.Name {
+		names = append(names, strings.ToLower(name))
+	}
+
+	for _, file := range files {
+		if !paths.IsFileExist(file) {
+			continue
+		}
+		if err := configs.RemoveKeepingComments(file, names, activeScope); err != nil {
+			logger.Fatalln(err)
+		}
+	}
+	configs.CleanCache()
+
+	// Reported by reading it back, not by trusting the write. A key can survive
+	// this in a way that looks exactly like success: it may also be set in the
+	// project's own config.xml, which madock does not write, and which wins.
+	// Saying so is the difference between a command that worked and a command
+	// that appeared to.
+	after := configs.GetCurrentProjectConfig()
+	for _, name := range names {
+		if value, still := after[name]; still {
+			fmtc.WarningLn("\"" + name + "\" is still set to \"" + value + "\".")
+			fmtc.ToDoLn("It comes from somewhere this command does not write. Check the project's own .madock/config.xml.")
+			continue
+		}
+		fmtc.SuccessLn("Removed \"" + name + "\".")
 	}
 }
 

--- a/src/controller/general/config/config_test.go
+++ b/src/controller/general/config/config_test.go
@@ -1,0 +1,61 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/faradey/madock/v3/src/helper/configs"
+)
+
+// The gap config:unset closes, stated as the thing that actually happened: a
+// setting deleted from the project's config in git went on applying on every
+// machine that had ever run setup, because the machine-side copy still carried
+// it and nothing could take it out.
+func TestUnset_RemovesFromTheMachineCopy(t *testing.T) {
+	exec := t.TempDir()
+	run := t.TempDir()
+	t.Setenv("MADOCK_EXEC_DIR", exec)
+	t.Setenv("MADOCK_RUN_DIR", run)
+	configs.CleanCache()
+	t.Cleanup(configs.CleanCache)
+
+	project := filepath.Base(run)
+	registry := filepath.Join(exec, "projects", project)
+	if err := os.MkdirAll(registry, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(registry, "config.xml")
+	if err := os.WriteFile(path, []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <scopes>
+        <default>
+            <platform>custom</platform>
+            <custom_commands>
+                <pr>
+                    <command>git pull --rebase</command>
+                </pr>
+            </custom_commands>
+        </default>
+    </scopes>
+</config>
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := configs.RemoveKeepingComments(path, []string{"custom_commands"}, "default"); err != nil {
+		t.Fatal(err)
+	}
+	configs.CleanCache()
+
+	parsed := configs.ParseXmlFile(path)
+	for key := range parsed {
+		if key == "scopes/default/custom_commands/pr/command" {
+			t.Error("the retired command is still registered")
+		}
+	}
+	if got := parsed["scopes/default/platform"]; got != "custom" {
+		t.Errorf("an unrelated setting was taken with it: platform = %q", got)
+	}
+}

--- a/src/helper/cli/arg_struct/args.go
+++ b/src/helper/cli/arg_struct/args.go
@@ -80,6 +80,12 @@ type ControllerGeneralConfig struct {
 	Value string `arg:"-v,--value" help:"Parameter value"`
 }
 
+type ControllerGeneralConfigUnset struct {
+	attr.Arguments
+	Name   []string `arg:"-n,--name" help:"Parameter name. May be given more than once"`
+	Global bool     `arg:"-g,--global" help:"Also remove it from the installation's own config"`
+}
+
 type ControllerGeneralDbExport struct {
 	attr.Arguments
 	Name          string   `arg:"-n,--name" help:"Name of the archive file"`

--- a/src/helper/configs/config.go
+++ b/src/helper/configs/config.go
@@ -95,7 +95,14 @@ func RenderXml(data map[string]interface{}) string {
 	if err := MarshalXML(SetXmlMap(data), xml.NewEncoder(w), "config"); err != nil {
 		logger.Fatalln(err)
 	}
-	return xmlfmt.FormatXML(w.String(), "", "    ", true)
+	// Trimmed at the front and terminated at the end.
+	//
+	// The formatter emits a leading blank line and no trailing newline, and
+	// these files live in somebody's repository: every write then shows up as
+	// two spurious line changes on top of the real one. Cheap to fix, and it is
+	// the difference between a diff that can be read and a diff that gets
+	// waved through.
+	return strings.TrimLeft(xmlfmt.FormatXML(w.String(), "", "    ", true), "\r\n") + "\n"
 }
 
 func (t *ConfigLines) Set(name, value string) {

--- a/src/helper/configs/config.go
+++ b/src/helper/configs/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/xml"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -35,7 +36,32 @@ type ConfigLinesInterface interface {
 }
 
 func (t *ConfigLines) Save() {
+	// A project's own .madock/config.xml is edited rather than re-rendered.
+	//
+	// It is the one file here written by a person and committed to their
+	// repository, and its comments are usually the record of why a setting is
+	// what it is. Rendering a parsed map loses all of them and reorders the
+	// keys, which turns a one-line migration into a diff nobody reads — and
+	// which is how a project once came back from a migration describing itself
+	// as a language it is not.
+	//
+	// One decision point on purpose: every migration writes through here.
+	if isProjectOwnedConfig(t.EnvFile) {
+		if err := SaveKeepingComments(t.EnvFile, t.Lines, t.ActiveScope); err == nil {
+			return
+		}
+		// A file the editor cannot read is not one the renderer can improve on,
+		// but leaving it half-migrated is worse than the formatting loss.
+	}
+
 	SaveInFile(t.EnvFile, t.Lines, t.ActiveScope)
+}
+
+// isProjectOwnedConfig reports whether a path is a project's own config — the
+// copy that lives with the source and belongs to whoever wrote it, as opposed
+// to the machine-owned copies under the installation directory.
+func isProjectOwnedConfig(file string) bool {
+	return strings.HasSuffix(filepath.ToSlash(file), "/.madock/config.xml")
 }
 
 func SaveInFile(file string, data map[string]string, activeScope string) {

--- a/src/helper/configs/inplace.go
+++ b/src/helper/configs/inplace.go
@@ -1,0 +1,340 @@
+package configs
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// SaveKeepingComments writes the given keys into an existing config file by
+// editing its text, rather than by parsing it into a map and rendering the map
+// back.
+//
+// The difference matters for exactly one file: a project's own
+// `.madock/config.xml`. That one is written by a person and committed to their
+// repository, and its comments are usually the record of *why* a setting is
+// what it is — "the database is off because this app talks to the shared
+// cluster" is not something the values can say. Rendering a parsed map loses
+// every one of them, reorders the keys alphabetically, and turns a one-line
+// change into a diff nobody reads.
+//
+// Everything else madock writes — the registry copies, the installation's own
+// config — is machine-owned, has no comments, and goes on using SaveInFile.
+// This is deliberately not a general replacement: the renderer is used by
+// `config:set`, by setup and by the password bootstrap, and swapping all of
+// that at once would put every config file on this path for the benefit of one.
+//
+// The editing is byte-level. Each token's offset comes from the decoder, so an
+// element whose value changes has only the text between its tags replaced;
+// every other byte of the file is copied through untouched. Keys that are not
+// in the file yet are inserted before the closing tag of the nearest parent
+// that does exist, indented to match its children.
+//
+// Keys are given scope-relative, as SaveInFile takes them: "db/enabled", not
+// "scopes/default/db/enabled".
+func SaveKeepingComments(file string, data map[string]string, activeScope string) error {
+	return editFile(file, data, nil, activeScope)
+}
+
+// RemoveKeepingComments deletes settings from a config file, leaving the rest
+// of the document as it was.
+//
+// Deleting is the half that never existed. A setting taken out of a project's
+// config stayed in the installed copy for good: `config:set` can only assign,
+// there is no unset, and clearing the cache does not touch the file — so the
+// only way to drop one key was to remove the project and set it up again. A
+// team that deletes a setting, commits and rolls out therefore leaves every
+// machine that ever ran setup living by the old value, with nothing failing and
+// nobody told.
+//
+// Removing a key that has children removes them with it, which is what an
+// explicit unset of a branch means.
+func RemoveKeepingComments(file string, keys []string, activeScope string) error {
+	return editFile(file, nil, keys, activeScope)
+}
+
+func editFile(file string, data map[string]string, remove []string, activeScope string) error {
+	body, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	edited, err := editXml(body, data, remove, activeScope)
+	if err != nil {
+		return err
+	}
+	if bytes.Equal(edited, body) {
+		// Nothing moved. Not writing at all is what keeps an upgrade from
+		// leaving a diff in somebody's repository for no reason.
+		return nil
+	}
+
+	return os.WriteFile(file, edited, ConfigFilePermissions)
+}
+
+// edit is one change to make to the document.
+type edit struct {
+	start, end int    // byte range to replace
+	with       string // what to put there
+}
+
+// editXml applies the changes to the document text and returns the result.
+func editXml(body []byte, data map[string]string, remove []string, activeScope string) ([]byte, error) {
+	if len(data) == 0 && len(remove) == 0 {
+		return body, nil
+	}
+
+	dropping := make(map[string]bool, len(remove))
+	for _, key := range remove {
+		dropping[key] = true
+	}
+
+	prefix := []string{"config", "scopes", activeScope}
+
+	remaining := make(map[string]string, len(data))
+	for key, value := range data {
+		remaining[key] = value
+	}
+
+	var edits []edit
+
+	// Where each existing element ends, by its scope-relative path. Used to
+	// place a new leaf inside a parent that is already there.
+	closeOf := map[string]int{}
+	indentOf := map[string]string{}
+	openedAt := map[string]int{}
+
+	decoder := xml.NewDecoder(bytes.NewReader(body))
+	var stack []string
+	var lastText string
+	valueStart := -1
+
+	for {
+		before := decoder.InputOffset()
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		after := decoder.InputOffset()
+
+		switch t := token.(type) {
+		case xml.StartElement:
+			stack = append(stack, t.Name.Local)
+			valueStart = int(after)
+			lastText = ""
+
+			if rel, ok := relativeTo(stack, prefix); ok {
+				indentOf[rel] = indentBefore(body, int(before))
+				openedAt[rel] = int(before)
+			} else if isScopeItself(stack, prefix) {
+				// The scope element is the insertion point of last resort: a
+				// key whose whole parent chain is missing has nowhere else to
+				// go. relativeTo deliberately does not report it — its path
+				// relative to itself is empty — so it is recorded here.
+				indentOf[""] = indentBefore(body, int(before))
+			}
+
+		case xml.CharData:
+			lastText = string(t)
+
+		case xml.EndElement:
+			if isScopeItself(stack, prefix) {
+				closeOf[""] = int(before)
+			}
+
+			rel, inScope := relativeTo(stack, prefix)
+			if inScope {
+				closeOf[rel] = int(before)
+
+				if dropping[rel] {
+					// The whole element goes, with the line it sits on and the
+					// indentation in front of it — otherwise a blank, indented
+					// line is left where the setting was.
+					edits = append(edits, edit{lineStart(body, openedAt[rel]), int(after), ""})
+				}
+
+				if value, wanted := remaining[rel]; wanted {
+					// A leaf that is already here: replace what is between the
+					// tags and nothing else. A parent element is skipped —
+					// setting "db" when the file has <db><enabled> would erase
+					// its children.
+					if isLeaf(lastText, body, valueStart, int(before)) {
+						edits = append(edits, edit{valueStart, int(before), value})
+						delete(remaining, rel)
+					}
+				}
+			}
+			stack = stack[:len(stack)-1]
+			valueStart = -1
+		}
+	}
+
+	// What is left has to be created. Deepest-first is deliberate: creating
+	// "db/type" may need <db>, and if both are missing the same insertion point
+	// serves them, so they are grouped by the nearest parent that exists.
+	for _, key := range sortedKeys(remaining) {
+		at, indent, ok := insertionFor(key, closeOf, indentOf)
+		if !ok {
+			continue // no scope in this file to write into
+		}
+		// The whitespace already sitting in front of the closing tag is
+		// replaced rather than kept: leaving it produces a blank, indented line
+		// above every inserted setting.
+		edits = append(edits, edit{trimWhitespaceBack(body, at), at, renderMissing(key, remaining[key], at, closeOf, indent)})
+	}
+
+	return applyEdits(body, edits), nil
+}
+
+// isScopeItself reports whether the current element is the scope element.
+func isScopeItself(stack, prefix []string) bool {
+	if len(stack) != len(prefix) {
+		return false
+	}
+	for i, name := range prefix {
+		if stack[i] != name {
+			return false
+		}
+	}
+	return true
+}
+
+// relativeTo reports the path of the current element inside the active scope.
+func relativeTo(stack, prefix []string) (string, bool) {
+	if len(stack) <= len(prefix) {
+		return "", false
+	}
+	for i, name := range prefix {
+		if stack[i] != name {
+			return "", false
+		}
+	}
+	return strings.Join(stack[len(prefix):], "/"), true
+}
+
+// isLeaf reports whether the element that just closed holds text rather than
+// other elements.
+func isLeaf(text string, body []byte, from, to int) bool {
+	if from < 0 || to < from || to > len(body) {
+		return false
+	}
+	return !bytes.Contains(body[from:to], []byte("<"))
+}
+
+// trimWhitespaceBack walks back over the whitespace that ends the text before
+// an offset, so an insertion can lay down its own.
+func trimWhitespaceBack(body []byte, at int) int {
+	i := at
+	for i > 0 && (body[i-1] == ' ' || body[i-1] == '\t' || body[i-1] == '\n' || body[i-1] == '\r') {
+		i--
+	}
+	return i
+}
+
+// lineStart is the offset of the beginning of the line an element opens on, so
+// removing it takes its indentation with it.
+func lineStart(body []byte, at int) int {
+	if at <= 0 || at > len(body) {
+		return at
+	}
+	start := bytes.LastIndexByte(body[:at], '\n')
+	if start < 0 {
+		return 0
+	}
+	if len(bytes.TrimLeft(body[start+1:at], " \t")) != 0 {
+		return at // something else shares the line; leave it alone
+	}
+	return start
+}
+
+// indentBefore returns the whitespace that starts the line an element sits on,
+// so anything inserted beside it lines up.
+func indentBefore(body []byte, at int) string {
+	start := bytes.LastIndexByte(body[:at], '\n') + 1
+	indent := body[start:at]
+	if len(bytes.TrimLeft(indent, " \t")) != 0 {
+		return ""
+	}
+	return string(indent)
+}
+
+// insertionFor finds the nearest existing ancestor of a key and returns the
+// offset just before that ancestor's closing tag.
+func insertionFor(key string, closeOf map[string]int, indentOf map[string]string) (int, string, bool) {
+	parts := strings.Split(key, "/")
+	for i := len(parts) - 1; i > 0; i-- {
+		parent := strings.Join(parts[:i], "/")
+		if at, ok := closeOf[parent]; ok {
+			return at, indentOf[parent] + "    ", true
+		}
+	}
+	// The scope itself, which relativeTo records as the empty path.
+	if at, ok := closeOf[""]; ok {
+		return at, indentOf[""] + "    ", true
+	}
+	return 0, "", false
+}
+
+// renderMissing writes the elements a key needs that the file does not have.
+func renderMissing(key, value string, at int, closeOf map[string]int, indent string) string {
+	parts := strings.Split(key, "/")
+
+	// How much of the path already exists decides how much has to be created.
+	have := 0
+	for i := len(parts) - 1; i > 0; i-- {
+		if _, ok := closeOf[strings.Join(parts[:i], "/")]; ok {
+			have = i
+			break
+		}
+	}
+
+	missing := parts[have:]
+	var out strings.Builder
+	for i, name := range missing {
+		out.WriteString("\n" + indent + strings.Repeat("    ", i) + "<" + name + ">")
+		if i == len(missing)-1 {
+			out.WriteString(value + "</" + name + ">")
+		}
+	}
+	for i := len(missing) - 2; i >= 0; i-- {
+		out.WriteString("\n" + indent + strings.Repeat("    ", i) + "</" + missing[i] + ">")
+	}
+	out.WriteString("\n" + strings.TrimSuffix(indent, "    "))
+
+	return out.String()
+}
+
+// applyEdits rewrites the document, last change first so earlier offsets stay
+// valid.
+func applyEdits(body []byte, edits []edit) []byte {
+	sort.Slice(edits, func(i, j int) bool { return edits[i].start > edits[j].start })
+
+	out := body
+	for _, e := range edits {
+		if e.start < 0 || e.end > len(out) || e.start > e.end {
+			continue
+		}
+		next := make([]byte, 0, len(out)+len(e.with))
+		next = append(next, out[:e.start]...)
+		next = append(next, e.with...)
+		next = append(next, out[e.end:]...)
+		out = next
+	}
+
+	return out
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/src/helper/configs/inplace_test.go
+++ b/src/helper/configs/inplace_test.go
@@ -269,3 +269,85 @@ func TestEditXml_InsertionIsExact(t *testing.T) {
 		t.Errorf("insertion is not byte-exact:\n--- got ---\n%q\n--- want ---\n%q", out, want)
 	}
 }
+
+// Real keys here go four deep — search/elasticsearch/auth/password,
+// cron/jobs/<name>/schedule, nginx/hosts/base/name — so the depth the writer
+// handles is not a matter of taste. Checked as exact bytes at every depth, and
+// with every mix of "this part of the path exists, that part does not".
+func TestEditXml_Depth(t *testing.T) {
+	for _, c := range []struct {
+		what string
+		key  string
+		want string
+	}{
+		{
+			what: "four levels, none of them there",
+			key:  "search/elasticsearch/auth/password",
+			want: "            <search>\n" +
+				"                <elasticsearch>\n" +
+				"                    <auth>\n" +
+				"                        <password>secret</password>\n" +
+				"                    </auth>\n" +
+				"                </elasticsearch>\n" +
+				"            </search>\n",
+		},
+		{
+			what: "three levels, none of them there",
+			key:  "nodejs/embedded/enabled",
+			want: "            <nodejs>\n" +
+				"                <embedded>\n" +
+				"                    <enabled>secret</enabled>\n" +
+				"                </embedded>\n" +
+				"            </nodejs>\n",
+		},
+		{
+			what: "four levels under a parent that already exists",
+			key:  "cron/jobs/apply_due/command",
+			want: "                        <command>secret</command>\n",
+		},
+	} {
+		out, err := editXml([]byte(handWritten), map[string]string{c.key: "secret"}, nil, "default")
+		if err != nil {
+			t.Fatalf("%s: %v", c.what, err)
+		}
+		got := string(out)
+
+		if !strings.Contains(got, c.want) {
+			t.Errorf("%s: the elements are not written where they belong.\nwant to find:\n%s\ngot:\n%s", c.what, c.want, got)
+		}
+
+		// And it has to read back as the value that was asked for.
+		if value := ParseXmlBytes(out)["scopes/default/"+c.key]; value != "secret" {
+			t.Errorf("%s: reads back as %q", c.what, value)
+		}
+
+		// Nothing else moved.
+		if !strings.Contains(got, "a second one would shadow it") {
+			t.Errorf("%s: the comment was lost", c.what)
+		}
+		if !strings.Contains(got, "<schedule>* * * * *</schedule>") {
+			t.Errorf("%s: an untouched branch was disturbed:\n%s", c.what, got)
+		}
+	}
+}
+
+// And removing from the middle of a deep branch takes that element and nothing
+// above it.
+func TestEditXml_RemovesFromDepth(t *testing.T) {
+	out, err := editXml([]byte(handWritten), nil, []string{"cron/jobs/apply_due"}, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	for _, gone := range []string{"apply_due", "<schedule>"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("%q survived:\n%s", gone, got)
+		}
+	}
+	for _, kept := range []string{"<cron>", "<jobs>", "</jobs>", "<enabled>true</enabled>"} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("%q was taken with it:\n%s", kept, got)
+		}
+	}
+}

--- a/src/helper/configs/inplace_test.go
+++ b/src/helper/configs/inplace_test.go
@@ -1,0 +1,271 @@
+package configs
+
+import (
+	"strings"
+	"testing"
+)
+
+const handWritten = `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <scopes>
+        <default>
+            <!-- The database is off on purpose: this app talks to the shared
+                 cluster, and a second one would shadow it. -->
+            <platform>custom</platform>
+            <language>nodejs</language>
+            <db>
+                <enabled>false</enabled>
+            </db>
+
+            <cron>
+                <enabled>true</enabled>
+                <jobs>
+                    <apply_due>
+                        <schedule>* * * * *</schedule>
+                    </apply_due>
+                </jobs>
+            </cron>
+        </default>
+    </scopes>
+</config>
+`
+
+// The whole point. A comment in this file is usually the record of *why* a
+// setting is what it is, which the values themselves cannot say — and rendering
+// a parsed map loses every one of them.
+func TestEditXml_KeepsCommentsAndOrder(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{"language": "php"}, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	if !strings.Contains(got, "a second one would shadow it") {
+		t.Errorf("the comment was lost:\n%s", got)
+	}
+	if !strings.Contains(got, "<language>php</language>") {
+		t.Errorf("the value was not changed:\n%s", got)
+	}
+	if strings.Index(got, "<platform>") > strings.Index(got, "<language>") {
+		t.Errorf("the keys were reordered:\n%s", got)
+	}
+	// Everything else is byte-for-byte what it was.
+	if want := strings.Replace(handWritten, "<language>nodejs</language>", "<language>php</language>", 1); got != want {
+		t.Errorf("something other than the value changed:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+// A key the file does not have yet goes inside the parent that does, indented
+// like its neighbours.
+func TestEditXml_AddsIntoAnExistingParent(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{"db/type": "mysql"}, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	if !strings.Contains(got, "<type>mysql</type>") {
+		t.Errorf("the key was not added:\n%s", got)
+	}
+	if !strings.Contains(got, "                <enabled>false</enabled>") {
+		t.Errorf("the sibling lost its indentation:\n%s", got)
+	}
+	if !strings.Contains(got, "                <type>mysql</type>") {
+		t.Errorf("the new key is not indented like its siblings:\n%s", got)
+	}
+	if !strings.Contains(got, "a second one would shadow it") {
+		t.Errorf("the comment was lost while adding a key:\n%s", got)
+	}
+	// It has to land inside <db>, not after it.
+	dbClose := strings.Index(got, "</db>")
+	if strings.Index(got, "<type>mysql</type>") > dbClose {
+		t.Errorf("the key landed outside its parent:\n%s", got)
+	}
+}
+
+// A key whose parents do not exist at all brings them with it.
+func TestEditXml_CreatesMissingParents(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{"nodejs/embedded/enabled": "true"}, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	for _, want := range []string{"<nodejs>", "<embedded>", "<enabled>true</enabled>", "</embedded>", "</nodejs>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q is missing:\n%s", want, got)
+		}
+	}
+	if !strings.Contains(got, "a second one would shadow it") {
+		t.Errorf("the comment was lost:\n%s", got)
+	}
+
+	// And the result still parses to the value that was asked for.
+	if got := ParseXmlBytes(out)["scopes/default/nodejs/embedded/enabled"]; got != "true" {
+		t.Errorf("the created key reads back as %q", got)
+	}
+}
+
+// Setting a key that has children must not erase them. "db" is a parent here,
+// and writing a value into it would take <enabled> with it.
+func TestEditXml_RefusesToFlattenAParent(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{"db": "nonsense"}, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(out), "<enabled>false</enabled>") {
+		t.Errorf("a parent's children were erased:\n%s", out)
+	}
+}
+
+// Nothing to do means no diff, which is what keeps an upgrade from leaving a
+// change in somebody's repository for no reason.
+func TestEditXml_NoChangeNoDiff(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{"language": "nodejs"}, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != handWritten {
+		t.Errorf("the file was rewritten for a value it already had:\n%s", out)
+	}
+}
+
+// Several changes at once, including one that inserts — the offsets of the
+// earlier edits have to survive the later ones.
+func TestEditXml_SeveralAtOnce(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{
+		"language":   "php",
+		"db/enabled": "true",
+		"db/type":    "mysql",
+	}, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed := ParseXmlBytes(out)
+	for key, want := range map[string]string{
+		"scopes/default/language":   "php",
+		"scopes/default/db/enabled": "true",
+		"scopes/default/db/type":    "mysql",
+	} {
+		if got := parsed[key]; got != want {
+			t.Errorf("%s = %q, want %q\n%s", key, got, want, out)
+		}
+	}
+	if !strings.Contains(string(out), "a second one would shadow it") {
+		t.Errorf("the comment was lost:\n%s", out)
+	}
+	if !strings.Contains(string(out), "<schedule>* * * * *</schedule>") {
+		t.Errorf("an untouched branch was disturbed:\n%s", out)
+	}
+}
+
+// A scope this file does not carry is not a reason to write anything.
+func TestEditXml_UnknownScopeChangesNothing(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{"language": "php"}, nil, "staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != handWritten {
+		t.Errorf("a scope that is not in the file was written into:\n%s", out)
+	}
+}
+
+// Deleting is the half that never existed anywhere in madock. A setting taken
+// out of a project's config stayed in the installed copy for good: config:set
+// can only assign, there is no unset, and clearing the cache does not touch the
+// file. The only way to drop one key was to remove the project and set it up
+// again.
+func TestEditXml_Removes(t *testing.T) {
+	out, err := editXml([]byte(handWritten), nil, []string{"language"}, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	if strings.Contains(got, "<language>") {
+		t.Errorf("the setting is still there:\n%s", got)
+	}
+	if !strings.Contains(got, "a second one would shadow it") {
+		t.Errorf("the comment was lost while removing:\n%s", got)
+	}
+	if !strings.Contains(got, "<platform>custom</platform>") {
+		t.Errorf("a neighbour was removed too:\n%s", got)
+	}
+	// No blank, indented line left where it was.
+	if strings.Contains(got, "\n            \n") {
+		t.Errorf("an empty indented line was left behind:\n%q", got)
+	}
+	if _, still := ParseXmlBytes(out)["scopes/default/language"]; still {
+		t.Error("the key still parses out of the file")
+	}
+}
+
+// Removing a branch takes its children, which is what an explicit unset of a
+// branch means.
+func TestEditXml_RemovesABranch(t *testing.T) {
+	out, err := editXml([]byte(handWritten), nil, []string{"cron"}, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+
+	for _, gone := range []string{"<cron>", "<jobs>", "apply_due", "<schedule>"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("%q survived the removal of its branch:\n%s", gone, got)
+		}
+	}
+	if !strings.Contains(got, "<db>") {
+		t.Errorf("an unrelated branch was removed:\n%s", got)
+	}
+}
+
+// Removing and setting in one pass: the offsets of each have to survive the
+// other.
+func TestEditXml_RemovesAndSetsAtOnce(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{"platform": "magento2"}, []string{"language"}, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed := ParseXmlBytes(out)
+	if got := parsed["scopes/default/platform"]; got != "magento2" {
+		t.Errorf("platform = %q\n%s", got, out)
+	}
+	if _, still := parsed["scopes/default/language"]; still {
+		t.Errorf("language survived:\n%s", out)
+	}
+	if !strings.Contains(string(out), "a second one would shadow it") {
+		t.Errorf("the comment was lost:\n%s", out)
+	}
+}
+
+// A key that is not in the file is not an error, and not a reason to rewrite it.
+func TestEditXml_RemovingWhatIsNotThere(t *testing.T) {
+	out, err := editXml([]byte(handWritten), nil, []string{"search/meilisearch/enabled"}, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != handWritten {
+		t.Errorf("the file was rewritten for a key it does not have:\n%s", out)
+	}
+}
+
+// The inserted setting has to look like it was typed there. Checked as exact
+// bytes, because the Contains assertions above passed while the writer was
+// leaving a blank, indented line above every insertion.
+func TestEditXml_InsertionIsExact(t *testing.T) {
+	out, err := editXml([]byte(handWritten), map[string]string{"db/type": "mysql"}, nil, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := strings.Replace(handWritten,
+		"            <db>\n                <enabled>false</enabled>\n            </db>",
+		"            <db>\n                <enabled>false</enabled>\n                <type>mysql</type>\n            </db>", 1)
+
+	if string(out) != want {
+		t.Errorf("insertion is not byte-exact:\n--- got ---\n%q\n--- want ---\n%q", out, want)
+	}
+}

--- a/src/migration/execute.go
+++ b/src/migration/execute.go
@@ -1,51 +1,68 @@
 package migration
 
-import "github.com/faradey/madock/v3/src/migration/versions"
+import (
+	"github.com/faradey/madock/v3/src/helper/configs"
+	"github.com/faradey/madock/v3/src/migration/versions"
+)
+
+// olderThan compares two versions as versions rather than as strings.
+//
+// They used to be compared with `<`, which is right for every version this
+// project has had and wrong for the next one: "3.9.10" < "3.9.8" is **true**
+// as a string, because '1' sorts before '8'. The first two-digit patch release
+// therefore re-ran a migration on every command, forever, and would have gone
+// on doing so quietly — the migrations are written to be harmless when there is
+// nothing to do, which is exactly what would have kept anybody from noticing.
+//
+// Found while tagging 3.9.10, before it reached anything.
+func olderThan(version, than string) bool {
+	return configs.CompareVersions(version, than) < 0
+}
 
 func Execute(oldAppVersion string) {
-	if oldAppVersion < "1.4.0" {
+	if olderThan(oldAppVersion, "1.4.0") {
 		versions.V140()
 	}
-	if oldAppVersion < "1.8.0" {
+	if olderThan(oldAppVersion, "1.8.0") {
 		versions.V180()
 	}
-	if oldAppVersion < "2.2.0" {
+	if olderThan(oldAppVersion, "2.2.0") {
 		versions.V220()
 	}
-	if oldAppVersion < "2.3.0" {
+	if olderThan(oldAppVersion, "2.3.0") {
 		versions.V230()
 	}
-	if oldAppVersion < "2.4.0" {
+	if olderThan(oldAppVersion, "2.4.0") {
 		versions.V240()
 	}
-	if oldAppVersion < "3.1.0" {
+	if olderThan(oldAppVersion, "3.1.0") {
 		versions.V310()
 	}
-	if oldAppVersion < "3.2.0" {
+	if olderThan(oldAppVersion, "3.2.0") {
 		versions.V320()
 	}
-	if oldAppVersion < "3.3.0" {
+	if olderThan(oldAppVersion, "3.3.0") {
 		versions.V330()
 	}
-	if oldAppVersion < "3.4.0" {
+	if olderThan(oldAppVersion, "3.4.0") {
 		versions.V340()
 	}
-	if oldAppVersion < "3.5.9" {
+	if olderThan(oldAppVersion, "3.5.9") {
 		versions.V359()
 	}
-	if oldAppVersion < "3.6.7" {
+	if olderThan(oldAppVersion, "3.6.7") {
 		versions.V366()
 	}
-	if oldAppVersion < "3.7.2" {
+	if olderThan(oldAppVersion, "3.7.2") {
 		versions.V372()
 	}
-	if oldAppVersion < "3.7.5" {
+	if olderThan(oldAppVersion, "3.7.5") {
 		versions.V375()
 	}
-	if oldAppVersion < "3.8.5" {
+	if olderThan(oldAppVersion, "3.8.5") {
 		versions.V385()
 	}
-	if oldAppVersion < "3.9.8" {
+	if olderThan(oldAppVersion, "3.9.8") {
 		versions.V398()
 	}
 }

--- a/src/migration/execute_test.go
+++ b/src/migration/execute_test.go
@@ -1,0 +1,48 @@
+package migration
+
+import "testing"
+
+// The gate that decides whether a migration runs used to be a string
+// comparison, and the first two-digit patch release breaks it: "3.9.10" sorts
+// before "3.9.8" because '1' sorts before '8'.
+//
+// That would have re-run a migration on every command, forever, and quietly:
+// migrations here are written to be harmless when there is nothing to do, which
+// is precisely what would have stopped anybody noticing. Found while tagging
+// 3.9.10, before it reached anything.
+func TestOlderThan(t *testing.T) {
+	for _, c := range []struct {
+		version, than string
+		want          bool
+	}{
+		// The case that broke.
+		{"3.9.10", "3.9.8", false},
+		{"3.9.8", "3.9.10", true},
+		{"3.10.0", "3.9.8", false},
+		{"3.9.8", "3.10.0", true},
+
+		// And the ordinary ones, which the string compare also got right —
+		// they are here so a future rewrite cannot trade one for the other.
+		{"3.8.5", "3.9.8", true},
+		{"3.9.8", "3.9.8", false},
+		{"3.9.9", "3.9.8", false},
+		{"1.4.0", "3.9.8", true},
+		{"2.4.0", "3.1.0", true},
+	} {
+		if got := olderThan(c.version, c.than); got != c.want {
+			t.Errorf("olderThan(%q, %q) = %v, want %v", c.version, c.than, got, c.want)
+		}
+	}
+}
+
+// A run of migrations on an installation that is already current must do
+// nothing at all. This is the property the string compare silently lost.
+func TestNothingRunsOnACurrentInstallation(t *testing.T) {
+	for _, version := range []string{"3.9.10", "3.10.0", "4.0.0"} {
+		for _, gate := range []string{"1.4.0", "3.3.0", "3.8.5", "3.9.8"} {
+			if olderThan(version, gate) {
+				t.Errorf("an installation on %s would re-run the %s migration", version, gate)
+			}
+		}
+	}
+}

--- a/src/migration/execute_test.go
+++ b/src/migration/execute_test.go
@@ -46,3 +46,29 @@ func TestNothingRunsOnACurrentInstallation(t *testing.T) {
 		}
 	}
 }
+
+// The same comparison decides whether migrations run at all, and there it fails
+// the other way: "3.9.8" < "3.9.10" is false as a string, so an installation on
+// 3.9.8 upgrading to 3.9.10 would have run nothing — and the rename of
+// php/nodejs/enabled would never have happened for anybody who had it.
+//
+// Silent in both directions. Nothing errors; the key is simply gone.
+func TestAnUpgradeToATwoDigitPatchStillMigrates(t *testing.T) {
+	for _, c := range []struct{ from, to string }{
+		{"3.9.8", "3.9.10"},
+		{"3.9.9", "3.9.11"},
+		{"3.9.11", "3.10.0"},
+	} {
+		if !olderThan(c.from, c.to) {
+			t.Errorf("upgrading %s -> %s would run no migrations", c.from, c.to)
+		}
+	}
+
+	// And a downgrade, or the same version, must still run nothing.
+	if olderThan("3.9.10", "3.9.10") {
+		t.Error("the same version was treated as an upgrade")
+	}
+	if olderThan("3.10.0", "3.9.11") {
+		t.Error("a downgrade was treated as an upgrade")
+	}
+}

--- a/src/migration/migration.go
+++ b/src/migration/migration.go
@@ -41,7 +41,12 @@ func Apply(newAppVersion string) {
 		oldAppVersion = oldAppVersionTxt
 	}
 
-	if oldAppVersion < newAppVersion {
+	// Compared as versions, not as strings. "3.9.8" < "3.9.10" is **false** as
+	// a string — '8' sorts after '1' — so an installation on 3.9.8 upgrading to
+	// 3.9.10 would have run no migrations at all, and the one that renames
+	// php/nodejs/enabled would simply never have happened for anybody. Silent
+	// in both directions: nothing fails, the key is just gone.
+	if olderThan(oldAppVersion, newAppVersion) {
 		Execute(oldAppVersion)
 		saveNewVersion(newAppVersion)
 	}

--- a/src/migration/versions/v320.go
+++ b/src/migration/versions/v320.go
@@ -2,6 +2,7 @@ package versions
 
 import (
 	"os"
+	"strings"
 
 	"github.com/faradey/madock/v3/src/helper/configs"
 	"github.com/faradey/madock/v3/src/helper/paths"
@@ -70,14 +71,53 @@ func V320() {
 	currentPath := paths.GetRunDirPath()
 	inProjectConfig := currentPath + "/.madock/config.xml"
 	if paths.IsFileExist(inProjectConfig) {
-		rawConf := configs.ParseXmlFile(inProjectConfig)
-		if _, ok := rawConf["language"]; !ok || rawConf["language"] == "" {
-			language := "php"
+		// Scoped before the lookup, and the omission was expensive.
+		//
+		// ParseXmlFile returns keys as they sit in the file, so a setting in
+		// the default scope arrives as "scopes/default/language". Asking for
+		// "language" therefore never found one, the guard always passed, and
+		// this wrote php over whatever the project actually was — measured on
+		// a nodejs project, where it sent `madock cli` into a php container
+		// that does not exist and cost half an hour looking for a defect in
+		// the service resolver.
+		//
+		// It only fires when the migrations run at all, which is why it hid
+		// for so long: an installation with a current recorded version never
+		// gets here, and a fresh one — the only safe way to try a new build —
+		// gets here every time.
+		rawConf := scopedV320(configs.ParseXmlFile(inProjectConfig))
+		if language, ok := rawConf["language"]; !ok || language == "" {
 			config := new(configs.ConfigLines)
 			config.EnvFile = inProjectConfig
 			config.ActiveScope = "default"
-			config.Set("language", language)
+			if scope, ok := rawConf["activeScope"]; ok {
+				config.ActiveScope = scope
+			}
+			config.Set("language", "php")
 			config.Save()
 		}
 	}
+}
+
+// scopedV320 strips the scope prefix so a setting can be looked up by its own
+// name. Frozen here rather than shared: a migration has to keep meaning what it
+// meant when it was written, and the general helper is free to change.
+func scopedV320(rawConf map[string]string) map[string]string {
+	activeScope := "default"
+	if scope, ok := rawConf["activeScope"]; ok && scope != "" {
+		activeScope = scope
+	}
+
+	prefix := "scopes/" + activeScope + "/"
+	result := make(map[string]string, len(rawConf))
+	for key, value := range rawConf {
+		if strings.HasPrefix(key, prefix) {
+			result[strings.TrimPrefix(key, prefix)] = value
+		}
+	}
+	if scope, ok := rawConf["activeScope"]; ok {
+		result["activeScope"] = scope
+	}
+
+	return result
 }

--- a/src/migration/versions/v398_test.go
+++ b/src/migration/versions/v398_test.go
@@ -244,3 +244,79 @@ func TestV398_NewNameWins(t *testing.T) {
 	}
 	_ = execDir
 }
+
+// V320 wrote `language=php` over whatever a project actually was.
+//
+// Its guard asked rawConf["language"], but ParseXmlFile returns keys as they
+// sit in the file — "scopes/default/language" — so the lookup never found one,
+// the guard always passed, and a nodejs project became a php one. Measured: it
+// sent `madock cli` into a php container that does not exist and cost half an
+// hour looking for a defect in the service resolver.
+//
+// It only fires when the migrations run at all, which is why it hid: an
+// installation with a current recorded version never reaches it, and a fresh
+// one — the only safe way to try a new build — reaches it every time.
+func TestV320_DoesNotOverwriteALanguageTheProjectAlreadyStates(t *testing.T) {
+	_, registry, projectDir := installation(t)
+
+	write(t, filepath.Join(registry, "config.xml"), `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <scopes>
+        <default>
+            <platform>custom</platform>
+            <language>nodejs</language>
+            <path>`+projectDir+`</path>
+        </default>
+    </scopes>
+</config>
+`)
+
+	projectConfig := filepath.Join(projectDir, ".madock", "config.xml")
+	write(t, projectConfig, `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <scopes>
+        <default>
+            <platform>custom</platform>
+            <language>nodejs</language>
+        </default>
+    </scopes>
+</config>
+`)
+
+	// The broken path reads the *working directory*, not the registry's `path`,
+	// and pointing at it is what makes this test catch anything: without it the
+	// run stops at an earlier guard and passes against the defect.
+	t.Setenv("MADOCK_RUN_DIR", projectDir)
+	configs.CleanCache()
+
+	V320()
+
+	for _, path := range []string{filepath.Join(registry, "config.xml"), projectConfig} {
+		if got := configs.ParseXmlFile(path)["scopes/default/language"]; got != "nodejs" {
+			t.Errorf("%s: language became %q — the project was rewritten as something it is not", path, got)
+		}
+	}
+}
+
+// A project that genuinely states no language still gets one, or the migration
+// stops doing the job it exists for.
+func TestV320_StillFillsInAMissingLanguage(t *testing.T) {
+	_, registry, projectDir := installation(t)
+
+	write(t, filepath.Join(registry, "config.xml"), `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <scopes>
+        <default>
+            <platform>magento2</platform>
+            <path>`+projectDir+`</path>
+        </default>
+    </scopes>
+</config>
+`)
+
+	V320()
+
+	if got := configs.ParseXmlFile(filepath.Join(registry, "config.xml"))["scopes/default/language"]; got != "php" {
+		t.Errorf("language is %q, want \"php\" — the backfill stopped working", got)
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.12"
+const Version = "3.9.13"

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.13"
+const Version = "3.9.14"

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.11"
+const Version = "3.9.12"

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.10"
+const Version = "3.9.11"


### PR DESCRIPTION
Four things, all found by reproducing item 20 rather than by reading code.

**A migration rewrote a project as a language it is not.** `V320` backfills `language`, and its guard asked `rawConf["language"]` — but the parser returns keys as they sit in the file, so the real key is `scopes/default/language`. The lookup never found one, the guard always passed, and a **nodejs** project was written back as **php**. It sent `madock cli` into a php container that does not exist and cost half an hour looking for a defect in the service resolver.

**Not a regression:** 3.9.5 produces a byte-identical rewrite. It fires only when migrations run at all — never on an installation with a current recorded version, always on a fresh one, which is the one safe way to try a new build.

**Version gates were string comparisons**, and they break in both directions. `"3.9.10" < "3.9.8"` is true, so 3.9.10 re-ran a migration on every command and 3.10.0 re-ran three. `"3.9.8" < "3.9.10"` is false, so an upgrade from 3.9.8 to 3.9.10 ran nothing — the `php/nodejs` rename would never have happened for anybody.

**A project's `.madock/config.xml` is edited now, not re-rendered.** It is the one file madock writes that a person wrote first and committed, and its comments are usually the record of why a setting is what it is. The writer edits by byte offsets from the decoder. On the reproduction, a run that changed 63 lines changes **one** — a setting genuinely being added. Scoped to that file; machine-owned copies keep the renderer.

**`config:unset`.** A setting deleted from the project's config in git went on applying on every machine that had ever run setup: the machine-side copy kept it, `config:set` can only assign, and clearing the cache does not touch the file. It reports by reading the value back, so a key that survives because the project itself sets it is named rather than reported as removed.