### PR TITLE
Extraction removes what a release withdrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v3.9.15**
+
+Fixed:
+- **Extraction removes what a release withdrew.** It only ever added and overwrote, so a template dropped from the shipped set stayed on the machine for good. Measured on a live server: twelve `docker-compose.{darwin,linux,windows}.yml` files that neither madock nor madock-pro ships, and `snippets/dockerfile/php/nodejs` still carrying the `.php.nodejs.enabled` syntax removed in 3.9.8. Harmless there by accident — the first are empty, and nothing includes the second any more
+- Worth fixing before that accident runs out: the resolver reaches `{execDir}/docker/{platform}/docker-compose.<GOOS>.yml` and applies what it finds as `docker-compose.override.yml`, so a non-empty template withdrawn in a release would go on applying on upgraded machines and not on fresh ones — **at the same version**. The result would depend on the history of an installation rather than on what it says it is
+- **Only files this mechanism itself wrote are removed**, from a manifest it keeps, never from a walk of the directory. madock-pro extracts its own platform templates into the same tree, and a sweep of everything-not-in-the-embed would delete them. An installation with no manifest yet — every installation before this version — has nothing removed, so orphans predating it need one clean by hand
+- **The error a template raises when the binary is older than it now says so.** `function "memShareGB" not defined` reads as a broken template and sends somebody to edit a file that is correct: template functions are compiled into the binary while templates are files on disk. The message keeps the engine's own words and adds the cause and the cure. Measured on this machine, where the radius is every project at once, because the installation directory and the source checkout are the same directory
+
 **v3.9.14**
 
 Added:

--- a/src/helper/configs/aruntime/project/render.go
+++ b/src/helper/configs/aruntime/project/render.go
@@ -41,10 +41,36 @@ func Render(projectName, file, name string, extra map[string]string) string {
 
 	out, err := newRenderer(projectName, file, extra).Render(name, string(body))
 	if err != nil {
-		logger.Fatal(fmt.Errorf("rendering %s for project %s: %w", name, projectName, err))
+		logger.Fatal(fmt.Errorf("rendering %s for project %s: %w%s", name, projectName, err, adviceFor(err)))
 	}
 
 	return out
+}
+
+// adviceFor names the cause and the cure when the error is one whose message
+// points at the wrong thing.
+//
+// `function "memShareGB" not defined` reads as a broken template and sends
+// somebody to edit a file that is correct. It is not: template functions are
+// compiled into the binary while the templates are files on disk, so the
+// message means the installed binary is older than the tree it is rendering.
+// Measured on this machine — the function arrived in the templates at 16:13 and
+// the binary in use had been built at 13:44 the same day — and the radius there
+// is every project at once, because the installation directory and the source
+// checkout are the same directory: `docker/` moves with git and the binary does
+// not.
+//
+// Written as a suffix rather than folded into the error so the original text
+// survives verbatim; the point is to add what is missing, not to paraphrase
+// what the engine said.
+func adviceFor(err error) string {
+	if err == nil || !strings.Contains(err.Error(), "not defined") {
+		return ""
+	}
+
+	return "\n\nThe function is compiled into madock, the template is a file on disk," +
+		"\nso this means the binary in use is older than the templates it is rendering." +
+		"\nRebuild or reinstall madock; the template needs no editing."
 }
 
 // RenderTo renders a located template and writes the result where the

--- a/src/helper/configs/aruntime/project/render_test.go
+++ b/src/helper/configs/aruntime/project/render_test.go
@@ -1,0 +1,36 @@
+package project
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// `function "memShareGB" not defined` reads as a broken template and sends
+// somebody to edit a file that is correct. Template functions are compiled into
+// the binary while templates are files on disk, so it means the binary is older
+// than the tree it renders — which the message never said, on a machine where
+// the radius is every project at once.
+func TestAdviceFor(t *testing.T) {
+	advice := adviceFor(errors.New(`template: x.yml:3: function "memShareGB" not defined`))
+	if advice == "" {
+		t.Fatal("the one error whose message points at the wrong file gets no advice")
+	}
+	for _, want := range []string{"older than the templates", "Rebuild", "needs no editing"} {
+		if !strings.Contains(advice, want) {
+			t.Errorf("the advice does not mention %q:\n%s", want, advice)
+		}
+	}
+
+	// Everything else is left to speak for itself, or the suffix becomes noise
+	// attached to errors it does not explain.
+	for _, other := range []error{
+		nil,
+		errors.New("template: x.yml:3: unexpected EOF"),
+		errors.New("open /nope: no such file or directory"),
+	} {
+		if got := adviceFor(other); got != "" {
+			t.Errorf("advice was attached to an unrelated error (%v):\n%s", other, got)
+		}
+	}
+}

