### PR TITLE
Restart one service, so a deploy recipe can do it itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+**v3.9.20**
+
+Added:
+- **`service:restart <name>` restarts one service and leaves the rest of the project running.** `madock service:restart php`, `madock service:restart php worker-queue`. Names are the ones compose uses — a name the project does not have is refused with the list of the ones it does — and a config key resolves too, so `search/opensearch` finds `opensearch`
+- **This is the command a deploy recipe can call, and `restart` is not.** Not for being blunt: `restart` stops every container including `deployer`, which on a deployer host is the container running the deploy, so a recipe calling it dies at the moment it succeeds. Restarting after a deploy therefore stayed a second step for a person to remember — and **on 2026-08-19, on one machine, three of four projects were serving a release older than the one `current` pointed at**, twice in the same session, with two of the three who forgot knowing about the trap. One of them was found only because a new column stayed NULL where the new code always fills it
+- The same precision removes a cost on a shared-database machine, where a project-wide restart takes down the database container every other application on the host is connected to
+- **It reports the state after the restart, not the fact that one was ordered.** `docker compose restart` exits zero once the signals are sent, and a worker with a broken command is gone a moment later; a service that is not running when the command returns is a failure naming the service. A docker that cannot be asked afterwards says so — that is neither success nor failure, and rounding it to either is the silence this command was written against
+- Every name is resolved before anything is restarted, so a typo in the second of two arguments does not leave the first restarted and the caller guessing
+
+Changed:
+- **`madock restart php` now names the command that does what was asked.** It was already refused rather than acted on — that is the 3.9.16 fix and it still holds, containers stay up — but the message was go-arg's "too many positional arguments at 'php'", which reads as a parser complaint and names neither the intent nor the command that serves it
+
 **v3.9.19**
 
 Fixed:

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -92,6 +92,23 @@ A service has none of those. It is described where the rest of the environment i
 
 It also removes a subtler cost: a host-side unit keeps the madock binary open, and replacing an open binary with `cp` fails with `Text file busy`. That is a strange thing to discover while updating a server.
 
