### PR TITLE
tests: a golden for the shared proxy with a neighbour

### DIFF
--- a/src/helper/configs/aruntime/nginx/golden_neighbours_test.go
+++ b/src/helper/configs/aruntime/nginx/golden_neighbours_test.go
@@ -1,0 +1,58 @@
+package nginx
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/faradey/madock/v3/src/helper/testenv"
+)
+
+// TestGoldenProxyWithTwoProjects pins the half of the shared proxy that one
+// project cannot show: what happens when there is a neighbour.
+//
+// `proxy.conf` is a single file describing every project on the machine, and it
+// is rebuilt whenever any one of them is generated. So the failure it can have
+// that nothing else can is a project losing its block, or gaining somebody
+// else's port — and against one project both are invisible, because there is
+// only one of everything to compare.
+//
+// e2e covers the behaviour and cannot replace this. It needs docker, takes
+// minutes, and reports "the neighbour is unreachable" rather than which line
+// moved; a golden answers with the line.
+func TestGoldenProxyWithTwoProjects(t *testing.T) {
+	first := testenv.SetupWith(t, "goldenfirst", "goldenfirst.test", nil)
+	MakeConf(first.ProjectName)
+
+	second := testenv.AddProject(t, first, "goldensecond", "goldensecond.test", nil)
+	MakeConf(second.ProjectName)
+
+	rendered := testenv.Collect(t, filepath.Join(first.ExecDir, "aruntime", "ctx"), first)
+	conf, ok := rendered["proxy.conf"]
+	if !ok {
+		t.Fatalf("proxy.conf is not among the generated files: %v", keys(rendered))
+	}
+
+	// Before the fixture: both projects are in there at all. A golden written
+	// over a file that had lost a project would pin the loss.
+	for _, host := range []string{"goldenfirst.test", "goldensecond.test"} {
+		if !strings.Contains(conf, host) {
+			t.Fatalf("%s is missing from the shared proxy:\n%s", host, conf)
+		}
+	}
+
+	// The second project's run directory is its own, and it appears nowhere in a
+	// proxy configuration — but normalising it costs nothing and means a future
+	// template that does mention it cannot bake this machine's path into the
+	// fixture.
+	conf = strings.ReplaceAll(conf, second.RunDir, "<RUN_DIR_2>")
+
+	only := map[string]string{"proxy.conf": maskPorts(conf)}
+
+	goldenDir := filepath.Join("testdata", "golden", "proxy-two-projects")
+	if *updateGolden {
+		testenv.WriteGolden(t, goldenDir, only)
+		return
+	}
+	testenv.CompareGolden(t, goldenDir, only)
+}