--- a/src/helper/embedded/extract.go
+++ b/src/helper/embedded/extract.go
@@ -4,6 +4,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/faradey/madock/v3/src/helper/paths"
 )
@@ -46,14 +48,76 @@ func ExtractIfNeeded(appVersion string) {
 		return
 	}
 
+	written := map[string]bool{}
 	if DockerFS != nil {
-		extractFS(DockerFS, filepath.Join(execDir, "docker"))
+		extractFS(DockerFS, filepath.Join(execDir, "docker"), written)
 	}
 	if ScriptsFS != nil {
-		extractFS(ScriptsFS, filepath.Join(execDir, "scripts"))
+		extractFS(ScriptsFS, filepath.Join(execDir, "scripts"), written)
 	}
 
+	removeWithdrawn(execDir, written)
+	writeManifest(execDir, written)
+
 	os.WriteFile(markerFile, []byte(appVersion), 0644)
+}
+
+// manifestFile lists what the last extraction put on disk.
+const manifestFile = ".embedded_files"
+
+// removeWithdrawn deletes files a previous extraction wrote and this one did
+// not — the ones a release withdrew.
+//
+// Extraction only ever added and overwrote, so a template dropped from the
+// shipped set stayed on the machine for good. Measured on extmag: twelve
+// `docker-compose.{darwin,linux,windows}.yml` files that neither madock 3.9.14
+// nor madock-pro ships, and `snippets/dockerfile/php/nodejs` still carrying the
+// `.php.nodejs.enabled` syntax that 3.9.8 removed. Harmless there only by
+// accident — the first is empty and nothing includes the second any more.
+//
+// What makes it worth fixing before it stops being harmless: the resolver
+// reaches `{execDir}/docker/{platform}/docker-compose.<GOOS>.yml` and applies
+// what it finds as `docker-compose.override.yml`. A non-empty template withdrawn
+// in a release would therefore go on applying on upgraded machines and not on
+// fresh ones — at the same version. The result would depend on the history of
+// the installation rather than on what it says it is.
+//
+// **Only files this mechanism itself wrote are removed.** The list comes from
+// the manifest of the previous run, never from a walk of the directory:
+// madock-pro extracts its own platform templates into the same tree, and a
+// sweep of everything-not-in-the-embed would delete them. An installation with
+// no manifest yet — every installation before this version — has nothing
+// removed, so orphans predating it need one clean by hand.
+func removeWithdrawn(execDir string, written map[string]bool) {
+	body, err := os.ReadFile(filepath.Join(execDir, manifestFile))
+	if err != nil {
+		return
+	}
+
+	for _, previous := range strings.Split(string(body), "\n") {
+		previous = strings.TrimSpace(previous)
+		if previous == "" || written[previous] {
+			continue
+		}
+		// Relative paths only, and nothing that climbs out of the tree: the
+		// manifest is a file on disk and this deletes what it names.
+		if filepath.IsAbs(previous) || strings.Contains(previous, "..") {
+			continue
+		}
+		os.Remove(filepath.Join(execDir, previous))
+	}
+}
+
+// writeManifest records what this extraction wrote, so the next one can tell a
+// withdrawn file from somebody else's.
+func writeManifest(execDir string, written map[string]bool) {
+	paths := make([]string, 0, len(written))
+	for path := range written {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	os.WriteFile(filepath.Join(execDir, manifestFile), []byte(strings.Join(paths, "\n")+"\n"), 0644)
 }
 
 // sourceSentinel is the file that says the docker tree in this directory is
@@ -87,7 +151,7 @@ func isSourceCheckout(execDir string) bool {
 	return err == nil
 }
 
-func extractFS(fsys fs.FS, destDir string) {
+func extractFS(fsys fs.FS, destDir string, written map[string]bool) {
 	fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || path == "." {
 			return err
@@ -101,6 +165,9 @@ func extractFS(fsys fs.FS, destDir string) {
 			return err
 		}
 		os.MkdirAll(filepath.Dir(target), 0755)
+		if rel, relErr := filepath.Rel(paths.GetExecDirPath(), target); relErr == nil {
+			written[filepath.ToSlash(rel)] = true
+		}
 		return os.WriteFile(target, data, 0755)
 	})
 }

--- a/src/helper/embedded/withdrawn_test.go
+++ b/src/helper/embedded/withdrawn_test.go
@@ -1,0 +1,115 @@
+package embedded
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// Extraction only ever added and overwrote, so a template a release withdrew
+// stayed on the machine for good — and the resolver goes on applying it. The
+// result then depends on the history of the installation rather than on the
+// version it reports.
+func TestRemoveWithdrawn(t *testing.T) {
+	dir := t.TempDir()
+
+	write(t, filepath.Join(dir, manifestFile), "docker/a.yml\ndocker/gone.yml\n")
+	write(t, filepath.Join(dir, "docker", "a.yml"), "kept")
+	write(t, filepath.Join(dir, "docker", "gone.yml"), "withdrawn")
+
+	removeWithdrawn(dir, map[string]bool{"docker/a.yml": true})
+
+	if !exists(filepath.Join(dir, "docker", "a.yml")) {
+		t.Error("a file this extraction wrote was removed")
+	}
+	if exists(filepath.Join(dir, "docker", "gone.yml")) {
+		t.Error("a withdrawn file survived")
+	}
+}
+
+// The rule that makes this safe: only files this mechanism itself wrote are
+// removed, and it knows which those are from its own manifest. madock-pro
+// extracts its own platform templates into the same tree, so a sweep of
+// everything-not-in-the-embed would delete them.
+func TestRemoveWithdrawn_LeavesForeignFilesAlone(t *testing.T) {
+	dir := t.TempDir()
+
+	write(t, filepath.Join(dir, manifestFile), "docker/a.yml\n")
+	write(t, filepath.Join(dir, "docker", "a.yml"), "ours")
+	write(t, filepath.Join(dir, "docker", "packeton", "docker-compose.yml"), "pro's")
+	write(t, filepath.Join(dir, "docker", "notes.txt"), "somebody's")
+
+	removeWithdrawn(dir, map[string]bool{})
+
+	for _, keep := range []string{
+		filepath.Join(dir, "docker", "packeton", "docker-compose.yml"),
+		filepath.Join(dir, "docker", "notes.txt"),
+	} {
+		if !exists(keep) {
+			t.Errorf("a file this mechanism never wrote was removed: %s", keep)
+		}
+	}
+	if exists(filepath.Join(dir, "docker", "a.yml")) {
+		t.Error("a file in the manifest and not in this extraction survived")
+	}
+}
+
+// An installation that has never written a manifest — every installation before
+// this version — has nothing removed. Orphans predating it need one clean by
+// hand, which is stated rather than guessed at.
+func TestRemoveWithdrawn_NoManifestRemovesNothing(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "docker", "orphan.yml"), "from before")
+
+	removeWithdrawn(dir, map[string]bool{})
+
+	if !exists(filepath.Join(dir, "docker", "orphan.yml")) {
+		t.Error("a file was removed on an installation with no manifest")
+	}
+}
+
+// The manifest is a file on disk and this deletes what it names, so a path that
+// climbs out of the tree is refused.
+func TestRemoveWithdrawn_RefusesToClimbOut(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "outside.txt")
+	write(t, outside, "not ours")
+
+	inner := filepath.Join(dir, "install")
+	write(t, filepath.Join(inner, manifestFile), "../outside.txt\n/etc/passwd\n")
+
+	removeWithdrawn(inner, map[string]bool{})
+
+	if !exists(outside) {
+		t.Error("a relative path climbed out of the installation and deleted a file")
+	}
+}
+
+// And the manifest round-trips, or the next run removes everything it wrote.
+func TestWriteManifest(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(dir, map[string]bool{"docker/b.yml": true, "docker/a.yml": true})
+
+	body, err := os.ReadFile(filepath.Join(dir, manifestFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "docker/a.yml\ndocker/b.yml\n" {
+		t.Errorf("manifest is %q", body)
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.14"
+const Version = "3.9.15"


### PR DESCRIPTION
Extraction only ever added and overwrote, so a template dropped from the shipped set stayed on the machine for good. Measured on a live server: per-OS `docker-compose.{darwin,linux,windows}.yml` files across a dozen platform directories that nothing ships — all zero bytes, dated June — and `snippets/dockerfile/php/nodejs` still carrying the syntax 3.9.8 removed.

Harmless there **by accident**: the first are empty, and nothing includes the second any more.

Worth fixing before the accident runs out. The resolver applies `{execDir}/docker/{platform}/docker-compose.<GOOS>.yml` as `docker-compose.override.yml`, so a non-empty template withdrawn in a release would go on applying on upgraded machines and not on fresh ones — **at the same version**. The result would depend on the history of an installation rather than on what it says it is.

**Only files this mechanism itself wrote are removed**, from a manifest it keeps, never from a walk of the directory: madock-pro extracts its own platform templates into the same tree and a sweep would delete them. An installation with no manifest has nothing removed, so orphans predating this need one clean by hand — three tests cover exactly those boundaries, including a manifest path that tries to climb out of the installation.

Separately: the render error now names its cause. A template function is compiled into the binary while the template is a file on disk, so `function "memShareGB" not defined` means the binary is older than the tree — not that the template is wrong, which is where the message sent people. Measured: the function reached the templates at 16:13 and the binary in use was built at 13:44 the same day.

Also corrected while reproducing: `start` and `setup` do **not** exit 0 on a render failure — both exit 1. `status` exits 0, which is a different question.