### PR TITLE
Derive where the application lives instead of storing it (3.9.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v3.9.19**
+
+Fixed:
+- **Where the application lives is derived now, not stored.** With deployer managing releases the root is `<mount>/current`, and that was a value written into the config once, by `deploy:enable` — a copy of a derivation, kept in one file. It is computed on every read instead, in the same place `nodejs/major_version` and `db/type` are computed, so no caller has to remember and none can read a stale one
+- **Three failures in one day, 2026-08-19, all the same shape**: a cron job with the path spelled out, correct until the project moved to deployer; a systemd unit on the host naming `current/artisan`, pointing at a deploy root that has no artisan in it; and a deploy that failed after the pre-rebuild, which removes the file the copy lived in — the rebuild in that window read an older config and installed a scheduler that ran the wrong command for seventeen minutes on a live application. Derived, the answer survives that file being absent, which is exactly the window that broke
+- Idempotent, so an installation that already stored `/var/www/html/current` reads back unchanged, and a custom root keeps its shape: `/var/www/html/storefront` becomes `/var/www/html/storefront/current`. `php/workdir` follows when it is set and is not invented when it is not
+- **`snapshot:restore` and `project:clone` refuse on a deployer-managed project.** Both write a file tree into `/var/www/html` after `rm -rf`. On an ordinary project that path is the application and the mount at once, which is why the literal was never wrong; here the mount holds `releases/`, `shared/`, `current` and deployer's state, so the same line would delete every release **and `shared/`** — where the environment file lives, and which no snapshot contains. The database half of a restore would have worked, which is worse: it would have done the safe part first. They stop and name what to do instead — a deploy, `deploy:rollback`, or `db:import` for the database alone
+
 **v3.9.18**
 
 Added:

--- a/src/controller/general/project/clone/clone.go
+++ b/src/controller/general/project/clone/clone.go
@@ -54,8 +54,33 @@ func Execute() {
 			return
 		}
 	}
-	fmt.Println("Cloning the project")
 	projectConf := configs.GetCurrentProjectConfig()
+
+	// A deployer-managed project is not something a file copy can reproduce.
+	//
+	// Cloning copies the source tree and untars it into the clone with
+	// `rm -rf /var/www/html/*` first. Under deployer that tree is not the
+	// application: it is `releases/` — every release still on disk — plus
+	// `shared/`, `current` and deployer's own state. The copy would carry all of
+	// it, the clone would inherit `deploy/enabled` pointing at the original's
+	// deploy path, and the result is a project that looks cloned and is a
+	// hybrid of two.
+	//
+	// The same shape as the other refusal in snapshot:restore, and for the same
+	// reason: `/var/www/html` means the application and the mount at once on an
+	// ordinary project, and two different things here.
+	if configs.IsDeployManaged(projectConf) {
+		fmtc.WarningLn("project:clone is refused on a project managed by deployer.")
+		fmt.Println("  Its source tree is releases/, shared/ and current — the deploy layout, not the")
+		fmt.Println("  application. Copying it would produce a project pointing at the original's")
+		fmt.Println("  deploy path, with every old release along for the ride.")
+		fmt.Println("")
+		fmt.Println("  Set up the second environment from the repository instead: create the project,")
+		fmt.Println("  `madock deploy:enable`, and deploy the branch you want into it.")
+		return
+	}
+
+	fmt.Println("Cloning the project")
 	exPath := paths.GetExecDirPath()
 	projectName := configs.GetProjectName()
 	currentDest := paths.MakeDirsByPath(exPath + "/projects/" + projectName + "/")

--- a/src/controller/general/snapshot/restore/restore.go
+++ b/src/controller/general/snapshot/restore/restore.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 
 	"github.com/faradey/madock/v3/src/command"
-	"github.com/faradey/madock/v3/src/helper/cli/attr"
 	"github.com/faradey/madock/v3/src/controller/general/rebuild"
+	"github.com/faradey/madock/v3/src/helper/cli/attr"
+	"github.com/faradey/madock/v3/src/helper/cli/fmtc"
 	"github.com/faradey/madock/v3/src/helper/configs"
 	"github.com/faradey/madock/v3/src/helper/docker"
 	"github.com/faradey/madock/v3/src/helper/logger"
