### PR TITLE
status: name the container the configuration dropped, do not remove it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**Unreleased**
+
+Fixed:
+- **`status` named a container the project no longer has as one of its services.** `docker compose ps` lists by project rather than by file — the project name comes from the directory the compose file sits in — so a container created from an earlier version of that file keeps being reported after its service is gone from the configuration. Turning `db/enabled` off, or moving a project onto a shared database, left the old container running and `status` calling it a service
+- **It hid a real defect for a day, which is how it was found.** A project whose config said `db/type: MariaDB` generated a compose file with no `db` service at all, and `status --json` went on listing `db` as running — so the first test written for that bug passed against the broken build, and only reading the generated file showed the truth. A status that invents a service is worse than one that says nothing, because it is believed
+- Named, not removed, and that is the decision rather than an omission. The compose file is generated from a config, so a rendering bug decides what counts as an orphan: `--remove-orphans` on `up` would have pointed the deletion at a running database container in exactly the case above. `orphan` is a field in `--json`, absent for ordinary services, and a phrase on the human line
+- The list of services is asked of compose (`config --services`) rather than parsed out of the YAML, so the answer is the one `up` acts on — override files and interpolation included. When compose cannot be asked, or answers with nothing, no container is flagged: an unanswered check must not become "everything here is a leftover"
+
 **v4.0.0**
 
 Changed:

--- a/src/controller/general/status/orphan.go
+++ b/src/controller/general/status/orphan.go
@@ -1,0 +1,98 @@
+package status
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/faradey/madock/v4/src/helper/paths"
+)
+
+// markOrphans flags containers that belong to this compose project but are not
+// among the services its files declare.
+//
+// `docker compose ps` lists by project, not by file: the project name comes from
+// the directory the compose file sits in, so a container created from an earlier
+// version of that file keeps being reported after the service is gone from it.
+// `status` presented those as ordinary services, which is a wrong answer rather
+// than a missing one — and it hid a real defect for a day. A project whose config
+// said `db/type: MariaDB` generated a compose file with **no db service at all**,
+// and `status --json` went on listing `db` as running, so a test written against
+// `status` passed against the broken build. Only reading the generated file
+// showed the truth.
+//
+// Reported, never removed. `--remove-orphans` would delete them, and that is the
+// wrong trade here: the compose file is generated from a config, so a rendering
+// bug decides what counts as an orphan — and the very bug above would then have
+// aimed the deletion at a running database container. Naming the container costs
+// nothing and cannot destroy anything; the person reading it can decide.
+//
+// `known` false means the question could not be asked, and then nothing is
+// flagged: an unanswered check must not turn into "everything here is an orphan".
+func markOrphans(services []ServiceStatus, known map[string]bool, ok bool) []ServiceStatus {
+	if !ok || len(services) == 0 {
+		return services
+	}
+
+	for i := range services {
+		// A container compose could not name a service for is not evidence of
+		// anything — it is compose declining to answer, and the whole point of
+		// this is to stop turning silence into a claim.
+		if services[i].Service == "" {
+			continue
+		}
+		if !known[services[i].Service] {
+			services[i].Orphan = true
+		}
+	}
+
+	return services
+}
+
+// definedServices asks compose which services a stack's files declare.
+//
+// Asked of docker rather than read out of the YAML, because the answer has to be
+// the same one `up` acts on: the override file, profiles and any interpolation
+// are compose's to resolve, and a second implementation here would disagree with
+// it on exactly the projects where it matters. The override is included when it
+// exists for the same reason — `up` passes both, so a service declared only there
+// is not an orphan.
+//
+// The second return value is whether the question was answered at all.
+func definedServices(composePath, overridePath string) (map[string]bool, bool) {
+	if !paths.IsFileExist(composePath) {
+		return nil, false
+	}
+
+	args := []string{"compose", "-f", composePath}
+	if overridePath != "" && paths.IsFileExist(overridePath) {
+		args = append(args, "-f", overridePath)
+	}
+	args = append(args, "config", "--services")
+
+	cmd := exec.Command("docker", args...)
+	// stdout only: compose writes its deprecation warnings to stderr, and folding
+	// them in here would turn a warning into a service name.
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, false
+	}
+
+	known := map[string]bool{}
+	for _, line := range strings.Split(string(out), "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			known[name] = true
+		}
+	}
+
+	// An empty list is not an answer worth acting on. A stack always declares
+	// something, so nothing coming back means compose printed to a place this did
+	// not read, and flagging every running container as an orphan on the strength
+	// of that would be the loudest possible way to be wrong.
+	if len(known) == 0 {
+		return nil, false
+	}
+
+	return known, true
+}

