### PR TITLE
debug:enable stops being a PHP command wearing a general name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+**v4.0.3**
+
+Added:
+- **`debug:enable` now debugs Node as well as PHP**, and on a project with both it turns on both rather than picking one. It was a PHP command wearing a general name: every one of its handlers wrote `php/xdebug/*`, so on a Node project it set a value nothing reads, rebuilt, and reported success — debugging simply absent, arranged by a command that said it had
+- **The two debuggers work in opposite directions, and that is the whole design.** Xdebug *connects out* to the IDE, which is why PHP debugging has never needed a compose change: nothing is published and no port is allocated. `node --inspect` *listens*, so the IDE connects in — which costs a published port, and it is taken from the registry like every other one. Never a fixed 9229: that is a number the second project to start debugging would fight over
+- **`madock info:ports` shows it with no change to that command**, as `nodejs_debug`. It prints every pair the registry holds, so allocating through the registry rather than writing a number into the template is what puts the port in front of the person who needs it
+- `NODE_OPTIONS` rather than a flag on the command, because the entrypoint execs `yarn dev` or `npm run dev` and the dev server is a child of that — a flag on the outer command dies with the package manager, an environment variable is inherited. It binds `0.0.0.0`, not node's default loopback, which inside a container is reachable by nothing
+- `nodejs/debug/break` stops the process before the first line and waits for the IDE. A separate switch and off by default: right for debugging a startup problem, and as a default it would make every debugged container look hung
+- **Node inside the application container (`nodejs/embedded/enabled`) is refused, by name.** It has no container of its own and therefore nothing to publish a port from, which is the entire mechanism its debugger needs — so the command says that and points at the setting that gives it one, instead of turning on a switch that renders nothing
+- The profiler stays PHP-only. `--cpu-prof` writes a file to open afterwards, which is a different command with a different answer, not this one with a second branch
+
 **v4.0.2**
 
 Added:

--- a/config.xml
+++ b/config.xml
@@ -173,6 +173,21 @@
                 <script></script>
                 <script_type>auto</script_type>
                 <browser_libs>false</browser_libs>
+                <!-- Node's debugger, turned on by `madock debug:enable`.
+
+                     Unlike xdebug it listens rather than connecting out, so it
+                     costs a published port — allocated from the registry like
+                     every other one, never a fixed 9229, which two projects
+                     debugging at once would fight over.
+
+                     `break` stops the process before the first line and waits
+                     for an IDE. Right for a startup problem and wrong for
+                     everything else, which is why it is a separate switch: as a
+                     default it would make every debugged container look hung. -->
+                <debug>
+                    <enabled>false</enabled>
+                    <break>false</break>
+                </debug>
                 <yarn>
                     <enabled>false</enabled>
                     <version>1.22.19</version>

--- a/docker/snippets/docker-compose/nodejs.yml
+++ b/docker/snippets/docker-compose/nodejs.yml
@@ -14,6 +14,27 @@
       # Harmless on Linux. Picked up by next/webpack/chokidar/medusa watcher.
       WATCHPACK_POLLING: "true"
       CHOKIDAR_USEPOLLING: "true"
+      {{{- if .nodejs.debug.enabled}}}
+      # NODE_OPTIONS rather than a flag on the command, because the entrypoint
+      # execs `yarn dev` / `npm run dev` and the dev server is a child of that.
+      # A flag on the outer command dies with the package manager; an
+      # environment variable is inherited by whatever it spawns.
+      #
+      # 0.0.0.0 and not the default 127.0.0.1: the IDE connects from outside the
+      # container, and a debugger bound to loopback inside it is reachable by
+      # nothing.
+      NODE_OPTIONS: "--inspect{{{if .nodejs.debug.break}}}-brk{{{end}}}=0.0.0.0:9229"
+      {{{- end}}}
+    {{{- if .nodejs.debug.enabled}}}
+    # The port inside the container is fixed and the one on the host is not:
+    # inside there is one node process and nothing to collide with, while two
+    # projects debugging at the same time would fight over a fixed host port.
+    # The registry is what keeps them apart, and it is also what puts the
+    # number into `madock info:ports` without that command knowing anything
+    # about debugging.
+    ports:
+      - "{{{port "nodejs_debug"}}}:9229"
+    {{{- end}}}
     volumes:
       - ./src:/var/www/html:cached
     extra_hosts:

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -158,10 +158,10 @@ This command shows you the following items:
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`--json, -j`     Output in JSON format
  
    
-* `debug:enable`   Enable xdebug
+* `debug:enable`   Enable the debugger for every runtime the project has — PHP (xdebug) and Node (`--inspect`). The Node debugger listens, so it is published on a port from the registry; `madock info:ports` shows it as `nodejs_debug`. `nodejs/debug/break` makes the process wait for the IDE before the first line
 
 
-* `debug:disable`   Disable xdebug
+* `debug:disable`   Disable it again
                      
 
 * `debug:profile:enable`   Enable xdebug profiling