@@ -124,6 +125,30 @@ func Execute() {
 }
 
 func RestoreSnapshot(projectName string, projectConf map[string]string, selectedInt int, snapshotNames []string, dbsPath string) {
+	// Refused where deployer owns the source tree, because the file half of a
+	// restore is `rm -rf /var/www/html/*` followed by an untar.
+	//
+	// On an ordinary project that path is the application and the mount at the
+	// same time, which is why the literal was never wrong. Under deployer the
+	// mount holds `releases/`, `shared/`, `current` and deployer's bookkeeping —
+	// so the same line deletes every release **and `shared/`**, which is where
+	// the environment file and, on some projects, the madock config live. None
+	// of that is in the snapshot: it was taken from a tree of a different shape.
+	//
+	// The database half would be fine. The file half is unrecoverable, so the
+	// command stops rather than doing the safe part and then the ruinous one.
+	if configs.IsDeployManaged(projectConf) {
+		fmtc.WarningLn("snapshot:restore is refused on a project managed by deployer.")
+		fmt.Println("  Restoring files here would run `rm -rf` over the deploy root — releases, shared/")
+		fmt.Println("  and the deploy state — and untar a tree of a different shape in their place.")
+		fmt.Println("  shared/ holds the environment file, and the snapshot does not contain it.")
+		fmt.Println("")
+		fmt.Println("  Put the application back with a deploy instead: `madock deploy <stage>`, or")
+		fmt.Println("  `madock deploy:rollback <stage>` for the release that was serving before.")
+		fmt.Println("  For the database alone, `madock db:import` takes the dump from the snapshot.")
+		return
+	}
+
 	containerName := docker.GetContainerName(projectConf, projectName, "snapshot")
 	docker.Down(projectName, false)
 	docker.UpSnapshot(projectName)

--- a/src/helper/configs/derived.go
+++ b/src/helper/configs/derived.go
@@ -92,6 +92,34 @@ func applyDerived(conf map[string]string) {
 		delete(conf, "nodejs/major_version")
 	}
 
+	// Where the application lives is answered here, once, rather than stored.
+	//
+	// With deployer managing releases the root is `<mount>/current`, and until
+	// now that was a value `deploy:enable` wrote into the config — a copy of a
+	// derivation, made at one moment, kept in one file. Every failure this
+	// caused was the same failure: something read a copy that was stale,
+	// missing, or written out by hand.
+	//
+	// **Three of them in one day, 2026-08-19.** A cron job with the path spelled
+	// out, correct until the project moved to deployer. A systemd unit on the
+	// host naming `current/artisan`, which pointed at a deploy root with no
+	// artisan in it. And a failed deploy that removed the config file holding
+	// the copy, so a rebuild read an older one and installed a scheduler that
+	// ran the wrong command for seventeen minutes on a live application.
+	//
+	// Derived, none of those are possible: there is no copy to go stale, and
+	// the answer survives the file that used to hold it being absent — which is
+	// exactly the window that broke. A consumer asks `workdir` and gets the
+	// truth whether or not deployer is configured, which is the whole point.
+	if strings.TrimSpace(conf["deploy/enabled"]) == "true" {
+		conf["workdir"] = deployRelativeRoot(conf["workdir"])
+		// Only when set: an unset php/workdir means the php container follows
+		// workdir, and inventing one here would fix it in place.
+		if php := strings.TrimSpace(conf["php/workdir"]); php != "" {
+			conf["php/workdir"] = deployRelativeRoot(php)
+		}
+	}
+
 	// msmtp will not send without an envelope sender, and there is no msmtprc in
 	// the image to hold a default. A mail transport supplies one; a bare mail()
 	// call with four arguments does not, and fails with exit 78. Rendering the
@@ -103,4 +131,43 @@ func applyDerived(conf map[string]string) {
 	} else {
 		conf["php/sendmail/from_argument"] = ""
 	}
+}
+
+// deployRelativeRoot puts the active release between the mount point and the
+// application, and says the same thing twice without saying it twice.
+//
+// Idempotent on purpose. Installations that ran `deploy:enable` before this was
+// derived have `/var/www/html/current` sitting in their config, and every read
+// of it must produce the same path rather than `current/current`. The same
+// property makes the derivation safe to apply to a value a person set by hand.
+func deployRelativeRoot(base string) string {
+	base = strings.TrimRight(strings.TrimSpace(base), "/")
+	if base == "" {
+		base = defaultWorkdir
+	}
+	if strings.HasSuffix(base, "/"+deployReleaseLink) {
+		return base
+	}
+	return base + "/" + deployReleaseLink
+}
+
+const (
+	// defaultWorkdir is where a project lives when nothing says otherwise. The
+	// same literal used to be repeated in a dozen fallbacks.
+	defaultWorkdir = "/var/www/html"
+	// deployReleaseLink is deployer's symlink to the release now serving.
+	deployReleaseLink = "current"
+)
+
+// IsDeployManaged reports whether a project's source tree belongs to deployer.
+//
+// It is the question to ask before writing anything into that tree wholesale.
+// On an ordinary project the mount point and the application are the same
+// directory, so `/var/www/html` means both and no caller ever had to choose.
+// Under deployer they are not: the mount holds `releases/`, `shared/`,
+// `current` and deployer's own bookkeeping, and the application is one level
+// down. Code that keeps meaning "the application" while writing to "the mount"
+// is the shape that produced three separate failures on 2026-08-19.
+func IsDeployManaged(conf map[string]string) bool {
+	return strings.TrimSpace(conf["deploy/enabled"]) == "true"
 }

