### PR TITLE
Keep the database logs when an e2e test fails

### DIFF
--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -246,6 +246,8 @@ func (p *project) destroy() {
 		}
 		return
 	}
+	p.captureDatabaseLogs()
+
 	p.install.destroyProxy(p)
 	if out, err := p.tryRun(5*time.Minute, "project:remove", "--force", "--name="+p.name); err != nil {
 		p.t.Logf("cleanup of %s did not complete: %v\n%s", p.name, err, out)
@@ -259,6 +261,49 @@ func (p *project) destroy() {
 	// a directory this test created.
 	if out, err := exec.Command("sudo", "rm", "-rf", p.runDir).CombinedOutput(); err != nil {
 		p.t.Logf("could not remove %s as root: %v\n%s", p.runDir, err, out)
+	}
+}
+
+// databaseLogTail is how much of each database log a failure is worth. Enough to
+// hold a crash, a recovery and the start-up banner around it; short enough that a
+// failing run stays readable.
+const databaseLogTail = 120
+
+// captureDatabaseLogs puts the database containers' logs into the test output
+// when the test has already failed.
+//
+// It runs from the teardown, before `project:remove`, because that is the only
+// moment they still exist. A CI runner is discarded when the job ends, so a
+// database that misbehaved takes the only account of why with it — and the
+// failure this exists for is one nobody can reproduce on demand:
+// `TestSecondDatabaseImportsIntoItself` failed once in three runs of a full
+// suite, passed alone every time, and left nothing behind but the assertion that
+// a row was missing. A second occurrence with no logs would be worth as little
+// as the first.
+//
+// Both databases, not just the one a test names: the flake is in an import
+// aimed at db2 while db is the one with everything to lose, so the interesting
+// question is what each of them was doing. `logs` answers "no such container"
+// for a project without db2, which is an expected answer here rather than a
+// problem, so it is skipped quietly.
+//
+// Never on a passing test. Logs are only evidence when something needs
+// explaining, and printing them otherwise buries the runs that do.
+func (p *project) captureDatabaseLogs() {
+	if !p.t.Failed() {
+		return
+	}
+
+	for _, service := range []string{"db", "db2"} {
+		out, err := p.tryRun(2*time.Minute, "logs", "-s", service)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(out) == "" {
+			continue
+		}
+		p.t.Logf("--- %s %s: last %d lines of the container log ---\n%s",
+			p.name, service, databaseLogTail, lastLines(out, databaseLogTail))
 	}
 }
 


### PR DESCRIPTION
A CI runner is discarded when the job ends, so a database that misbehaved takes the only account of why with it.

`TestSecondDatabaseImportsIntoItself` failed once in three runs of a full suite, passed every time it was run alone, and left nothing behind but the assertion that a row was missing. A second occurrence with no logs would be worth as little as the first.

## What it does

On a test that has already failed, the teardown prints the last 120 lines of the `db` and `db2` container logs into the test output. Before `project:remove`, because that is the only moment the containers still exist.

Both databases rather than the one a test names: the flake is an import aimed at `db2` while `db` is the one with everything to lose, so the interesting question is what each of them was doing. A project without `db2` gets "no such container", which is the expected answer here and is skipped quietly.

Never on a passing test. Logs are evidence when something needs explaining; printed otherwise they bury the runs that do.

## Scope

Test harness only — no change to any command, and nothing here runs outside `-tags e2e`.

## Verified

Compiles and vets under the e2e tag, and the call is the same one `logs_test.go` already makes successfully. It is **not** verified against a live failure: it fires only when a test fails, and faking one to watch it print would prove nothing about the case it exists for. Its first real exercise is the next flake.