--- a/llms.txt
+++ b/llms.txt
@@ -53,9 +53,9 @@ Each platform has its own CLI command(s). Use the one matching the project's pla
 - `cron:enable` — enable cron
 - `cron:disable` — disable cron
 
-### Debug (Xdebug)
-- `debug:enable` — enable Xdebug
-- `debug:disable` — disable Xdebug
+### Debug
+- `debug:enable` — enable the debugger for every runtime the project has: PHP (Xdebug) and Node (`--inspect`, on a port from the registry, shown by `info:ports`)
+- `debug:disable` — disable it again
 - `debug:profile:enable` — enable profiler
 - `debug:profile:disable` — disable profiler
 

--- a/src/controller/general/debug/debug.go
+++ b/src/controller/general/debug/debug.go
@@ -43,17 +43,15 @@ func init() {
 	})
 }
 
-// requirePHP stops the debug commands on a project they cannot do anything for.
+// requirePHP stops the profiler commands on a project they cannot do anything
+// for.
 //
-// Every one of them writes php/xdebug/*, so on a nodejs, python, golang or ruby
-// project they set a value nothing reads, rebuild the project, and report
-// success. Debugging is then simply absent, and the command that was supposed
-// to arrange it said it had.
-//
-// The other languages are not wired up yet and that is a piece of work, not an
-// oversight — their debuggers listen instead of connecting out, so each needs a
-// published port, an allocation, and a process started under the debugger. Until
-// then this says so rather than pretending.
+// They write php/xdebug/mode, so on a project with no PHP container they set a
+// value nothing reads, rebuild, and report success. Profiling is then simply
+// absent, and the command that was supposed to arrange it said it had. The
+// profiler stayed PHP-only when debugging stopped being: `--cpu-prof` writes a
+// file for somebody to open afterwards, which is a different command with a
+// different answer, not this one with a second branch.
 func requirePHP() bool {
 	projectConf := configs.GetCurrentProjectConfig()
 	if projectConf["php/enabled"] == "true" {
@@ -64,27 +62,108 @@ func requirePHP() bool {
 	if language == "" {
 		language = "this project's language"
 	}
-	fmtc.ErrorLn("Debugging is only wired up for PHP, and " + language + " has no PHP container.")
+	fmtc.ErrorLn("Profiling is only wired up for PHP, and " + language + " has no PHP container.")
 	fmtc.ToDoLn("Nothing was changed.")
 	return false
 }
 
-func Enable() {
-	attr.Parse(new(ArgsStruct))
-	if !requirePHP() {
+// runtime is something in this project that can be put into debug mode, and the
+// switch that does it.
+type runtime struct {
+	name string
+	key  string
+}
+
+// debuggable lists the runtimes this project actually has.
+//
+// Deliberately not a single `debug/enabled` key derived from `language`: a
+// project can run more than one of these at once — a PHP application with a
+// JavaScript front end in its own container is the ordinary case — and one
+// switch would have had to pick a winner. The per-runtime keys already exist
+// for other purposes, so the command derives the list and leaves the
+// configuration alone; php/xdebug/* keeps the name it has always had, and
+// nothing that reads it notices this change.
+//
+// Kept free of I/O so the choice can be tested without a project on disk.
+func debuggable(projectConf map[string]string) []runtime {
+	var found []runtime
+
+	if projectConf["php/enabled"] == "true" {
+		found = append(found, runtime{name: "PHP (xdebug)", key: "php/xdebug/enabled"})
+	}
+	if projectConf["nodejs/enabled"] == "true" {
+		found = append(found, runtime{name: "Node", key: "nodejs/debug/enabled"})
+	}
+
+	return found
+}
+
+// setDebug writes the switch for every debuggable runtime and rebuilds once.
+//
+// Nothing is silent: a project with two runtimes says so, because "debugging is
+// on" without saying what for is how somebody ends up attaching to the wrong
+// container.
+func setDebug(value string) {
+	projectConf := configs.GetCurrentProjectConfig()
+
+	runtimes := debuggable(projectConf)
+	if len(runtimes) == 0 {
+		refuse(projectConf)
 		return
 	}
-	configs.SetParam(configs.GetProjectName(), "php/xdebug/enabled", "true", configs.GetCurrentProjectConfig()["activeScope"], "")
+
+	for _, r := range runtimes {
+		fmtc.SuccessLn(verb(value) + " debugging for " + r.name)
+		configs.SetParam(configs.GetProjectName(), r.key, value, projectConf["activeScope"], "")
+	}
+
+	// Node's debugger listens, so the port only exists once the stack has been
+	// generated again — which is what makes the number worth pointing at rather
+	// than printing here, where it would be the previous rebuild's.
+	if value == "true" && projectConf["nodejs/enabled"] == "true" {
+		fmtc.ToDoLn("madock info:ports — the debugger listens on the port published for nodejs_debug")
+	}
+
 	rebuild.Execute()
+}
+
+func verb(value string) string {
+	if value == "true" {
+		return "Enabling"
+	}
+	return "Disabling"
+}
+
+// refuse says why nothing happened, and names the one case that looks like it
+// should have worked.
+func refuse(projectConf map[string]string) {
+	language := projectConf["language"]
+	if language == "" {
+		language = "this project's language"
+	}
+
+	fmtc.ErrorLn("Debugging is wired up for PHP and Node, and this project runs neither: " + language + ".")
+
+	// Node in the application container has no container of its own and so no
+	// port to publish, which is the whole mechanism its debugger needs. Somebody
+	// who has switched it on has every reason to expect this command to work.
+	if projectConf["nodejs/embedded/enabled"] == "true" {
+		fmtc.WarningLn("Node here runs inside the application container (nodejs/embedded/enabled), " +
+			"and its debugger needs a published port, which only a container of its own has.")
+		fmtc.ToDoLn("madock config:set -n nodejs/enabled -v true to give it one")
+	}
+
+	fmtc.ToDoLn("Nothing was changed.")
+}
+
+func Enable() {
+	attr.Parse(new(ArgsStruct))
+	setDebug("true")
 }
 
 func Disable() {
 	attr.Parse(new(ArgsStruct))
-	if !requirePHP() {
-		return
-	}
-	configs.SetParam(configs.GetProjectName(), "php/xdebug/enabled", "false", configs.GetCurrentProjectConfig()["activeScope"], "")
-	rebuild.Execute()
+	setDebug("false")
 }
 
 func ProfileEnable() {

--- a/src/controller/general/debug/debug_test.go
+++ b/src/controller/general/debug/debug_test.go
@@ -1,0 +1,63 @@
+package debug
+
+import "testing"
+
+// One command, and the project decides what it means. The alternative was a
+// single `debug/enabled` derived from `language`, and this is the case that
+// rules it out: a PHP application with a JavaScript front end in its own
+// container runs two debuggable things at once, and one switch would have had
+// to pick a winner silently.
+func TestDebuggableRuntimes(t *testing.T) {
+	tests := []struct {
+		name string
+		conf map[string]string
+		want []string
+	}{
+		{
+			name: "php alone is what it has always been",
+			conf: map[string]string{"php/enabled": "true"},
+			want: []string{"php/xdebug/enabled"},
+		},
+		{
+			name: "node alone",
+			conf: map[string]string{"nodejs/enabled": "true"},
+			want: []string{"nodejs/debug/enabled"},
+		},
+		{
+			name: "both, and neither is dropped",
+			conf: map[string]string{"php/enabled": "true", "nodejs/enabled": "true"},
+			want: []string{"php/xdebug/enabled", "nodejs/debug/enabled"},
+		},
+		{
+			// Node inside the application container has no container of its own,
+			// so nothing can publish the port its debugger needs. Counting it
+			// would turn on a switch that renders nothing.
+			name: "node embedded in another container is not debuggable",
+			conf: map[string]string{"nodejs/embedded/enabled": "true"},
+			want: nil,
+		},
+		{
+			name: "a project with neither",
+			conf: map[string]string{"language": "golang"},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			found := debuggable(test.conf)
+
+			if len(found) != len(test.want) {
+				t.Fatalf("got %d runtimes, want %d: %+v", len(found), len(test.want), found)
+			}
+			for i, key := range test.want {
+				if found[i].key != key {
+					t.Errorf("runtime %d writes %q, want %q", i, found[i].key, key)
+				}
+				if found[i].name == "" {
+					t.Errorf("runtime %d has no name, so the output cannot say what it turned on", i)
+				}
+			}
+		})
+	}
+}

--- a/src/helper/configs/aruntime/project/nodejs_debug_render_test.go
+++ b/src/helper/configs/aruntime/project/nodejs_debug_render_test.go
@@ -1,0 +1,99 @@
+package project
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/faradey/madock/v4/src/helper/ports"
+	"github.com/faradey/madock/v4/src/helper/testenv"
+)
+
+// Node's debugger is the first one madock wires up that is not xdebug, and the
+// two work in opposite directions: xdebug connects out to the IDE, so PHP
+// debugging needed no compose change at all, while node --inspect listens and
+// the IDE connects in. That is the whole reason this renders anything.
+//
+// Gated behind a config key that is off by default, which is the shape that
+// renders nothing forever and gets noticed a release later — so both halves are
+// asserted, the off one first.
+func TestNodejsDebugRendersOnlyWhenAskedFor(t *testing.T) {
+	compose := func(t *testing.T, overrides map[string]string) string {
+		t.Helper()
+
+		projectName := "nodedbg"
+		env := testenv.SetupWith(t, projectName, "nodedbg.test", overrides)
+
+		MakeConf(projectName)
+
+		rendered := testenv.Collect(t, filepath.Join(env.ExecDir, "aruntime", "projects", projectName), env)
+		for name, body := range rendered {
+			if strings.HasSuffix(name, "docker-compose.yml") {
+				return body
+			}
+		}
+		t.Fatal("MakeConf produced no docker-compose.yml")
+		return ""
+	}
+
+	t.Run("off by default", func(t *testing.T) {
+		body := compose(t, map[string]string{"nodejs/enabled": "true"})
+
+		if strings.Contains(body, "9229") {
+			t.Errorf("the debug port was published without being asked for:\n%s", body)
+		}
+		if strings.Contains(body, "NODE_OPTIONS") {
+			t.Errorf("the runtime was started under the debugger without being asked for:\n%s", body)
+		}
+	})
+
+	t.Run("published and switched on when enabled", func(t *testing.T) {
+		body := compose(t, map[string]string{
+			"nodejs/enabled":       "true",
+			"nodejs/debug/enabled": "true",
+		})
+
+		// The container side is fixed — inside there is one node process and
+		// nothing to collide with. The host side is masked here, because the
+		// harness normalises every published port, so what the number is gets
+		// asserted against the registry below instead.
+		if !strings.Contains(body, `- "<PORT>:9229"`) {
+			t.Fatalf("the debug port is not published:\n%s", body)
+		}
+
+		// The number comes from the registry and not from the template. That is
+		// what keeps two projects debugging at once apart, and it is also why
+		// `madock info:ports` needs no change to show it: that command prints
+		// every pair the registry holds, whatever allocated them.
+		if port := ports.GetRegistry().Get("nodedbg", "nodejs_debug"); port <= 0 {
+			t.Errorf("the debug port was not allocated from the registry, so info:ports will not show it: %d", port)
+		}
+
+		// The address matters as much as the port: node binds 127.0.0.1 by
+		// default, and a debugger on loopback inside a container is reachable by
+		// nothing at all.
+		if !strings.Contains(body, "--inspect=0.0.0.0:9229") {
+			t.Errorf("the debugger is not listening on an address the IDE can reach:\n%s", body)
+		}
+
+		// Without a break the process must not wait for anybody.
+		if strings.Contains(body, "--inspect-brk") {
+			t.Errorf("the process was made to wait for an IDE without nodejs/debug/break:\n%s", body)
+		}
+	})
+
+	// Stopping before the first line is right for debugging a startup problem
+	// and wrong for everything else — as a default it would make every debugged
+	// container look hung, which is why it is its own switch.
+	t.Run("break waits for the IDE", func(t *testing.T) {
+		body := compose(t, map[string]string{
+			"nodejs/enabled":       "true",
+			"nodejs/debug/enabled": "true",
+			"nodejs/debug/break":   "true",
+		})
+
+		if !strings.Contains(body, "--inspect-brk=0.0.0.0:9229") {
+			t.Errorf("nodejs/debug/break did not reach the runtime:\n%s", body)
+		}
+	})
+}

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -173,6 +173,21 @@
                 <script></script>
                 <script_type>auto</script_type>
                 <browser_libs>false</browser_libs>
+                <!-- Node's debugger, turned on by `madock debug:enable`.
+
+                     Unlike xdebug it listens rather than connecting out, so it
+                     costs a published port — allocated from the registry like
+                     every other one, never a fixed 9229, which two projects
+                     debugging at once would fight over.
+
+                     `break` stops the process before the first line and waits
+                     for an IDE. Right for a startup problem and wrong for
+                     everything else, which is why it is a separate switch: as a
+                     default it would make every debugged container look hung. -->
+                <debug>
+                    <enabled>false</enabled>
+                    <break>false</break>
+                </debug>
                 <yarn>
                     <enabled>false</enabled>
                     <version>1.22.19</version>

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.0.2"
+const Version = "4.0.3"

--- a/test/e2e/debug_test.go
+++ b/test/e2e/debug_test.go
@@ -11,12 +11,15 @@ import (
 // TestDebugRefusesWhereItCannotWork covers the half of debugging that can be
 // tested cheaply, and it is the half that was wrong.
 //
-// Every debug command writes php/xdebug/*. On a project with no PHP container
-// that set a value nothing reads, rebuilt the project, and reported success —
-// so debugging was absent and the command that was meant to arrange it said
-// otherwise. Wiring the other languages up is real work (their debuggers listen
-// rather than connect out, so each needs a published port, an allocation and a
-// process started under the debugger); saying so is one line.
+// Every debug command used to write php/xdebug/*. On a project with no PHP
+// container that set a value nothing reads, rebuilt the project, and reported
+// success — so debugging was absent and the command that was meant to arrange
+// it said otherwise. Node is wired up now; Python, Ruby and Go are not, and
+// their debuggers listen rather than connect out, so each still needs a
+// published port, an allocation and a process started under the debugger.
+//
+// This project has none of them, which is what makes it the cheap way to test
+// that the command refuses instead of pretending.
 //
 // The PHP path is not tested here. It needs a project with a PHP container,
 // which the cheap shape does not have, so it belongs with the platform tests
@@ -36,7 +39,8 @@ func TestDebugRefusesWhereItCannotWork(t *testing.T) {
 	// Deliberately short. A rebuild would take far longer, and not rebuilding is
 	// half the point: the old behaviour spent minutes to change nothing.
 	out, _ := p.tryRun(90*time.Second, "debug:enable")
-	requireContains(t, strings.ToLower(out), "only wired up for php", "the answer on a project without PHP")
+	requireContains(t, strings.ToLower(out), "wired up for php and node", "the answer on a project with neither")
+	requireContains(t, strings.ToLower(out), "nothing was changed", "the refusal saying it did nothing")
 
 	if readFile(t, p.generated("docker-compose.yml")) != before {
 		t.Error("debug:enable changed the generated configuration of a project it cannot debug")
@@ -46,5 +50,43 @@ func TestDebugRefusesWhereItCannotWork(t *testing.T) {
 	config := p.run(2*time.Minute, "config:list")
 	if strings.Contains(config, "php/xdebug/enabled true") {
 		t.Errorf("xdebug was switched on for a project with no PHP:\n%s", config)
+	}
+	if strings.Contains(config, "nodejs/debug/enabled true") {
+		t.Errorf("the node debugger was switched on for a project with no node container:\n%s", config)
+	}
+}
+
+// TestDebugRefusesNodeInsideAnotherContainer is the refusal that looks most like
+// it should have worked.
+//
+// `nodejs/embedded/enabled` runs node in the application container instead of
+// one of its own. Node is right there, so asking to debug it is reasonable — and
+// it cannot work, because the debugger listens and there is no container of its
+// own to publish a port from. Answering "this project runs neither" and stopping
+// would be true and useless; it has to name the setting that gives node a
+// container.
+//
+// Cheap on purpose: no rebuild, and the refusal is read straight off the
+// command.
+func TestDebugRefusesNodeInsideAnotherContainer(t *testing.T) {
+	p := newProject(t, "e2edebugemb")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2edebugemb.test",
+	)
+	p.run(2*time.Minute, "config:set", "-n", "nodejs/embedded/enabled", "-v", "true")
+
+	out, _ := p.tryRun(90*time.Second, "debug:enable")
+
+	requireContains(t, strings.ToLower(out), "nodejs/embedded/enabled",
+		"the refusal naming the setting that put node where it cannot be debugged")
+	requireContains(t, strings.ToLower(out), "nodejs/enabled",
+		"and the one that would give it a container of its own")
+
+	config := p.run(2*time.Minute, "config:list")
+	if strings.Contains(config, "nodejs/debug/enabled true") {
+		t.Errorf("a switch was turned on that nothing renders:\n%s", config)
 	}
 }


### PR DESCRIPTION
`debug:enable` was a PHP command wearing a general name. Every one of its handlers wrote `php/xdebug/*`, so on a Node project it set a value nothing reads, rebuilt the project, and reported success — debugging simply absent, arranged by the command that said it had arranged it.

It now enables the debugger for each runtime the project actually has, and says which. On a project with both PHP and a Node container it enables both rather than picking one silently.

## Why this is not "install an extension and rebuild"

The two debuggers work in opposite directions, and that decides everything else.

| | PHP (xdebug) | Node (`--inspect`) |
|---|---|---|
| Direction | container → IDE | IDE → container |
| Published port | none | required |
| Allocation | none | one per project |

Xdebug connects out, which is why PHP debugging has never needed a compose change. `node --inspect` listens, so the IDE connects in — and that costs a published port.

## Decisions

**The port comes from the registry**, as `nodejs_debug`, not a fixed 9229. Inside the container the number is fixed and safe: there is one node process and nothing to collide with. On the host a fixed number is what the second project debugging at the same time would fight over.

**`madock info:ports` needs no change to show it.** It prints every pair the registry holds, so allocating through the registry rather than writing a number into the template is what puts the port in front of the person who needs it. This was an open question in the plan and turns out to be no work at all — provided allocation goes through the registry.

**`NODE_OPTIONS`, not a flag on the command.** The entrypoint execs `yarn dev` / `npm run dev` and the dev server is a child of that: a flag on the outer command dies with the package manager, an environment variable is inherited by whatever it spawns. It binds `0.0.0.0` rather than node's default loopback, which inside a container is reachable by nothing.

**`nodejs/debug/break` is its own switch**, off by default. Stopping before the first line is right for debugging a startup problem and wrong for everything else; as a default it would make every debugged container look hung.

**Node inside the application container is refused by name.** `nodejs/embedded/enabled` gives it no container of its own and so nothing to publish a port from, which is the entire mechanism its debugger needs. The command says that and points at the setting that gives it one, instead of turning on a switch that renders nothing.

**The profiler stays PHP-only.** `--cpu-prof` writes a file to open afterwards — a different command with a different answer, not this one with a second branch. `requirePHP` now guards only the profiler, and its message was rewritten so it no longer claims something untrue about debugging.

## Tests

- The runtime choice as a table, including the both-at-once case and the embedded one that must not count.
- A render test asserting the off state as well as the on one — a feature behind a config key is exactly the kind that renders nothing forever and is noticed a release later.
- That the published number came from the registry rather than the template, which is the property `info:ports` depends on.

Python, Ruby and Go are unchanged and still queued; their shape is not affected by any of this.