--- a/src/helper/configs/workdir_derived_test.go
+++ b/src/helper/configs/workdir_derived_test.go
@@ -1,0 +1,101 @@
+package configs
+
+import "testing"
+
+// Where the application lives is derived, not stored, and this is the property
+// that matters: the answer is right even when the file that used to hold it is
+// not there.
+//
+// That window is not hypothetical. The pre-deploy rebuild stages the incoming
+// `.madock` and, on every project whose config.xml is untracked, that tree has
+// no config — so the project copy is gone while a rebuild reads it. Measured on
+// 2026-08-19: a scheduler ran the wrong command for seventeen minutes on a live
+// application because a stored copy showed through in that gap.
+func TestWorkdirFollowsDeployWithNothingStored(t *testing.T) {
+	conf := map[string]string{"deploy/enabled": "true"}
+
+	applyDerived(conf)
+
+	if got := conf["workdir"]; got != "/var/www/html/current" {
+		t.Errorf("workdir = %q, want /var/www/html/current", got)
+	}
+}
+
+// Without deployer the answer is the plain root, and a consumer that asks does
+// not have to know which kind of project it is looking at.
+func TestWorkdirWithoutDeployIsLeftAlone(t *testing.T) {
+	conf := map[string]string{"workdir": "/var/www/html"}
+
+	applyDerived(conf)
+
+	if got := conf["workdir"]; got != "/var/www/html" {
+		t.Errorf("workdir = %q, want /var/www/html", got)
+	}
+}
+
+// Installations that enabled deploy before this was derived have the release
+// path sitting in their config. Reading it must produce the same path, not
+// current/current.
+func TestWorkdirDerivationIsIdempotent(t *testing.T) {
+	conf := map[string]string{"deploy/enabled": "true", "workdir": "/var/www/html/current"}
+
+	applyDerived(conf)
+	applyDerived(conf)
+
+	if got := conf["workdir"]; got != "/var/www/html/current" {
+		t.Errorf("workdir = %q, want /var/www/html/current", got)
+	}
+}
+
+// A project whose application is not at the mount root keeps its own root and
+// gains the release link, rather than losing the first to the second.
+func TestWorkdirKeepsACustomRoot(t *testing.T) {
+	conf := map[string]string{"deploy/enabled": "true", "workdir": "/var/www/html/storefront"}
+
+	applyDerived(conf)
+
+	if got := conf["workdir"]; got != "/var/www/html/storefront/current" {
+		t.Errorf("workdir = %q, want /var/www/html/storefront/current", got)
+	}
+}
+
+// php/workdir follows when it is set and is not invented when it is not: an
+// unset one means the php container follows workdir, and writing one here would
+// fix in place a thing that was deliberately left to follow.
+func TestPhpWorkdirFollowsOnlyWhenSet(t *testing.T) {
+	set := map[string]string{"deploy/enabled": "true", "php/workdir": "/var/www/html"}
+	applyDerived(set)
+	if got := set["php/workdir"]; got != "/var/www/html/current" {
+		t.Errorf("php/workdir = %q, want /var/www/html/current", got)
+	}
+
+	unset := map[string]string{"deploy/enabled": "true"}
+	applyDerived(unset)
+	if _, exists := unset["php/workdir"]; exists {
+		t.Errorf("php/workdir was invented: %q", unset["php/workdir"])
+	}
+}
+
+// Trailing slashes and spaces come from hand-edited files, and neither should
+// produce a different answer.
+func TestWorkdirDerivationToleratesUntidyInput(t *testing.T) {
+	for _, stored := range []string{"/var/www/html/", "  /var/www/html  ", "/var/www/html/current/"} {
+		conf := map[string]string{"deploy/enabled": "true", "workdir": stored}
+		applyDerived(conf)
+		if got := conf["workdir"]; got != "/var/www/html/current" {
+			t.Errorf("stored %q derived to %q", stored, got)
+		}
+	}
+}
+
+// Only "true" enables it. A half-configured deploy block must not move the
+// application root.
+func TestWorkdirIgnoresANonTrueDeployFlag(t *testing.T) {
+	for _, flag := range []string{"", "false", "1", "yes"} {
+		conf := map[string]string{"deploy/enabled": flag, "workdir": "/var/www/html"}
+		applyDerived(conf)
+		if got := conf["workdir"]; got != "/var/www/html" {
+			t.Errorf("deploy/enabled=%q moved the root to %q", flag, got)
+		}
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.18"
+const Version = "3.9.19"


### PR DESCRIPTION
CI green on `1500d6f`.

## The defect

`deploy:enable` wrote `/var/www/html/current` into the project config. From then on the correct path was a **copy of a derivation**, made once, kept in one file — and everything after depended on that copy being present and right.

**Three failures in one day, 2026-08-19, all the same shape:**

- a cron job with the path spelled out, correct until the project moved to a deployer layout;
- a systemd unit on the host naming `current/artisan`, pointing at a deploy root that has no `artisan` in it;
- a deploy that failed after the pre-rebuild — which removes the config file the copy lived in. The rebuild in that window read an older config and installed a scheduler that ran the wrong command for **seventeen minutes on a live application**, with `status` correctly reporting a job installed the whole time.

## The fix

`workdir` is computed in `applyDerived`, beside `nodejs/major_version` and `php/sendmail/from_argument` — the place that "runs on every assembled project config, so no caller has to remember to do it and no generator can render a stale value". That mechanism already existed; this key was simply not in it.

- Idempotent: an installation that stored `/var/www/html/current` reads back unchanged.
- A custom root keeps its shape: `/var/www/html/storefront` → `/var/www/html/storefront/current`.
- Only `deploy/enabled == "true"` moves it; a half-configured deploy block does not.
- **The answer survives the file that used to hold it being absent**, which is exactly the window that broke.

## Two commands that now refuse

`snapshot:restore` and `project:clone` both do `rm -rf /var/www/html/* && tar -zxf -`.

On an ordinary project that path is the application and the mount at the same time, which is why the literal was never wrong. Under deployer the mount holds `releases/`, `shared/`, `current` and deployer's own state — so the same line deletes **every release and `shared/`**, where the environment file lives and which no snapshot contains.

The database half of a restore would have succeeded first. A command that does the safe part and then the unrecoverable one is worse than one that fails outright, so both stop and name the alternative: a deploy, `deploy:rollback`, or `db:import` for the database alone.

## Not in this change, and deliberately

Eight `workdir = "/var/www/html"` fallbacks in `install.go` run before a project is deployed at all. `hooks/deployer/exec.go` in madock-pro takes the deploy root rather than the workdir on purpose, and says why.

Merge as a merge commit.