### PR TITLE
Say when the binary is older than the templates it renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v4.0.2**
+
+Added:
+- **A binary older than the templates it renders now says so, before the command runs.** In a source checkout the two arrive separately — git delivers `docker/`, a build delivers the binary — and nothing married them, so a `git pull` silently left the installation half-updated. Measured 2026-08-23 on this machine: a 3.9.17 binary built on 19 August against a 4.0.1 tree merged on 21 August, with the php snippets reorganised in between. Every rebuild ended on `failed to read dockerfile: open php.Dockerfile: no such file or directory` — **after the containers were already down**, because `rebuild` destroys them and generates the build context afterwards. Any project on the machine would have hit it on its first rebuild, not only the one that did
+- Nothing could have shown it earlier: `--version` answers for the binary alone, and there is no second version beside it to disagree with. The check compares the templates compiled into the running binary against the ones on disk, so it answers the exact question — *was this binary built from these templates* — rather than asking a clock. Timestamps were the obvious implementation and the wrong one: `git checkout` rewrites mtimes on files it restored and leaves them on files it did not change
+- It warns and does not stop. From source the renderer reads templates off disk, so editing one and running a command is the development loop working — refusing there would break the workflow the drift is normal in. It says how many differ, names three, and gives the `go build` line
+- Silent wherever extraction owns the tree: a downloaded binary unpacks its own snapshot and stamps it, and madock-pro's installation gets `docker/` the same way because the assets belong to the imported module. Neither has a compiler to act on the warning, and in both the two cannot disagree
+
 **v4.0.1**
 
 Added:

