### PR TITLE
docs: setup already started the containers

### DIFF
--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -62,8 +62,8 @@ madock setup
 # Select PHP, MySQL, Elasticsearch versions matching your project
 # Enter host (e.g.: magento.local)
 
-# 3. Start containers (with rebuild)
-madock rebuild
+# 3. The containers are already up — setup ends with a rebuild
+madock status
 
 # 4. Install dependencies
 madock composer install
@@ -96,8 +96,8 @@ madock setup
 # Select PHP, MySQL/MariaDB versions matching your project
 # Enter host (e.g.: shopware.local)
 
-# 3. Start containers (with rebuild)
-madock rebuild
+# 3. The containers are already up — setup ends with a rebuild
+madock status
 
 # 4. Install dependencies
 madock composer install
@@ -133,8 +133,8 @@ madock setup
 # Configure language version and other settings
 # Enter host (e.g.: myproject.test)
 
-# 3. Start containers (with rebuild)
-madock rebuild
+# 3. The containers are already up — setup ends with a rebuild
+madock status
 
 # 4. Work inside the container
 madock bash

--- a/docs/magento.md
+++ b/docs/magento.md
@@ -14,8 +14,8 @@ madock setup
 # Choose PHP, MySQL, Elasticsearch versions matching your project
 # Enter host (e.g.: magento.local)
 
-# 3. Start containers
-madock start
+# 3. The containers are already up — setup ends with a rebuild
+madock status
 
 # 4. Install dependencies
 madock composer install

--- a/docs/prestashop.md
+++ b/docs/prestashop.md
@@ -14,8 +14,8 @@ madock setup
 # Choose PHP, MySQL versions matching your project
 # Enter host (e.g.: prestashop.local)
 
-# 3. Start containers
-madock start
+# 3. The containers are already up — setup ends with a rebuild
+madock status
 
 # 4. Install dependencies
 madock composer install

--- a/docs/saleor.md
+++ b/docs/saleor.md
@@ -9,7 +9,6 @@ madock runs Saleor 3.x commerce projects locally inside Docker: Python (uvicorn/
 git clone --branch 3.23 https://github.com/saleor/saleor.git my-saleor
 cd my-saleor
 madock setup --platform saleor --preset latest
-madock start
 madock install
 ```
 

--- a/docs/shopware.md
+++ b/docs/shopware.md
@@ -14,8 +14,8 @@ madock setup
 # Choose PHP, MySQL versions matching your project
 # Enter host (e.g.: shopware.local)
 
-# 3. Start containers
-madock start
+# 3. The containers are already up — setup ends with a rebuild
+madock status
 
 # 4. Install dependencies
 madock composer install

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -8,6 +8,10 @@ madock/projects/{project name}/env.xml
 
 #### 1. Start containers
 
+`madock setup` ends by building and starting them, so straight after setup there is nothing to start — the project is already up, and `madock status` says so.
+
+`start` is what brings a project back later: after `madock stop`, after a reboot, or in the morning.
+
 ```
 madock start
 ```


### PR DESCRIPTION
Six places told the reader to start a project that was already running. `madock setup` ends with `rebuild.Execute()` — all eleven platform setups do — so by the time somebody reaches "3. Start containers" the containers are up.

- `docs/workflow.md` opened the whole guide with it;
- `docs/magento.md`, `docs/prestashop.md`, `docs/shopware.md` and three blocks of `docs/deployment-guide.md` repeated it inside their setup sequences (the guide with `madock rebuild`, which is worse — a full rebuild for nothing);
- `docs/saleor.md` had a bare `madock start` between setup and install.

The step now checks instead of repeating: `madock status` answers the question a reader actually has there, which is whether what they just configured came up.

Found the hard way: an e2e test written this week believed the same thing, asked for status on a project it thought had never been started, and CI answered with three running services. That half is pinned by a test now; this is the half people read.

Worth knowing next to it — `snapshot:restore`, `service:enable`, `service:disable` and `debug:enable` end with a rebuild too, so none of them needs a start afterwards either.