--- a/src/controller/general/status/orphan_test.go
+++ b/src/controller/general/status/orphan_test.go
@@ -1,0 +1,65 @@
+package status
+
+import "testing"
+
+// The bug this exists for: `docker compose ps` lists by project, not by file, so
+// a container created from an earlier version of the compose file keeps being
+// reported after its service is gone from the configuration. `status` presented
+// those as ordinary services — a wrong answer rather than a missing one.
+//
+// It hid a real defect for a day. A project whose config said `db/type: MariaDB`
+// generated a compose file with no db service at all, and `status --json` went on
+// listing `db` as running; a test written against `status` therefore passed
+// against the broken build, and only reading the generated file showed the truth.
+func TestMarkOrphansNamesWhatTheConfigurationNoLongerHas(t *testing.T) {
+	services := []ServiceStatus{
+		{Service: "app", State: "running", Running: true},
+		{Service: "db", State: "running", Running: true},
+		{Service: "mailpit", State: "exited"},
+	}
+	// nginx is declared and not running, which is why it is in the set and not in
+	// the list: the two sides answer different questions and the check is the
+	// difference between them.
+	known := map[string]bool{"app": true, "nginx": true}
+
+	got := markOrphans(services, known, true)
+
+	if got[0].Orphan {
+		t.Error("app is declared and must not be flagged")
+	}
+	if !got[1].Orphan {
+		t.Error("db is running and is not in the configuration — that is the whole finding")
+	}
+	// State has nothing to do with it: a stopped leftover is as much a leftover
+	// as a running one. The running one is the dangerous half, because it looks
+	// exactly like the project working.
+	if !got[2].Orphan {
+		t.Error("mailpit is not in the configuration; a stopped leftover is still a leftover")
+	}
+}
+
+// An unanswered question must not become a claim. If compose could not be asked
+// which services exist, nothing is flagged — the alternative is a status that
+// calls every running container an orphan the first time docker is slow.
+func TestMarkOrphansFlagsNothingWhenItCouldNotAsk(t *testing.T) {
+	services := []ServiceStatus{
+		{Service: "app", State: "running", Running: true},
+		{Service: "db", State: "running", Running: true},
+	}
+
+	for _, s := range markOrphans(services, nil, false) {
+		if s.Orphan {
+			t.Errorf("%s was flagged on an answer nobody has: unknown is not the same as absent", s.Service)
+		}
+	}
+}
+
+// A container compose could not name a service for is compose declining to
+// answer, not evidence of anything.
+func TestMarkOrphansIgnoresAContainerWithNoServiceName(t *testing.T) {
+	services := []ServiceStatus{{Name: "stray-container", Service: "", State: "running", Running: true}}
+
+	if markOrphans(services, map[string]bool{"app": true}, true)[0].Orphan {
+		t.Error("a container with no service name was flagged; that is silence being read as a fact")
+	}
+}