--- a/src/app/app.go
+++ b/src/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -21,6 +22,7 @@ import (
 func Run(appVersion string) {
 	log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
 	embedded.ExtractIfNeeded(appVersion)
+	reportTemplateDrift()
 	migration.Apply(appVersion)
 
 	if len(os.Args) <= 1 {
@@ -46,6 +48,39 @@ func Run(appVersion string) {
 	} else {
 		isnotdefine.Execute(cmdName)
 	}
+}
+
+// reportTemplateDrift says, before any command runs, that this binary was not
+// built from the templates it is about to render.
+//
+// It warns and does not stop. On a source checkout the renderer reads the
+// templates off disk, so editing one and running a command is the development
+// loop working as intended — refusing there would break the very workflow the
+// drift is normal in. What is not normal is drift a person did not create, and
+// they cannot tell the two apart without being told the first one exists.
+//
+// The place is here rather than in rebuild, even though rebuild is what the
+// failure destroys: by the time a handler runs, the answer has to be repeated in
+// every command that renders a template, and the one that bites is whichever one
+// nobody added it to.
+func reportTemplateDrift() {
+	drift := embedded.TemplateDrift()
+	if drift == nil {
+		return
+	}
+
+	fmtc.WarningIconLn("This binary was built from different templates than the ones in this tree — " +
+		fmt.Sprintf("%d changed, %d missing from disk, %d new to it", len(drift.Changed), len(drift.Missing), len(drift.Extra)))
+
+	for _, path := range drift.Examples(3) {
+		fmtc.WarningLn("  docker/" + path)
+	}
+	if remainder := drift.Total() - 3; remainder > 0 {
+		fmtc.WarningLn(fmt.Sprintf("  and %d more", remainder))
+	}
+
+	fmtc.ToDoLn("Rebuild it — go build -o madock . in " + paths.GetExecDirPath() +
+		" — unless you are editing templates and know why they differ")
 }
 
 // wantsHelp reports whether the arguments ask for the command's help.

--- a/src/helper/embedded/stale.go
+++ b/src/helper/embedded/stale.go
@@ -1,0 +1,175 @@
+package embedded
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/faradey/madock/v4/src/helper/paths"
+)
+
+// Drift is the disagreement between the templates a binary was built from and
+// the ones it is about to render.
+type Drift struct {
+	// Changed exists in both and differs.
+	Changed []string
+	// Missing is in the binary and not on disk.
+	Missing []string
+	// Extra is on disk and not in the binary.
+	Extra []string
+}
+
+// Total counts everything that disagrees.
+func (d *Drift) Total() int {
+	if d == nil {
+		return 0
+	}
+
+	return len(d.Changed) + len(d.Missing) + len(d.Extra)
+}
+
+// Examples names a few of the differing paths, for a message that has to fit on
+// a screen. Missing and Extra come first: a changed template usually still
+// renders, while one that has moved is what stops a build.
+func (d *Drift) Examples(limit int) []string {
+	if d == nil {
+		return nil
+	}
+
+	out := make([]string, 0, limit)
+	for _, group := range [][]string{d.Missing, d.Extra, d.Changed} {
+		for _, path := range group {
+			if len(out) == limit {
+				return out
+			}
+			out = append(out, path)
+		}
+	}
+
+	return out
+}
+
+// TemplateDrift reports templates on disk that the running binary was not built
+// from, and nil when there is nothing to say.
+//
+// **Only a source checkout can drift.** Everywhere else the two are kept
+// together by construction: a downloaded binary extracts its own snapshot and
+// stamps it, and madock-pro's installation gets docker/ the same way because the
+// assets belong to the imported module. In a clone they are separate objects —
+// git delivers the templates, a build delivers the binary — and nothing married
+// them.
+//
+// What that cost, measured 2026-08-23: the live binary was 3.9.17 built 19
+// August, the tree was 4.0.1 merged 21 August, and the php snippets had been
+// reorganised in between. Every rebuild ended as
+//
+//	target php: failed to solve: failed to read dockerfile: open php.Dockerfile: no such file or directory
+//
+// with the containers already destroyed — rebuild takes them down before it
+// generates the build context. Nothing said the binary was old: `--version`
+// answers for the binary alone, and there was no second version to compare it
+// with. The drift was only ever visible as a failed rebuild, which is after the
+// damage.
+//
+// The comparison is content, not timestamps. `git checkout` rewrites mtimes on
+// files it did not change and leaves them on files it restored, so a clock
+// answers a question nobody asked; the embedded snapshot is what this binary
+// actually knows, so comparing it against the disk answers exactly "was this
+// binary built from these templates".
+func TemplateDrift() *Drift {
+	if DockerFS == nil {
+		return nil
+	}
+
+	execDir := paths.GetExecDirPath()
+	if !isSourceCheckout(execDir) {
+		return nil
+	}
+
+	root := filepath.Join(execDir, "docker")
+	drift := &Drift{}
+	inBinary := map[string]bool{}
+
+	fs.WalkDir(DockerFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || path == "." || d.IsDir() {
+			return err
+		}
+
+		inBinary[path] = true
+
+		embeddedBody, err := fs.ReadFile(DockerFS, path)
+		if err != nil {
+			return nil
+		}
+
+		onDisk, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(path)))
+		if err != nil {
+			drift.Missing = append(drift.Missing, path)
+			return nil
+		}
+
+		if !bytes.Equal(embeddedBody, onDisk) {
+			drift.Changed = append(drift.Changed, path)
+		}
+
+		return nil
+	})
+
+	collectExtra(root, inBinary, drift)
+
+	sort.Strings(drift.Changed)
+	sort.Strings(drift.Missing)
+	sort.Strings(drift.Extra)
+
+	if drift.Total() == 0 {
+		return nil
+	}
+
+	return drift
+}
+
+// collectExtra finds files on disk that the binary has never heard of — the half
+// of the drift the embedded walk cannot see, and the half a reorganised template
+// tree shows up as.
+//
+// It descends only into the top-level directories the embed itself contains,
+// which is what keeps it from reporting docker/embed.go and the tests beside it:
+// the //go:embed patterns name asset directories, so everything at the root of
+// docker/ is source and belongs to no snapshot.
+func collectExtra(root string, inBinary map[string]bool, drift *Drift) {
+	tops, err := fs.ReadDir(DockerFS, ".")
+	if err != nil {
+		return
+	}
+
+	for _, top := range tops {
+		if !top.IsDir() {
+			continue
+		}
+
+		filepath.WalkDir(filepath.Join(root, top.Name()), func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			// macOS writes these into any directory that has been opened in
+			// Finder. They are in no embed and never will be, so reporting them
+			// would make the check cry wolf on every machine it runs on.
+			if d.Name() == ".DS_Store" {
+				return nil
+			}
+
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return nil
+			}
+
+			if slash := filepath.ToSlash(rel); !inBinary[slash] {
+				drift.Extra = append(drift.Extra, slash)
+			}
+
+			return nil
+		})
+	}
+}