--- a/src/helper/configs/aruntime/nginx/testdata/golden/proxy-two-projects/proxy.conf
+++ b/src/helper/configs/aruntime/nginx/testdata/golden/proxy-two-projects/proxy.conf
@@ -1,0 +1,709 @@
+worker_processes 2;
+worker_rlimit_nofile 200000;
+events {
+    worker_connections 4096;
+use epoll;
+}
+http {
+server_names_hash_bucket_size  128;
+server_names_hash_max_size 1024;
+# Requests per second, per client address
+limit_req_zone $binary_remote_addr zone=general:10m rate=50r/s;
+# Simultaneous connections, per client address
+limit_conn_zone $binary_remote_addr zone=addr:10m;
+# Gzip compression
+gzip on;
+gzip_vary on;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_min_length 1000;
+gzip_types text/plain text/css text/xml application/json application/javascript application/xml+rss application/atom+xml image/svg+xml;
+# WebSocket upgrade map
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' '';
+}
+# Access log format
+log_format main '$remote_addr - $host [$time_local] "$request" '
+                '$status $body_bytes_sent "$http_referer" '
+                '"$http_user_agent" $request_time';
+access_log /var/log/nginx/access.log main;
+
+upstream upstreamm_madock_<PORT1> {
+  keepalive 512;
+  server host.docker.internal:<PORT1> max_fails=3 fail_timeout=30s;
+}
+upstream upstreamm_madock_<PORT2> {
+  server host.docker.internal:<PORT2> max_fails=3 fail_timeout=30s;
+}
+upstream upstreamm_madock_<PORT3> {
+  server host.docker.internal:<PORT3> max_fails=3 fail_timeout=30s;
+}
+
+server {
+        listen 80;
+        server_name  goldenfirst.test;
+        location / {
+            limit_req zone=general burst=200 nodelay;
+            limit_conn addr 100;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   Host      $http_host;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            client_max_body_size       128M;
+            client_body_buffer_size    512k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+            send_timeout 60s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+            proxy_pass         http://upstreamm_madock_<PORT1>;
+        }
+
+        location /phpmyadmin/ {
+            proxy_pass         http://host.docker.internal:<PORT4>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /phpmyadmin2/ {
+            proxy_pass         http://host.docker.internal:<PORT5>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /kibana/ {
+            proxy_pass         http://host.docker.internal:<PORT6>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /opensearch-dashboard/ {
+            proxy_pass         http://host.docker.internal:<PORT7>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /grafana/ {
+            proxy_pass         http://host.docker.internal:<PORT8>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /grafana/api/live/ {
+            rewrite ^/grafana/(.*) /$1 break;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_pass http://host.docker.internal:<PORT8>;
+        }
+}
+
+server {
+        listen 443 ssl;
+        http2 on;
+        server_name  goldenfirst.test;
+        location / {
+            limit_req zone=general burst=200 nodelay;
+            limit_conn addr 100;
+            proxy_set_header   X-Real-IP $remote_addr;
+            # $http_host, not $host: the latter drops the port, and this stack
+            # is regularly published somewhere other than 443. The unsecure
+            # server above has always done it this way.
+            proxy_set_header   Host      $http_host;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            client_max_body_size       128M;
+            client_body_buffer_size    512k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+            send_timeout 60s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+            proxy_pass         http://upstreamm_madock_<PORT1>;
+        }
+
+        location /phpmyadmin/ {
+            proxy_pass         http://host.docker.internal:<PORT4>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /phpmyadmin2/ {
+            proxy_pass         http://host.docker.internal:<PORT5>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /kibana/ {
+            proxy_pass         http://host.docker.internal:<PORT6>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /opensearch-dashboard/ {
+            proxy_pass         http://host.docker.internal:<PORT7>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /grafana/ {
+            proxy_pass         http://host.docker.internal:<PORT8>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /grafana/api/live/ {
+            rewrite ^/grafana/(.*) /$1 break;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_pass http://host.docker.internal:<PORT8>;
+        }
+
+        ssl_certificate /sslcert/fullchain.crt;
+        ssl_certificate_key /sslcert/madock.local.key;
+        include /sslcert/options-ssl-nginx.conf;
+}
+
+server {
+        listen 35729;
+        server_name  goldenfirst.test;
+        location / {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $http_host;
+            proxy_read_timeout 86400;
+            proxy_pass http://upstreamm_madock_<PORT2>/;
+        }
+}
+
+server {
+        listen 5173;
+        server_name  goldenfirst.test;
+        location / {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $http_host;
+            proxy_read_timeout 86400;
+            proxy_pass http://upstreamm_madock_<PORT3>/;
+        }
+}
+
+upstream upstreamm_madock_<PORT9> {
+  keepalive 512;
+  server host.docker.internal:<PORT9> max_fails=3 fail_timeout=30s;
+}
+upstream upstreamm_madock_<PORT10> {
+  server host.docker.internal:<PORT10> max_fails=3 fail_timeout=30s;
+}
+upstream upstreamm_madock_<PORT11> {
+  server host.docker.internal:<PORT11> max_fails=3 fail_timeout=30s;
+}
+
+server {
+        listen 80;
+        server_name  goldensecond.test;
+        location / {
+            limit_req zone=general burst=200 nodelay;
+            limit_conn addr 100;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   Host      $http_host;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            client_max_body_size       128M;
+            client_body_buffer_size    512k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+            send_timeout 60s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+            proxy_pass         http://upstreamm_madock_<PORT9>;
+        }
+
+        location /phpmyadmin/ {
+            proxy_pass         http://host.docker.internal:<PORT12>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /phpmyadmin2/ {
+            proxy_pass         http://host.docker.internal:<PORT13>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /kibana/ {
+            proxy_pass         http://host.docker.internal:<PORT14>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /opensearch-dashboard/ {
+            proxy_pass         http://host.docker.internal:<PORT15>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /grafana/ {
+            proxy_pass         http://host.docker.internal:<PORT16>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /grafana/api/live/ {
+            rewrite ^/grafana/(.*) /$1 break;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_pass http://host.docker.internal:<PORT16>;
+        }
+}
+
+server {
+        listen 443 ssl;
+        http2 on;
+        server_name  goldensecond.test;
+        location / {
+            limit_req zone=general burst=200 nodelay;
+            limit_conn addr 100;
+            proxy_set_header   X-Real-IP $remote_addr;
+            # $http_host, not $host: the latter drops the port, and this stack
+            # is regularly published somewhere other than 443. The unsecure
+            # server above has always done it this way.
+            proxy_set_header   Host      $http_host;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            client_max_body_size       128M;
+            client_body_buffer_size    512k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+            send_timeout 60s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+            proxy_pass         http://upstreamm_madock_<PORT9>;
+        }
+
+        location /phpmyadmin/ {
+            proxy_pass         http://host.docker.internal:<PORT12>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /phpmyadmin2/ {
+            proxy_pass         http://host.docker.internal:<PORT13>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /kibana/ {
+            proxy_pass         http://host.docker.internal:<PORT14>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /opensearch-dashboard/ {
+            proxy_pass         http://host.docker.internal:<PORT15>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        location /grafana/ {
+            proxy_pass         http://host.docker.internal:<PORT16>/;
+            proxy_redirect     off;
+
+            proxy_set_header   Host             $host;
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+
+            client_max_body_size       128M;
+            client_body_buffer_size    256k;
+
+            proxy_connect_timeout      60s;
+            proxy_send_timeout         300s;
+            proxy_read_timeout         300s;
+
+            proxy_buffer_size          256k;
+            proxy_buffers              256 16k;
+            proxy_busy_buffers_size    256k;
+            proxy_temp_file_write_size 256k;
+        }
+
+        # Proxy Grafana Live WebSocket connections.
+        location /grafana/api/live/ {
+            rewrite ^/grafana/(.*) /$1 break;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_pass http://host.docker.internal:<PORT16>;
+        }
+
+        ssl_certificate /sslcert/fullchain.crt;
+        ssl_certificate_key /sslcert/madock.local.key;
+        include /sslcert/options-ssl-nginx.conf;
+}
+
+server {
+        listen 35729;
+        server_name  goldensecond.test;
+        location / {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $http_host;
+            proxy_read_timeout 86400;
+            proxy_pass http://upstreamm_madock_<PORT10>/;
+        }
+}
+
+server {
+        listen 5173;
+        server_name  goldensecond.test;
+        location / {
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $http_host;
+            proxy_read_timeout 86400;
+            proxy_pass http://upstreamm_madock_<PORT11>/;
+        }
+}
+
+server {
+    listen       80  default_server;
+    listen 443 default_server ssl;
+    http2 on;
+    server_name  _;
+    return       444;
+    ssl_certificate /sslcert/fullchain.crt;
+    ssl_certificate_key /sslcert/madock.local.key;
+    include /sslcert/options-ssl-nginx.conf; 
+}
+
+}