--- a/src/controller/general/status/status.go
+++ b/src/controller/general/status/status.go
@@ -45,6 +45,11 @@ type ServiceStatus struct {
 	Service string `json:"service"`
 	State   string `json:"state"`
 	Running bool   `json:"running"`
+	// Orphan marks a container that belongs to this compose project but is not
+	// among the services its files declare — left behind by an earlier version
+	// of the configuration. Absent for the ordinary case, so a script reading
+	// this can treat its presence as the exception it is.
+	Orphan bool `json:"orphan,omitempty"`
 }
 
 type ToolsStatus struct {
@@ -67,9 +72,16 @@ func Execute() {
 
 	// Get services status
 	servicesData := getContainerStatus(pp.DockerCompose())
+	knownServices, servicesKnown := definedServices(pp.DockerCompose(), pp.DockerComposeOverride())
+	servicesData = markOrphans(servicesData, knownServices, servicesKnown)
 
 	// Get proxy status
 	proxyData := getContainerStatus(paths.ProxyDockerCompose())
+	// The proxy has the same problem and a documented instance of it: disabling
+	// mailpit leaves its container behind, and it went on being listed as one of
+	// the proxy's services.
+	knownProxy, proxyKnown := definedServices(paths.ProxyDockerCompose(), "")
+	proxyData = markOrphans(proxyData, knownProxy, proxyKnown)
 
 	// Get tools status
 	projectConf := configs.GetCurrentProjectConfig()
@@ -104,12 +116,7 @@ func Execute() {
 	fmtc.TitleLn("Services:")
 	if len(servicesData) > 0 {
 		for _, val := range servicesData {
-			row := fmt.Sprintf("%s %s", val.Service, val.State)
-			if val.Running {
-				fmtc.SuccessLn(row)
-			} else {
-				fmtc.WarningLn(row)
-			}
+			printServiceRow(val, "")
 		}
 	} else {
 		fmtc.WarningLn("No services found")
@@ -118,12 +125,7 @@ func Execute() {
 	fmtc.TitleLn("Proxy:")
 	if len(proxyData) > 0 {
 		for _, val := range proxyData {
-			row := fmt.Sprintf(" %s %s", val.Service, val.State)
-			if val.Running {
-				fmtc.SuccessLn(row)
-			} else {
-				fmtc.WarningLn(row)
-			}
+			printServiceRow(val, " ")
 		}
 	} else {
 		fmtc.WarningLn("No services found")
@@ -155,6 +157,25 @@ func Execute() {
 		fmtc.SuccessLn(" Debugger is enabled")
 	} else {
 		fmtc.WarningLn(" Debugger is disabled")
+	}
+}
+
+// printServiceRow writes one line of the human output.
+//
+// An orphan is printed as a warning whatever its state, and said in words rather
+// than left to be inferred from a name the reader is not expecting: a container
+// running here is not the project working, it is the previous configuration
+// still running, and those two look identical in a list.
+func printServiceRow(val ServiceStatus, indent string) {
+	row := fmt.Sprintf("%s%s %s", indent, val.Service, val.State)
+	if val.Orphan {
+		fmtc.WarningLn(row + " — orphan: not in this project's configuration any more")
+		return
+	}
+	if val.Running {
+		fmtc.SuccessLn(row)
+	} else {
+		fmtc.WarningLn(row)
 	}
 }
 

--- a/test/e2e/orphan_test.go
+++ b/test/e2e/orphan_test.go
@@ -1,0 +1,105 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStatusNamesAContainerTheConfigurationDropped is the lie this was written
+// against, reproduced the way it happened.
+//
+// `docker compose ps` lists by project, not by file: the project name comes from
+// the directory the compose file sits in, so a container created from an earlier
+// version of that file keeps being reported after the service is gone from it.
+// `status` presented those as ordinary services.
+//
+// It hid a real defect for a day. A project whose config said `db/type: MariaDB`
+// generated a compose file with **no db service at all**, and `status --json`
+// went on listing `db` as running — so the first version of the test written for
+// that bug passed against the broken build, and only reading the generated file
+// showed the truth. A status that invents a service is worse than one that says
+// nothing, because it is believed.
+//
+// Nothing is removed here, and that is the decision rather than an omission. The
+// compose file is generated from a config, so a rendering bug decides what counts
+// as an orphan — `--remove-orphans` on `up` would have pointed the deletion at a
+// running database container in exactly the case above.
+func TestStatusNamesAContainerTheConfigurationDropped(t *testing.T) {
+	p := newProject(t, "e2eorphan")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2eorphan.test",
+	)
+	p.run(20*time.Minute, "start")
+
+	if !p.runningServices(t, "after start")["db"] {
+		t.Fatal("the project came up without a database, so this test has nothing to orphan")
+	}
+
+	// The service leaves the configuration. The container does not leave with it
+	// — that is the state under test, and it is an ordinary one: `db/enabled` is
+	// how a project says it has no database of its own, and any project moving to
+	// a shared database goes through exactly this.
+	p.run(2*time.Minute, "config:set", "-n", "db/enabled", "-v", "false")
+	p.run(20*time.Minute, "start")
+
+	generated := readFile(t, p.generated("docker-compose.yml"))
+	if strings.Contains(generated, "\n  db:") {
+		t.Fatalf("db is still declared in the compose file, so nothing was orphaned:\n%s", generated)
+	}
+
+	// The text output has to say the word, because the failure is that a reader
+	// takes the line for a working service.
+	human := p.run(2*time.Minute, "status")
+	if strings.Contains(human, "db running") && !strings.Contains(human, "orphan") {
+		t.Errorf("status listed db as a service of this project without naming it a leftover:\n%s", human)
+	}
+
+	// And the JSON, which is what a script reads. `orphan` is absent for an
+	// ordinary service and present here, so its presence is the exception.
+	var payload struct {
+		Data struct {
+			Services []struct {
+				Service string `json:"service"`
+				Running bool   `json:"running"`
+				Orphan  bool   `json:"orphan"`
+			} `json:"services"`
+		} `json:"data"`
+	}
+	decode(t, p.run(3*time.Minute, "status", "--json"), &payload, "status --json")
+
+	for _, service := range payload.Data.Services {
+		if service.Service == "db" && !service.Orphan {
+			t.Errorf("status --json reported db as a service of this project: %+v", payload.Data.Services)
+		}
+		if service.Service == "app" && service.Orphan {
+			t.Errorf("app is declared and was flagged as a leftover: %+v", payload.Data.Services)
+		}
+	}
+}
+
+// runningServices reads the project's own services out of `status --json`.
+func (p *project) runningServices(t *testing.T, what string) map[string]bool {
+	t.Helper()
+
+	var payload struct {
+		Data struct {
+			Services []struct {
+				Service string `json:"service"`
+				Running bool   `json:"running"`
+			} `json:"services"`
+		} `json:"data"`
+	}
+	decode(t, p.run(3*time.Minute, "status", "--json"), &payload, "status --json "+what)
+
+	running := map[string]bool{}
+	for _, service := range payload.Data.Services {
+		running[service.Service] = service.Running
+	}
+	return running
+}


### PR DESCRIPTION
`docker compose ps` lists by **project**, not by file — the project name comes
from the directory the compose file sits in — so a container created from an
earlier version of that file keeps being reported after its service is gone from
the configuration. `status` presented those as ordinary services.

## How it was found

It hid a real defect for a day. A project whose config said `db/type: MariaDB`
generated a compose file with **no `db` service at all**, and `status --json`
went on listing `db` as running. The first test written for that bug therefore
passed against the broken build, and only reading the generated file showed the
truth. A status that invents a service is worse than one that says nothing,
because it is believed.

## Named, not removed — the decision, not an omission

The compose file is **generated from a config**, so a rendering bug decides what
counts as an orphan. `--remove-orphans` on `up` would have pointed the deletion
at a running database container in exactly the case above. Named volumes would
have survived it, which is not much comfort.

So: `orphan` is a field in `--json`, absent for ordinary services, and a phrase
on the human line. A person decides what to do about it.

## Two things that keep it honest

- The service list is asked of compose (`config --services`) rather than parsed
  out of the YAML, so it is the answer `up` acts on — override files and
  interpolation included. A second implementation here would disagree with
  compose on exactly the projects where it matters.
- Compose unable to answer, or answering with nothing, flags **no** container.
  An unanswered check must not turn into "everything here is a leftover".

## Verified

Unit tests cover the classification, including the could-not-ask case and a
container compose gives no service name for.

The e2e reproduces the state the way it happens — `db/enabled` off, which is also
how a project moves to a shared database. **Run against `b39913c` (master without
this change) it fails**, reporting `{Service:db Running:true Orphan:false}` with
no `db` in the generated compose file; it passes on this branch.

No version bump — this rides the next release.