--- a/src/helper/embedded/stale_test.go
+++ b/src/helper/embedded/stale_test.go
@@ -1,0 +1,152 @@
+package embedded
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+// sourceTree makes a temp directory look like a clone: the embed declaration is
+// what says the templates here are git's to deliver, so it is what makes drift
+// possible at all.
+func sourceTree(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("MADOCK_EXEC_DIR", dir)
+
+	if err := os.MkdirAll(filepath.Join(dir, "docker"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(sourceSentinel)), []byte("package dockerassets\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	return dir
+}
+
+func writeTemplate(t *testing.T, dir, rel, body string) {
+	t.Helper()
+
+	path := filepath.Join(dir, "docker", filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The incident this exists for, in miniature: the binary is older than the tree,
+// the php snippets have been reorganised under it, and the only way anyone found
+// out was a rebuild that had already destroyed the containers.
+func TestTemplateDrift_SeesABinaryOlderThanTheTree(t *testing.T) {
+	dir := sourceTree(t)
+
+	writeTemplate(t, dir, "snippets/dockerfile/php/header", "the new layout\n")
+	writeTemplate(t, dir, "general/docker-compose.yml", "edited\n")
+
+	DockerFS = fstest.MapFS{
+		// Where the snippet used to live, and where this binary still looks.
+		"snippets/dockerfile/php/nodejs": {Data: []byte("the old layout\n")},
+		"general/docker-compose.yml":     {Data: []byte("as built\n")},
+		"magento2/docker-compose.yml":    {Data: []byte("unchanged\n")},
+	}
+	t.Cleanup(func() { DockerFS = nil })
+
+	writeTemplate(t, dir, "magento2/docker-compose.yml", "unchanged\n")
+
+	drift := TemplateDrift()
+	if drift == nil {
+		t.Fatal("no drift reported against a tree the binary was not built from")
+	}
+
+	if len(drift.Missing) != 1 || drift.Missing[0] != "snippets/dockerfile/php/nodejs" {
+		t.Errorf("the withdrawn template was not reported as missing: %v", drift.Missing)
+	}
+	if len(drift.Extra) != 1 || drift.Extra[0] != "snippets/dockerfile/php/header" {
+		t.Errorf("the template the binary has never heard of was not reported: %v", drift.Extra)
+	}
+	if len(drift.Changed) != 1 || drift.Changed[0] != "general/docker-compose.yml" {
+		t.Errorf("the edited template was not reported as changed: %v", drift.Changed)
+	}
+}
+
+func TestTemplateDrift_SilentWhenTheyAgree(t *testing.T) {
+	dir := sourceTree(t)
+
+	writeTemplate(t, dir, "general/docker-compose.yml", "as built\n")
+
+	DockerFS = fstest.MapFS{
+		"general/docker-compose.yml": {Data: []byte("as built\n")},
+	}
+	t.Cleanup(func() { DockerFS = nil })
+
+	if drift := TemplateDrift(); drift != nil {
+		t.Fatalf("a binary built from these very templates was called stale: %+v", drift)
+	}
+}
+
+// Where extraction owns the tree the two cannot disagree, and a warning would be
+// noise on every customer installation and on madock-pro's — neither of which
+// has a compiler to act on it.
+func TestTemplateDrift_SaysNothingWhereExtractionOwnsTheTree(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MADOCK_EXEC_DIR", dir)
+
+	// No docker/embed.go: this is an extracted tree, not a clone.
+	if err := os.MkdirAll(filepath.Join(dir, "docker", "general"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docker", "general", "docker-compose.yml"), []byte("from an old binary\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	DockerFS = fstest.MapFS{
+		"general/docker-compose.yml": {Data: []byte("from the binary\n")},
+	}
+	t.Cleanup(func() { DockerFS = nil })
+
+	if drift := TemplateDrift(); drift != nil {
+		t.Fatalf("drift reported where extraction is responsible for the tree: %+v", drift)
+	}
+}
+
+// Finder writes these into any directory somebody has looked at, so counting
+// them would make the check warn on every Mac it runs on — including this one,
+// where docker/ already carries them.
+func TestTemplateDrift_IgnoresDSStore(t *testing.T) {
+	dir := sourceTree(t)
+
+	writeTemplate(t, dir, "general/docker-compose.yml", "as built\n")
+	writeTemplate(t, dir, "general/.DS_Store", "\x00\x00")
+
+	DockerFS = fstest.MapFS{
+		"general/docker-compose.yml": {Data: []byte("as built\n")},
+	}
+	t.Cleanup(func() { DockerFS = nil })
+
+	if drift := TemplateDrift(); drift != nil {
+		t.Fatalf("a Finder leftover was reported as drift: %+v", drift)
+	}
+}
+
+// The tests beside the templates are source, not assets — they are in no
+// //go:embed pattern and never will be, so reporting them would make the check
+// permanently wrong about madock's own tree.
+func TestTemplateDrift_IgnoresSourceBesideTheTemplates(t *testing.T) {
+	dir := sourceTree(t)
+
+	writeTemplate(t, dir, "general/docker-compose.yml", "as built\n")
+	writeTemplate(t, dir, "embed_test.go", "package dockerassets\n")
+
+	DockerFS = fstest.MapFS{
+		"general/docker-compose.yml": {Data: []byte("as built\n")},
+	}
+	t.Cleanup(func() { DockerFS = nil })
+
+	if drift := TemplateDrift(); drift != nil {
+		t.Fatalf("source at the root of docker/ was reported as drift: %+v", drift)
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.0.1"
+const Version = "4.0.2"


### PR DESCRIPTION
A source checkout gets its templates from git and its binary from a build, and nothing married the two. A pull therefore left the installation half-updated, and the only symptom was a rebuild that had already destroyed the containers.

Measured on this machine 2026-08-23: a 3.9.17 binary built on 19 August against a 4.0.1 tree merged on 21 August, with the php snippets reorganised in between. Every rebuild ended on

    target php: failed to solve: failed to read dockerfile: open php.Dockerfile: no such file or directory

after `rebuild` had taken the containers down — it destroys them and generates the build context afterwards. Any project on the machine would have hit it on its first rebuild, not only the one that did. Nothing could have shown it earlier: `--version` answers for the binary alone, and there is no second version beside it to disagree with.

## What it does

Compares the templates compiled into the running binary against the ones on disk, before the handler runs. That answers the exact question — was this binary built from these templates — rather than asking a clock. Timestamps were the obvious implementation and the wrong one: `git checkout` rewrites mtimes on files it restored and leaves them on files it did not change.

```
⚠ This binary was built from different templates than the ones in this tree — 0 changed, 0 missing from disk, 1 new to it
  docker/snippets/probe-drift.yml
Rebuild it — go build -o madock . in /Users/…/madock — unless you are editing templates and know why they differ
```

It warns and does not refuse. From source the renderer reads templates off disk, so editing one and running a command is the development loop working; refusing there would break the workflow the drift is normal in.

Silent wherever extraction owns the tree — a downloaded binary unpacks its own snapshot and stamps it, and madock-pro's installation gets `docker/` the same way because the assets belong to the imported module. Neither has a compiler to act on the warning, and in both the two cannot disagree.

## Verified

- Fires on real drift and is silent on the real 319-file tree, including the `.DS_Store` files and the `*_test.go` beside the templates, both excluded deliberately.
- Cost measured, not estimated: 0.015–0.019s against 0.033s without it, warm cache.
- `madock rebuild` end to end in the sandbox with the rebuilt binary: images built, three containers up, 7m17s, no `php.Dockerfile` failure.
- Five unit tests, and the whole `./src/...` suite green.