--- a/src/helper/testenv/testenv.go
+++ b/src/helper/testenv/testenv.go
@@ -112,7 +112,59 @@ func SetupWith(t *testing.T, projectName, hostName string, overrides map[string]
 	// Clean config cache so the new env vars are picked up
 	configs.CleanCache()
 
-	// Create project config via SaveInFile with Magento 2.4.8 settings
+	writeProjectConfig(execDir, runDir, projectName, hostName, overrides)
+
+	// Reset global port registry so it re-reads from the new execDir
+	ports.ResetRegistry()
+
+	return &Env{
+		ExecDir:     execDir,
+		RunDir:      runDir,
+		ProjectName: projectName,
+	}
+}
+
+// AddProject puts a second project into an installation Setup already made.
+//
+// One project is enough for everything generated *inside* a project, and that is
+// what every fixture covered until now. The shared proxy is the exception: it is
+// one file describing every project on the machine, so the interesting part of
+// it — that two projects get their own upstreams, their own server blocks and
+// their own ports, and that neither overwrites the other — cannot be rendered
+// from a single project at all.
+//
+// The second project lives in the same installation and gets a run directory of
+// its own. MADOCK_RUN_DIR moves with it, because that is how madock decides
+// which project it is being asked about.
+func AddProject(t *testing.T, env *Env, projectName, hostName string, overrides map[string]string) *Env {
+	t.Helper()
+
+	runDir := filepath.Join(filepath.Dir(env.RunDir), "run-"+projectName)
+	for _, dir := range []string{
+		runDir,
+		filepath.Join(env.ExecDir, "projects", projectName, "docker", "ctx"),
+		filepath.Join(env.ExecDir, "aruntime", "projects", projectName, "ctx"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create dir %s: %v", dir, err)
+		}
+	}
+
+	t.Setenv("MADOCK_RUN_DIR", runDir)
+	configs.CleanCache()
+
+	writeProjectConfig(env.ExecDir, runDir, projectName, hostName, overrides)
+
+	return &Env{
+		ExecDir:     env.ExecDir,
+		RunDir:      runDir,
+		ProjectName: projectName,
+	}
+}
+
+// writeProjectConfig writes one project's configuration, defaults first and the
+// caller's overrides on top.
+func writeProjectConfig(execDir, runDir, projectName, hostName string, overrides map[string]string) {
 	projectConfigPath := filepath.Join(execDir, "projects", projectName, "config.xml")
 	projectConfigData := map[string]string{
 		"platform":                                  "magento2",
@@ -223,14 +275,6 @@ func SetupWith(t *testing.T, projectName, hostName string, overrides map[string]
 
 	// Clean cache again after writing config
 	configs.CleanCache()
-	// Reset global port registry so it re-reads from the new execDir
-	ports.ResetRegistry()
-
-	return &Env{
-		ExecDir:     execDir,
-		RunDir:      runDir,
-		ProjectName: projectName,
-	}
 }
 
 // Collect reads every generated file, with the machine-specific parts


### PR DESCRIPTION
`proxy.conf` is one file describing every project on the machine, rebuilt whenever any one of them is generated. The failure only it can have is a project losing its block, or taking the neighbour's port — and against a single project both are invisible, because there is one of everything to compare against. The existing proxy golden renders one project; this one renders two.

`testenv` grew `AddProject` for it — a second project inside the same installation, with its own run directory and `MADOCK_RUN_DIR` moved to match, which is how madock decides which project it is being asked about. The setup path is now one config writer shared by both, rather than a second copy of ninety keys.

The fixture holds four server blocks per project and three upstreams, ports masked by position exactly as the single-project golden does, so a block pointing at the neighbour's port still shows as a difference rather than as an equal-looking number.

This does not replace the e2e neighbour test and is not meant to: that one needs docker, takes minutes, and answers "the neighbour is unreachable" where a golden answers with the line that moved.