### PR TITLE
A migration may carry a key across, not invent one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v3.9.21**
+
+Fixed:
+- **The `db/type` migration wrote an engine into projects that had never named one.** `GetDbType` answers "mysql" for anything it cannot read as postgres or mongo — nothing at all included — so V340 put `db/type=mysql` into the config of a project with `db/enabled=false` and no repository. A migration may carry a key across; it may not invent one, and the invention lands in the project's own committed file, where every later reader believes it
+- Two guards, answering different questions: `db/enabled=false` is the project saying it has no database (absent still means enabled, as everywhere else in the codebase), and no `db/repository` is the project having said nothing to carry across. Neither costs anything — `GetDbType` falls back the same way at read time whether or not the key was ever written
+
 **v3.9.20**
 
 Added:

--- a/src/migration/versions/v340.go
+++ b/src/migration/versions/v340.go
@@ -2,6 +2,7 @@ package versions
 
 import (
 	"os"
+	"strings"
 
 	"github.com/faradey/madock/v3/src/helper/configs"
 	"github.com/faradey/madock/v3/src/helper/paths"
@@ -52,8 +53,32 @@ func V340() {
 	}
 }
 
+// migrateDbType writes the engine beside the repository it was already implied
+// by — and only there.
+//
+// A migration may carry a key across. It may not invent one, and this did:
+// `GetDbType` falls back to "mysql" for anything it cannot read as postgres or
+// mongo, including nothing at all, so a project that had said nothing about a
+// database got `db/type=mysql` written into its own config file. Measured on a
+// project with `db/enabled=false` and no repository: the file came back
+// declaring an engine its author had never chosen, and a declaration in the
+// project's committed config is exactly what a later reader trusts.
+//
+// Two guards, and they are different questions. `db/enabled=false` is the
+// project saying it has no database — absent means enabled, which is how every
+// other reader in the codebase treats it. No repository is the project not
+// having said anything to carry across, so there is nothing to migrate and the
+// fallback would be the invention rather than a rescue: `GetDbType` answers the
+// same "mysql" at read time whether or not this key exists, so a project loses
+// nothing by it staying unwritten.
 func migrateDbType(configPath string, projectConf map[string]string) {
 	if _, hasType := projectConf["db/type"]; hasType {
+		return
+	}
+	if projectConf["db/enabled"] == "false" {
+		return
+	}
+	if strings.TrimSpace(projectConf["db/repository"]) == "" {
 		return
 	}
 

--- a/src/migration/versions/v340_test.go
+++ b/src/migration/versions/v340_test.go
@@ -153,6 +153,80 @@ func TestMigrateDbType_SkipsIfAlreadySet(t *testing.T) {
 	}
 }
 
+// A project that says it has no database does not get an engine written into
+// its config.
+//
+// `GetDbType` answers "mysql" for anything it cannot read as postgres or mongo,
+// nothing at all included, so this wrote a declaration the author never made —
+// into the project's own committed file, where a later reader believes it.
+// Measured on a project with db/enabled=false and no repository.
+func TestMigrateDbType_LeavesADisabledDatabaseAlone(t *testing.T) {
+	tmpPath := writeConfig(t, `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <activeScope>default</activeScope>
+    <scopes>
+        <default>
+            <db>
+                <enabled>false</enabled>
+            </db>
+        </default>
+    </scopes>
+</config>`)
+
+	migrateDbType(tmpPath, map[string]string{"db/enabled": "false"})
+
+	result := configs.ParseXmlFile(tmpPath)
+	if got, ok := result["scopes/default/db/type"]; ok {
+		t.Errorf("db/type = %q was invented for a project with no database", got)
+	}
+}
+
+// Nothing to carry across is not a reason to write a default.
+//
+// The key is a convenience: `GetDbType` falls back to the repository — and to
+// "mysql" — at read time either way, so a project whose config never named a
+// repository loses nothing by this staying unwritten, and keeps a config that
+// claims only what it was given.
+func TestMigrateDbType_WritesNothingWithNoRepository(t *testing.T) {
+	tmpPath := writeConfig(t, `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <activeScope>default</activeScope>
+    <scopes>
+        <default>
+            <php>
+                <version>8.3</version>
+            </php>
+        </default>
+    </scopes>
+</config>`)
+
+	migrateDbType(tmpPath, map[string]string{"php/version": "8.3"})
+
+	result := configs.ParseXmlFile(tmpPath)
+	if got, ok := result["scopes/default/db/type"]; ok {
+		t.Errorf("db/type = %q was invented for a project that named no repository", got)
+	}
+}
+
+// writeConfig puts an XML config in a temporary file and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp("", "db-type-migration-*.xml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Failed to close temp file: %v", err)
+	}
+	return tmpFile.Name()
+}
+
 func TestMigrateDbType_DefaultsToMySQL(t *testing.T) {
 	tmpFile, err := os.CreateTemp("", "db-type-migration-*.xml")
 	if err != nil {

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "3.9.20"
+const Version = "3.9.21"


### PR DESCRIPTION
V340 backfills `db/type` from `db/repository`. `GetDbType` answers "mysql" for anything it cannot read as postgres or mongo — including nothing at all — so a project with `db/enabled=false` and no repository got `db/type=mysql` written into its own config file: a statement about the stack its author never made, in the file every later reader trusts.

Two guards, answering different questions:

- `db/enabled=false` is the project saying it has no database (absent still means enabled, as everywhere else in the codebase);
- no `db/repository` is the project having said nothing to carry across, so the fallback would be the invention rather than a rescue.

Neither costs a project anything — `GetDbType` falls back to the repository, and to mysql, at read time whether or not the key was ever written.

Both new tests fail against the code before this change, with the measured symptom (`db/type = "mysql" was invented for a project with no database`).