+## Restarting one of them
+
+A worker holds its code in memory. After a deploy moves `current` to a new release, the container that was already running goes on serving the old one — the symlink moved and the process was never told.
+
+```bash
+madock service:restart worker-queue      # one service
+madock service:restart php worker-queue  # several, in one call
+```
+
+`restart` cannot do this job, and not because it is blunt. It stops every container of the project, `deployer` among them — and on a deployer host `deployer` is the container running the deploy, so a recipe that calls `restart` kills itself at the moment it succeeds. That is why restarting after a deploy stayed a second step for a person to remember, and **on 2026-08-19 three of four projects on one machine were serving a release older than the one `current` pointed at**, twice in the same session. Two of the three people who forgot knew about the trap.
+
+With a service named, the recipe ends by restarting its own application and the deployer container lives to report the result. The same precision matters on a machine where several projects share a database: a project-wide restart there takes the database container down, and every application connected to it.
+
+The names are the ones compose uses — `madock service:restart` with a name it does not have prints the list. The config key works too, so `search/opensearch` finds `opensearch`.
+
+What it reports is the state after the restart, not the fact that a restart was ordered: `docker compose restart` exits zero once the signals are sent, and a worker whose command is broken is gone a moment later. A service that is not running when the command finishes is a failure with the name in it. A service that dies thirty seconds later is not caught here — that is what `madock status` and the worker's own log are for.
+
 ## When this is not enough
 
 `worker` gives you restart-on-exit and nothing more, which is what most projects need. For several copies of one program, per-program logs, a hot reload without a rebuild, or a status command that asks the supervisor rather than docker, madock-pro has [`supervisor`](https://github.com/faradey/madock-pro) — the same idea with a process manager inside the container.

--- a/llms.txt
+++ b/llms.txt
@@ -79,6 +79,7 @@ Each platform has its own CLI command(s). Use the one matching the project's pla
 ### Services
 - `service:enable` — enable a service
 - `service:disable` — disable a service
+- `service:restart` — restart one service, leaving the rest of the project running
 
 ### Other
 - `logs` — show container logs (flag: `--service`)

--- a/src/controller/all/all.go
+++ b/src/controller/all/all.go
@@ -44,6 +44,7 @@ import (
 	_ "github.com/faradey/madock/v3/src/controller/general/service/disable"
 	_ "github.com/faradey/madock/v3/src/controller/general/service/enable"
 	_ "github.com/faradey/madock/v3/src/controller/general/service/list"
+	_ "github.com/faradey/madock/v3/src/controller/general/service/restart"
 	_ "github.com/faradey/madock/v3/src/controller/general/setup"
 	_ "github.com/faradey/madock/v3/src/controller/general/setup/env"
 	_ "github.com/faradey/madock/v3/src/controller/general/template"

--- a/src/controller/general/restart/restart.go
+++ b/src/controller/general/restart/restart.go
@@ -2,12 +2,14 @@ package restart
 
 import (
 	"os"
+	"strings"
 
 	"github.com/faradey/madock/v3/src/command"
 	"github.com/faradey/madock/v3/src/controller/general/start"
 	"github.com/faradey/madock/v3/src/controller/general/stop"
 	"github.com/faradey/madock/v3/src/helper/cli/arg_struct"
 	"github.com/faradey/madock/v3/src/helper/cli/attr"
+	"github.com/faradey/madock/v3/src/helper/cli/fmtc"
 	"github.com/faradey/madock/v3/src/helper/configs"
 	"github.com/faradey/madock/v3/src/helper/configs/aruntime/project"
 )
@@ -49,6 +51,18 @@ var (
 //
 // Parsing first turns that into a refusal that costs nothing.
 func Execute() {
+	// A bare word here is somebody asking for one service back, and there is a
+	// command for that now. go-arg would refuse it too — that is the 3.9.16 fix
+	// and it still holds — but "too many positional arguments at 'php'" is a
+	// parser complaint that names neither what was wanted nor what does it.
+	if len(os.Args) > 2 {
+		if name := unexpectedPositional(os.Args[2:]); name != "" {
+			fmtc.ErrorLn("`restart` restarts the whole project and takes no service name.")
+			fmtc.WarningLn("To restart one service: madock service:restart " + name)
+			os.Exit(1)
+		}
+	}
+
 	args := parseArgs()
 
 	// The same rule one step further out. `start` generates the build context,
@@ -62,4 +76,20 @@ func Execute() {
 
 	stopContainers()
 	startContainers(args)
+}
+
+// unexpectedPositional returns the first argument that is not a flag.
+//
+// Every flag this command takes is a boolean, so a bare word is never a flag's
+// value and can be named without ambiguity. If that stops being true — a flag
+// here that takes a value — this reads that value as a service name, and the
+// check has to learn the flag.
+func unexpectedPositional(argv []string) string {
+	for _, arg := range argv {
+		if arg == "" || strings.HasPrefix(arg, "-") {
+			continue
+		}
+		return arg
+	}
+	return ""
 }

--- a/src/controller/general/restart/restart_test.go
+++ b/src/controller/general/restart/restart_test.go
@@ -24,6 +24,37 @@ func swap(t *testing.T, parse func() *arg_struct.ControllerGeneralStart, stop fu
 	startContainers = start
 }
 
+// `madock restart php` is somebody asking for one service, and there is a
+// command for that.
+//
+// go-arg refuses the argument either way — that is the 3.9.16 fix, and it is
+// what keeps the environment up. What it cannot do is say what was meant: its
+// message reads "too many positional arguments at 'php'", which names neither
+// the want nor the command that serves it.
+func TestABareServiceNameIsRecognisedAsSuch(t *testing.T) {
+	if got := unexpectedPositional([]string{"php"}); got != "php" {
+		t.Errorf("unexpectedPositional([php]) = %q, want php", got)
+	}
+	if got := unexpectedPositional([]string{"--with-chown", "worker-queue"}); got != "worker-queue" {
+		t.Errorf("a service name after a flag was not seen: %q", got)
+	}
+}
+
+// Flags are not service names. Every flag this command takes is a boolean, so
+// nothing here is a value belonging to one.
+func TestFlagsAreNotMistakenForServiceNames(t *testing.T) {
+	for _, argv := range [][]string{
+		nil,
+		{"--with-chown"},
+		{"-c"},
+		{"--quiet", "--with-chown"},
+	} {
+		if got := unexpectedPositional(argv); got != "" {
+			t.Errorf("unexpectedPositional(%v) = %q, want none", argv, got)
+		}
+	}
+}
+
 // The command line is read before a single container is stopped.
 //
 // The order is the fix: go-arg ends the process on an argument the command does

--- a/src/controller/general/service/restart/restart.go
+++ b/src/controller/general/service/restart/restart.go
@@ -1,0 +1,201 @@
+package restart
+
+import (
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/faradey/madock/v3/src/command"
+	"github.com/faradey/madock/v3/src/controller/general/service"
+	"github.com/faradey/madock/v3/src/helper/cli/arg_struct"
+	"github.com/faradey/madock/v3/src/helper/cli/attr"
+	"github.com/faradey/madock/v3/src/helper/cli/fmtc"
+	"github.com/faradey/madock/v3/src/helper/configs"
+	"github.com/faradey/madock/v3/src/helper/docker"
+)
+
+func init() {
+	command.Register(&command.Definition{
+		Aliases:  []string{"service:restart"},
+		Handler:  Execute,
+		Help:     "Restart one service of the project, leaving the others running",
+		Category: "service",
+		ArgsType: new(arg_struct.ControllerGeneralServiceRestart),
+	})
+}
+
+// deployerService is the container a deploy runs in.
+//
+// Named here because it is the one service whose restart is a different kind of
+// act: from inside a deploy it kills the process doing the restarting.
+const deployerService = "deployer"
+
+// Seams for the tests. Nothing else replaces them.
+var (
+	composeServices = docker.ComposeServices
+	restartServices = docker.RestartServices
+	serviceStates   = docker.ServiceStates
+	projectName     = configs.GetProjectName
+	exit            = os.Exit
+)
+
+// Execute restarts the named services and touches nothing else.
+//
+// `restart` cannot be a step of a deploy recipe: it stops every container of
+// the project including `deployer`, which is the process running the recipe, so
+// it dies at the moment it succeeds. Restarting after a deploy therefore stayed
+// a second step for a person — and on 2026-08-19, on one machine, three of four
+// projects were serving a release older than the one `current` pointed at,
+// twice in the same session. Two of the three people who forgot knew about the
+// trap. Something that fails that way is not fixed by remembering harder.
+//
+// With one service named, the recipe ends by restarting its own application and
+// the deployer container lives to report the result. On a machine where several
+// projects share a database it also removes the price of the blunt tool: a
+// project-wide restart there takes down the database container every other
+// application on the machine is connected to.
+func Execute() {
+	args := attr.Parse(new(arg_struct.ControllerGeneralServiceRestart)).(*arg_struct.ControllerGeneralServiceRestart)
+
+	project := projectName()
+
+	available, err := composeServices(project)
+	if err != nil {
+		// A question that could not be asked is its own answer, and it is not
+		// "no such service". Saying which one it was is what lets somebody act.
+		fmtc.ErrorLn("Could not ask docker which services this project has: " + err.Error())
+		exit(1)
+		return
+	}
+
+	if len(args.Args) == 0 {
+		fmtc.ErrorLn("Service name is required: madock service:restart <name>")
+		printAvailable(available)
+		exit(1)
+		return
+	}
+
+	// Every name is resolved before anything is restarted. A typo in the second
+	// of two arguments would otherwise restart the first and then refuse, which
+	// leaves the caller guessing which half happened.
+	resolved := make([]string, 0, len(args.Args))
+	for _, name := range args.Args {
+		if current, renamed := service.Renamed(name); renamed {
+			fmtc.WarningLn("\"" + name + "\" is now \"" + current + "\". The old name still works for now.")
+		}
+
+		svc, ok := resolve(name, available)
+		if !ok {
+			fmtc.ErrorLn("The service \"" + name + "\" is not part of this project's stack. Nothing was restarted.")
+			printAvailable(available)
+			exit(1)
+			return
+		}
+		resolved = append(resolved, svc)
+	}
+
+	for _, svc := range resolved {
+		if svc == deployerService {
+			fmtc.WarningLn("\"deployer\" is the container a deploy runs in — restarting it from inside a deploy kills that deploy. That is the trap this command exists to avoid.")
+		}
+	}
+
+	if err := restartServices(project, resolved); err != nil {
+		fmtc.ErrorLn("Restart failed: " + err.Error())
+		exit(1)
+		return
+	}
+
+	report(project, resolved)
+}
+
+// report says whether the services came back, and says so from docker rather
+// than from the restart having returned zero.
+//
+// `docker compose restart` exits zero once it has sent the signals. A container
+// whose main process exits on start — a worker with a broken command, most
+// often — is gone a moment later, and the state right after the restart is the
+// only cheap chance to notice. It is not proof of health: a service that dies
+// thirty seconds in still reports running here. It is the difference between
+// "restarted" and "restarted and still there", which is the claim being made.
+func report(project string, services []string) {
+	states, err := serviceStates(project)
+	if err != nil {
+		fmtc.WarningLn("Restarted " + strings.Join(services, ", ") +
+			", but docker could not be asked whether they came back: " + err.Error())
+		return
+	}
+
+	state := make(map[string]string, len(states))
+	for _, entry := range states {
+		state[entry.Service] = entry.State
+	}
+
+	var down []string
+	for _, svc := range services {
+		switch current, known := state[svc]; {
+		case !known:
+			fmtc.WarningLn(svc + ": restarted, but docker lists no container for it")
+		case current == "running" || current == "restarting":
+			fmtc.Title(svc)
+			fmtc.SuccessLn(" " + current)
+		default:
+			down = append(down, svc+" ("+current+")")
+		}
+	}
+
+	if len(down) > 0 {
+		fmtc.ErrorLn("Not running after the restart: " + strings.Join(down, ", "))
+		exit(1)
+	}
+}
+
+// resolve maps a name a person types to the service compose knows.
+//
+// Three spellings arrive here and all three are legitimate: the compose service
+// itself (`php`, `worker-queue`, `deployer`), the short name madock prints
+// elsewhere (`elasticsearch`), and the config key that switches it
+// (`search/elasticsearch`). A name that matches none of them is refused rather
+// than guessed at — restarting a service nobody asked for is worse than
+// restarting nothing.
+func resolve(name string, available []string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+
+	if svc, ok := match(name, available); ok {
+		return svc, true
+	}
+	if svc, ok := match(service.GetByLong(name), available); ok {
+		return svc, true
+	}
+	// A name that moved — `php/nodejs` → `nodejs/embedded` → `embedded-node`.
+	if current, renamed := service.Renamed(name); renamed {
+		if svc, ok := match(service.GetByLong(current), available); ok {
+			return svc, true
+		}
+	}
+	return "", false
+}
+
+func match(name string, available []string) (string, bool) {
+	for _, svc := range available {
+		if strings.EqualFold(svc, name) {
+			return svc, true
+		}
+	}
+	return "", false
+}
+
+// printAvailable lists what the project actually has, which is the only useful
+// thing to say next to "no such service".
+func printAvailable(available []string) {
+	if len(available) == 0 {
+		fmtc.WarningLn("This project's stack declares no services.")
+		return
+	}
+	names := append([]string(nil), available...)
+	sort.Strings(names)
+	fmtc.WarningLn("Services of this project: " + strings.Join(names, ", "))
+}

--- a/src/controller/general/service/restart/restart_test.go
+++ b/src/controller/general/service/restart/restart_test.go
@@ -1,0 +1,199 @@
+package restart
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/faradey/madock/v3/src/helper/cli/attr"
+	"github.com/faradey/madock/v3/src/helper/docker"
+)
+
+// stack is what a real project answers: services the config names, services it
+// does not (`deployer`, `worker-queue`, `php_without_xdebug`), and a search
+// engine whose config key is spelled differently from its service.
+var stack = []string{"php", "php_without_xdebug", "nginx", "db", "opensearch", "deployer", "worker-queue"}
+
+// harness replaces the seams for one test and records what reached docker.
+type harness struct {
+	restarted []string
+	states    []docker.ServiceState
+	statesErr error
+	listErr   error
+	exits     []int
+}
+
+func newHarness(t *testing.T, argv ...string) *harness {
+	t.Helper()
+
+	h := &harness{}
+
+	origList, origRestart, origStates := composeServices, restartServices, serviceStates
+	origProject, origExit := projectName, exit
+	origArgs, origParse := os.Args, attr.IsParseArgs
+	t.Cleanup(func() {
+		composeServices, restartServices, serviceStates = origList, origRestart, origStates
+		projectName, exit = origProject, origExit
+		os.Args, attr.IsParseArgs = origArgs, origParse
+	})
+
+	composeServices = func(string) ([]string, error) {
+		if h.listErr != nil {
+			return nil, h.listErr
+		}
+		return stack, nil
+	}
+	restartServices = func(_ string, services []string) error {
+		h.restarted = append(h.restarted, services...)
+		return nil
+	}
+	serviceStates = func(string) ([]docker.ServiceState, error) {
+		return h.states, h.statesErr
+	}
+	projectName = func() string { return "project" }
+	exit = func(code int) { h.exits = append(h.exits, code) }
+
+	os.Args = append([]string{"madock", "service:restart"}, argv...)
+	attr.IsParseArgs = true
+
+	return h
+}
+
+func running(services ...string) []docker.ServiceState {
+	states := make([]docker.ServiceState, 0, len(services))
+	for _, svc := range services {
+		states = append(states, docker.ServiceState{Service: svc, State: "running"})
+	}
+	return states
+}
+
+// The name a person types is not the name compose uses, and three spellings are
+// in circulation. All three have to arrive at the same service.
+func TestResolveAcceptsEverySpellingInCirculation(t *testing.T) {
+	for _, tc := range []struct{ typed, want string }{
+		{"php", "php"},
+		{"PHP", "php"},
+		{"deployer", "deployer"},
+		{"worker-queue", "worker-queue"},
+		{"search/opensearch", "opensearch"}, // the config key that switches it
+	} {
+		got, ok := resolve(tc.typed, stack)
+		if !ok || got != tc.want {
+			t.Errorf("resolve(%q) = %q, %v; want %q, true", tc.typed, got, ok, tc.want)
+		}
+	}
+}
+
+// A name nobody can place is refused rather than guessed at.
+func TestResolveRefusesAnUnknownName(t *testing.T) {
+	for _, typed := range []string{"", "  ", "phpp", "mysql", "redis"} {
+		if got, ok := resolve(typed, stack); ok {
+			t.Errorf("resolve(%q) = %q, true; want refusal", typed, got)
+		}
+	}
+}
+
+// Nothing is restarted on a name that does not resolve.
+//
+// The order matters more than the refusal: with two services named and the
+// second misspelled, restarting the first and then refusing leaves the caller
+// unable to tell what happened without going and looking.
+func TestAnUnknownNameRestartsNothingAtAll(t *testing.T) {
+	h := newHarness(t, "php", "redis")
+
+	Execute()
+
+	if len(h.restarted) != 0 {
+		t.Fatalf("restarted %v; want nothing", h.restarted)
+	}
+	if len(h.exits) == 0 || h.exits[0] != 1 {
+		t.Fatalf("exits = %v; want the command to fail", h.exits)
+	}
+}
+
+// The named services reach docker, and only they do.
+func TestOnlyTheNamedServicesAreRestarted(t *testing.T) {
+	h := newHarness(t, "php", "worker-queue")
+	h.states = running("php", "worker-queue", "nginx", "db", "deployer")
+
+	Execute()
+
+	if len(h.restarted) != 2 || h.restarted[0] != "php" || h.restarted[1] != "worker-queue" {
+		t.Fatalf("restarted %v; want [php worker-queue]", h.restarted)
+	}
+	if len(h.exits) != 0 {
+		t.Fatalf("exits = %v; want success", h.exits)
+	}
+}
+
+// A service that does not come back is a failure, even though the restart
+// itself returned zero.
+//
+// `docker compose restart` exits zero once the signals are sent. A worker whose
+// command is broken is gone a moment later, and without this check the command
+// would report the restart it performed rather than the state it produced —
+// which is the same silence the deploy trap is made of.
+func TestAServiceThatDoesNotComeBackFailsTheCommand(t *testing.T) {
+	h := newHarness(t, "worker-queue")
+	h.states = []docker.ServiceState{{Service: "worker-queue", State: "exited", ExitCode: 1}}
+
+	Execute()
+
+	if len(h.restarted) != 1 {
+		t.Fatalf("restarted %v; want [worker-queue]", h.restarted)
+	}
+	if len(h.exits) == 0 || h.exits[len(h.exits)-1] != 1 {
+		t.Fatalf("exits = %v; want a failure after a service stayed down", h.exits)
+	}
+}
+
+// A docker that cannot be asked afterwards is not a failure and not a success.
+//
+// The restart happened; whether it took is unknown. Reporting that as failure
+// would have a recipe roll back a deploy that worked, and reporting it as
+// success is the lie this command was written against.
+func TestAnUnreadableStateIsNeitherFailureNorSilence(t *testing.T) {
+	h := newHarness(t, "php")
+	h.statesErr = errors.New("docker daemon is not responding")
+
+	Execute()
+
+	if len(h.restarted) != 1 {
+		t.Fatalf("restarted %v; want [php]", h.restarted)
+	}
+	if len(h.exits) != 0 {
+		t.Fatalf("exits = %v; want no failure when the state could not be read", h.exits)
+	}
+}
+
+// The service list itself failing stops the command before it restarts
+// anything, and says which question went unanswered.
+func TestAnUnaskableDockerStopsTheCommand(t *testing.T) {
+	h := newHarness(t, "php")
+	h.listErr = errors.New("docker daemon is not responding")
+
+	Execute()
+
+	if len(h.restarted) != 0 {
+		t.Fatalf("restarted %v; want nothing", h.restarted)
+	}
+	if len(h.exits) == 0 || h.exits[0] != 1 {
+		t.Fatalf("exits = %v; want the command to fail", h.exits)
+	}
+}
+
+// With no name at all the command asks for one instead of restarting the
+// project — which is what `restart` is for, and doing it here would be the
+// blunt tool wearing the precise name.
+func TestNoNameRestartsNothing(t *testing.T) {
+	h := newHarness(t)
+
+	Execute()
+
+	if len(h.restarted) != 0 {
+		t.Fatalf("restarted %v; want nothing", h.restarted)
+	}
+	if len(h.exits) == 0 || h.exits[0] != 1 {
+		t.Fatalf("exits = %v; want the command to fail", h.exits)
+	}
+}

--- a/src/helper/cli/arg_struct/args.go
+++ b/src/helper/cli/arg_struct/args.go
@@ -62,6 +62,10 @@ type ControllerGeneralServiceDisable struct {
 	Global bool `arg:"-g,--global" help:"Global"`
 }
 
+type ControllerGeneralServiceRestart struct {
+	attr.ArgumentsWithArgs
+}
+
 type ControllerGeneralBash struct {
 	attr.Arguments
 	Service string `arg:"-s,--service" help:"Service name (php, nginx, db, etc.)"`

--- a/src/helper/docker/docker.go
+++ b/src/helper/docker/docker.go
@@ -178,14 +178,7 @@ func HasContainers(projectName string) bool {
 // somebody read the log there was nothing to go on: start said success and
 // status, asked in between, honestly said running.
 func NotRunning(projectName string) []ServiceState {
-	pp := paths.NewProjectPaths(projectName)
-	composeFile := pp.DockerCompose()
-	if !paths.IsFileExist(composeFile) {
-		return nil
-	}
-
-	out, err := exec.Command("docker", "compose", "-f", composeFile, "-f", pp.DockerComposeOverride(),
-		"ps", "-a", "--format", "json").Output()
+	entries, err := ServiceStates(projectName)
 	if err != nil {
 		// Nothing to report rather than a false alarm: a docker that cannot be
 		// asked is not evidence that a service died.
@@ -193,7 +186,7 @@ func NotRunning(projectName string) []ServiceState {
 	}
 
 	var dead []ServiceState
-	for _, entry := range parseComposePS(out) {
+	for _, entry := range entries {
 		if entry.State != "running" && entry.State != "restarting" {
 			dead = append(dead, entry)
 		}

--- a/src/helper/docker/service.go
+++ b/src/helper/docker/service.go
@@ -1,0 +1,105 @@
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/faradey/madock/v3/src/helper/paths"
+)
+
+// ComposeServices returns the project's services under the names compose knows
+// them by.
+//
+// Asked of compose rather than assembled from the config, and that is the whole
+// point: the generated stack holds services no config key names — `deployer`,
+// `worker-<program>`, `php_without_xdebug` — so a list built here would be a
+// second spelling of something compose already answers, and it would go stale
+// the first time a template grew a service. It is also the only honest thing to
+// put in a "no such service" message.
+func ComposeServices(projectName string) ([]string, error) {
+	pp := paths.NewProjectPaths(projectName)
+	composeFile := pp.DockerCompose()
+	if !paths.IsFileExist(composeFile) {
+		return nil, fmt.Errorf("the project has no generated stack yet (%s is missing) — run `madock start` first", composeFile)
+	}
+
+	out, err := exec.Command("docker", "compose", "-f", composeFile, "-f", pp.DockerComposeOverride(),
+		"config", "--services").Output()
+	if err != nil {
+		return nil, composeError(err)
+	}
+
+	var services []string
+	for _, line := range strings.Split(string(out), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			services = append(services, line)
+		}
+	}
+	return services, nil
+}
+
+// RestartServices restarts the named services and leaves every other container
+// of the project alone.
+//
+// The difference from `restart` is not a matter of scope but of what is
+// possible. A deploy recipe cannot call `restart`: it stops the deployer
+// container, which is the process running the recipe, so the recipe dies at the
+// moment it succeeds. That is why restarting after a deploy stayed a second
+// step for a person, and why on 2026-08-19 three of four projects on one
+// machine were serving code from a release older than `current` — the symlink
+// had moved and the process had not been told.
+func RestartServices(projectName string, services []string) error {
+	if len(services) == 0 {
+		return errors.New("no services named")
+	}
+
+	pp := paths.NewProjectPaths(projectName)
+	composeFile := pp.DockerCompose()
+	if !paths.IsFileExist(composeFile) {
+		return fmt.Errorf("the project has no generated stack yet (%s is missing) — run `madock start` first", composeFile)
+	}
+
+	args := append([]string{"compose", "-f", composeFile, "-f", pp.DockerComposeOverride(), "restart"}, services...)
+	cmd := exec.Command("docker", args...)
+	attachOutput(cmd)
+	return cmd.Run()
+}
+
+// ServiceStates returns one row per container of the project, running or not.
+//
+// An error means the question could not be asked — a docker that does not
+// answer — which is not the same as a project with no containers, and callers
+// that round the two together are how "restarted successfully" gets printed
+// over a service that never came back.
+func ServiceStates(projectName string) ([]ServiceState, error) {
+	pp := paths.NewProjectPaths(projectName)
+	composeFile := pp.DockerCompose()
+	if !paths.IsFileExist(composeFile) {
+		return nil, fmt.Errorf("the project has no generated stack yet (%s is missing)", composeFile)
+	}
+
+	out, err := exec.Command("docker", "compose", "-f", composeFile, "-f", pp.DockerComposeOverride(),
+		"ps", "-a", "--format", "json").Output()
+	if err != nil {
+		return nil, composeError(err)
+	}
+	return parseComposePS(out), nil
+}
+
+// composeError keeps docker's own words.
+//
+// exec.Command().Output() puts them in ExitError.Stderr, and an ExitError
+// printed as `%v` reads "exit status 1" — a message that names neither the
+// service nor the reason, on a command whose entire value is saying which of
+// the two happened.
+func composeError(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if msg := strings.TrimSpace(string(exitErr.Stderr)); msg != "" {
+			return fmt.Errorf("%w: %s", err, msg)
+		}
+	}
+	return err
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.19"
+const Version = "3.9.20"

--- a/test/e2e/restart_test.go
+++ b/test/e2e/restart_test.go
@@ -51,9 +51,14 @@ func TestRestartReadsArgumentsBeforeStopping(t *testing.T) {
 
 	// An argument the command does not take. It has to fail — and leave the
 	// project exactly as it was.
-	if out, err := p.tryRun(2*time.Minute, "restart", "php"); err == nil {
+	out, err := p.tryRun(2*time.Minute, "restart", "php")
+	if err == nil {
 		t.Errorf("`restart php` was accepted; it takes no positional argument:\n%s", out)
 	}
+	// And it names the command that does what was asked. Refusing correctly
+	// while leaving somebody to find `service:restart` on their own is how the
+	// second step stayed a second step.
+	requireContains(t, out, "service:restart php", "the answer to `restart php`")
 	running("`restart php`")
 
 	// --help is answered, not acted on.

--- a/test/e2e/service_restart_test.go
+++ b/test/e2e/service_restart_test.go
@@ -1,0 +1,93 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServiceRestartTouchesOnlyTheServiceNamed is the whole reason the command
+// exists, stated as a measurement: one container is younger afterwards and the
+// others are exactly as old as they were.
+//
+// `restart` cannot be a step of a deploy recipe — it stops every container of
+// the project, `deployer` among them, which is the process running the recipe.
+// So restarting after a deploy stayed a second step for a person, and on
+// 2026-08-19 three of four projects on one machine were serving code from a
+// release older than the one `current` pointed at. Two of the three who forgot
+// knew about the trap. The gap closes only if a recipe can restart its own
+// application without touching the container it is running in.
+//
+// The same precision is what makes it usable on a machine where several
+// projects share a database: a project-wide restart there takes the database
+// container down with it, and every other application on the machine with it.
+func TestServiceRestartTouchesOnlyTheServiceNamed(t *testing.T) {
+	p := newProject(t, "e2esvcrestart")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2esvcrestart.test",
+	)
+	p.run(20*time.Minute, "start")
+
+	dbBefore := startedAt(t, p, "db")
+	nginxBefore := startedAt(t, p, "nginx")
+
+	// A name this project does not have restarts nothing, and says what the
+	// project does have — the only useful thing to put next to a refusal.
+	out, err := p.tryRun(2*time.Minute, "service:restart", "nosuchservice")
+	if err == nil {
+		t.Errorf("service:restart accepted a service this project does not have:\n%s", out)
+	}
+	requireContains(t, out, "Nothing was restarted", "the refusal of an unknown service name")
+	requireContains(t, out, "nginx", "the list of services offered after a refusal")
+
+	if got := startedAt(t, p, "db"); got != dbBefore {
+		t.Errorf("a refused name restarted db anyway: %s → %s", dbBefore, got)
+	}
+
+	// No name at all asks for one. Falling back to the whole project here would
+	// be the blunt tool wearing the precise name.
+	if out, err := p.tryRun(2*time.Minute, "service:restart"); err == nil {
+		t.Errorf("service:restart with no service name was accepted:\n%s", out)
+	}
+
+	p.run(5*time.Minute, "service:restart", "db")
+
+	dbAfter := startedAt(t, p, "db")
+	nginxAfter := startedAt(t, p, "nginx")
+
+	if dbAfter == dbBefore {
+		t.Errorf("db was not restarted: still started at %s", dbAfter)
+	}
+	if nginxAfter != nginxBefore {
+		t.Errorf("nginx was restarted too (%s → %s); the command is not precise, "+
+			"which is the entire point of it", nginxBefore, nginxAfter)
+	}
+}
+
+// startedAt reads when a service's container last started.
+//
+// Asked of docker rather than of madock, deliberately: `status` answers running
+// or not, and everything here is running before and after — the claim under
+// test is narrower than that, and it is which container is younger. This is a
+// measurement of what madock did, not a way of driving it.
+func startedAt(t *testing.T, p *project, service string) string {
+	t.Helper()
+
+	container := "madock_" + p.name + "-" + service + "-1"
+	out, err := exec.Command("docker", "inspect", "--format", "{{.State.StartedAt}}", container).CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not read the start time of %s: %v\n%s", container, err, out)
+	}
+
+	started := strings.TrimSpace(string(out))
+	if started == "" {
+		t.Fatalf("docker reported no start time for %s", container)
+	}
+	return started
+}


### PR DESCRIPTION
`restart` stops every container of the project, `deployer` among them — and on a deployer host that is the container running the deploy, so a recipe calling it dies at the moment it succeeds. Restarting after a deploy was therefore a second step for a person to remember, and on 2026-08-19 three of four projects on one machine were serving a release older than the one `current` pointed at, twice in the same session. Two of the three who forgot knew about the trap.

`service:restart <name>` names its own service and leaves the rest running. On a shared-database machine it also stops a restart from taking down the database container every other project is connected to.

- names come from compose, not from a list kept in the code — the stack holds services no config key names (`deployer`, `worker-<program>`)
- an unknown name is refused with the real list and restarts nothing; resolution finishes before the first restart
- the report is the state afterwards, not the fact a restart was ordered; a docker that cannot be asked is reported as unknown
- `madock restart php` keeps refusing (3.9.16) but now names `service:restart php`

Verified against a real environment: with three containers up, `service:restart db` moved only the db container's start time. Unit tests cover resolution and reporting; a new e2e test asserts one container is younger afterwards and the others are not.