### PR TITLE
The platform fixtures pinned a php image for a Node platform

### DIFF
--- a/docker/snippets/dockerfile/nodejs/footer
+++ b/docker/snippets/dockerfile/nodejs/footer
@@ -181,10 +181,15 @@ fi
 
 if [ -f yarn.lock ]; then
   pm="yarn"
+  pm_name="yarn"
 elif [ -f pnpm-lock.yaml ]; then
   pm="pnpm"
+  pm_name="pnpm"
 else
   pm="npm run"
+  # The name on its own, because $pm carries the subcommand: a message built
+  # from it read "starts through npm run, which is a Node program itself".
+  pm_name="npm"
 fi
 
 # Source .env right before exec so the dev server sees DATABASE_URL /
@@ -210,7 +215,7 @@ if [ "$mode" = "command" ]; then
 fi
 
 if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
-  explain_no_inspector "$pm"
+  explain_no_inspector "$pm_name"
 fi
 
 echo "[madock] starting: $pm $script"

--- a/src/controller/general/debug/debug.go
+++ b/src/controller/general/debug/debug.go
@@ -121,10 +121,48 @@ func setDebug(value string) {
 	// generated again — which is what makes the number worth pointing at rather
 	// than printing here, where it would be the previous rebuild's.
 	if value == "true" && projectConf["nodejs/enabled"] == "true" {
-		fmtc.ToDoLn("madock info:ports — the debugger listens on the port published for nodejs_debug")
+		if nodeInspectorAttaches(projectConf) {
+			fmtc.ToDoLn("madock info:ports — the debugger listens on the port published for nodejs_debug")
+		} else {
+			warnAboutThePackageManager(projectConf)
+		}
 	}
 
 	rebuild.Execute()
+}
+
+// nodeInspectorAttaches reports whether the node container will actually end up
+// with a debugger on it.
+//
+// Only `nodejs/script_type=command` can promise it. Everything else runs through
+// the project's package manager, and yarn, npm and pnpm are Node programs: they
+// take the inspector port themselves, the dev server they spawn cannot bind it
+// and runs without a debugger, and the IDE attaches to the wrapper. The
+// entrypoint refuses to arrange that and says so in the container's log — which
+// is a poor place to learn it, because the command that switched debugging on
+// reported success minutes earlier.
+//
+// The one case this calls wrong is a project with no `dev` or `start` script at
+// all, where the entrypoint falls back to a bare `node` and the inspector does
+// attach. The warning is worded to allow for it rather than pretending it cannot
+// happen.
+func nodeInspectorAttaches(projectConf map[string]string) bool {
+	return projectConf["nodejs/script_type"] == "command"
+}
+
+func warnAboutThePackageManager(projectConf map[string]string) {
+	fmtc.WarningLn("Node is switched on for debugging, but this project starts through its package manager, " +
+		"which is a Node program itself and takes the inspector port before the application can.")
+	fmtc.WarningLn("Nothing will be listening on nodejs_debug unless the container ends up running node directly.")
+
+	if script := projectConf["nodejs/script"]; script != "" {
+		fmtc.ToDoLn("madock config:set -n nodejs/script_type -v command — with nodejs/script holding the command to run " +
+			"(it is currently \"" + script + "\")")
+		return
+	}
+
+	fmtc.ToDoLn("madock config:set -n nodejs/script -v \"<the command that starts your app>\" " +
+		"and nodejs/script_type to command, or add --inspect to the script in package.json")
 }
 
 func verb(value string) string {

--- a/src/controller/general/debug/debug_test.go
+++ b/src/controller/general/debug/debug_test.go
@@ -2,6 +2,26 @@ package debug
 
 import "testing"
 
+// `debug:enable` used to finish by pointing at `info:ports` whenever the project
+// had a node container, which is a promise it cannot keep: with anything but an
+// explicit command the container starts through its package manager, the
+// entrypoint refuses to hand that the inspector, and nothing listens on the
+// published port. The IDE then answers "connection refused" and the explanation
+// is in the container's log — minutes after the command reported success.
+func TestNodeInspectorAttaches(t *testing.T) {
+	if !nodeInspectorAttaches(map[string]string{"nodejs/script_type": "command"}) {
+		t.Error("an explicit command is exactly the case the inspector can be put on")
+	}
+
+	// The default is "auto", and the empty value is what a project written
+	// before the key existed has.
+	for _, scriptType := range []string{"", "auto", "package"} {
+		if nodeInspectorAttaches(map[string]string{"nodejs/script_type": scriptType}) {
+			t.Errorf("script_type %q runs through the package manager, and it takes the port", scriptType)
+		}
+	}
+}
+
 // One command, and the project decides what it means. The alternative was a
 // single `debug/enabled` derived from `language`, and this is the case that
 // rules it out: a PHP application with a JavaScript front end in its own

--- a/src/helper/configs/aruntime/project/golden_platforms_test.go
+++ b/src/helper/configs/aruntime/project/golden_platforms_test.go
@@ -8,6 +8,22 @@ import (
 	"github.com/faradey/madock/v4/src/helper/configs/projects"
 	"github.com/faradey/madock/v4/src/helper/testenv"
 	"github.com/faradey/madock/v4/src/model/versions"
+
+	// The version providers register themselves in init(), and in the real
+	// binary they arrive with the platform controllers. The controllers cannot
+	// be imported here — they import this package — so the leaf packages are
+	// named directly. Without them GetVersionsForPlatform answers "no such
+	// platform", `language` goes unwritten, and every fixture quietly renders
+	// through the general fallback: that is exactly how Medusa's application
+	// image came to be pinned as php-fpm.
+	_ "github.com/faradey/madock/v4/src/model/versions/bigcommerce"
+	_ "github.com/faradey/madock/v4/src/model/versions/medusa"
+	_ "github.com/faradey/madock/v4/src/model/versions/prestashop"
+	_ "github.com/faradey/madock/v4/src/model/versions/saleor"
+	_ "github.com/faradey/madock/v4/src/model/versions/shopify"
+	_ "github.com/faradey/madock/v4/src/model/versions/shopware"
+	_ "github.com/faradey/madock/v4/src/model/versions/spree"
+	_ "github.com/faradey/madock/v4/src/model/versions/sylius"
 )
 
 // platformsWithoutAGolden is every platform madock ships templates for and had
@@ -103,6 +119,28 @@ func writePlatformDefaults(t *testing.T, execDir, projectName, platform string) 
 	config := new(configs.ConfigLines)
 	config.EnvFile = filepath.Join(execDir, "projects", projectName, "config.xml")
 	config.ActiveScope = "default"
+
+	// `platform` and `language` are written by the shared path that setup goes
+	// through before it reaches the platform's own writer, and this fixture used
+	// to skip them — which made every golden less representative than it looked.
+	//
+	// `language` decides which template tree answers when a platform ships no
+	// file of its own: the resolver tries the platform, then
+	// docker/languages/<language>/, then docker/general/service/. With the key
+	// empty, the language step is skipped and everything lands on the general
+	// one — so Medusa, a Node platform with no Dockerfile of its own, had its
+	// application image pinned here as **php-fpm on ubuntu**, and the fixture
+	// would have gone on approving that if the real resolution ever broke.
+	config.Set("platform", platform)
+
+	defaults, ok := versions.GetVersionsForPlatform(platform, "")
+	if !ok {
+		t.Fatalf("no version provider is registered for %q, so this fixture would render through the "+
+			"general fallback and pin whatever that produces — add the blank import above", platform)
+	}
+	if defaults.Language != "" {
+		config.Set("language", defaults.Language)
+	}
 
 	// The base configuration stands in for the general one, which is what the
 	// writers read defaults out of — credentials, timezone, the switches a

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/ctx/nodejs.Dockerfile
@@ -213,10 +213,15 @@ fi
 
 if [ -f yarn.lock ]; then
   pm="yarn"
+  pm_name="yarn"
 elif [ -f pnpm-lock.yaml ]; then
   pm="pnpm"
+  pm_name="pnpm"
 else
   pm="npm run"
+  # The name on its own, because $pm carries the subcommand: a message built
+  # from it read "starts through npm run, which is a Node program itself".
+  pm_name="npm"
 fi
 
 # Source .env right before exec so the dev server sees DATABASE_URL /
@@ -242,7 +247,7 @@ if [ "$mode" = "command" ]; then
 fi
 
 if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
-  explain_no_inspector "$pm"
+  explain_no_inspector "$pm_name"
 fi
 
 echo "[madock] starting: $pm $script"

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/ctx/nodejs.Dockerfile
@@ -202,10 +202,15 @@ fi
 
 if [ -f yarn.lock ]; then
   pm="yarn"
+  pm_name="yarn"
 elif [ -f pnpm-lock.yaml ]; then
   pm="pnpm"
+  pm_name="pnpm"
 else
   pm="npm run"
+  # The name on its own, because $pm carries the subcommand: a message built
+  # from it read "starts through npm run, which is a Node program itself".
+  pm_name="npm"
 fi
 
 # Source .env right before exec so the dev server sees DATABASE_URL /
@@ -231,7 +236,7 @@ if [ "$mode" = "command" ]; then
 fi
 
 if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
-  explain_no_inspector "$pm"
+  explain_no_inspector "$pm_name"
 fi
 
 echo "[madock] starting: $pm $script"

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/ctx/nodejs.Dockerfile
@@ -202,10 +202,15 @@ fi
 
 if [ -f yarn.lock ]; then
   pm="yarn"
+  pm_name="yarn"
 elif [ -f pnpm-lock.yaml ]; then
   pm="pnpm"
+  pm_name="pnpm"
 else
   pm="npm run"
+  # The name on its own, because $pm carries the subcommand: a message built
+  # from it read "starts through npm run, which is a Node program itself".
+  pm_name="npm"
 fi
 
 # Source .env right before exec so the dev server sees DATABASE_URL /
@@ -231,7 +236,7 @@ if [ "$mode" = "command" ]; then
 fi
 
 if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
-  explain_no_inspector "$pm"
+  explain_no_inspector "$pm_name"
 fi
 
 echo "[madock] starting: $pm $script"

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/ctx/nodejs.Dockerfile
@@ -200,10 +200,15 @@ fi
 
 if [ -f yarn.lock ]; then
   pm="yarn"
+  pm_name="yarn"
 elif [ -f pnpm-lock.yaml ]; then
   pm="pnpm"
+  pm_name="pnpm"
 else
   pm="npm run"
+  # The name on its own, because $pm carries the subcommand: a message built
+  # from it read "starts through npm run, which is a Node program itself".
+  pm_name="npm"
 fi
 
 # Source .env right before exec so the dev server sees DATABASE_URL /
@@ -229,7 +234,7 @@ if [ "$mode" = "command" ]; then
 fi
 
 if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
-  explain_no_inspector "$pm"
+  explain_no_inspector "$pm_name"
 fi
 
 echo "[madock] starting: $pm $script"

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/ctx/nodejs.Dockerfile
@@ -208,10 +208,15 @@ fi
 
 if [ -f yarn.lock ]; then
   pm="yarn"
+  pm_name="yarn"
 elif [ -f pnpm-lock.yaml ]; then
   pm="pnpm"
+  pm_name="pnpm"
 else
   pm="npm run"
+  # The name on its own, because $pm carries the subcommand: a message built
+  # from it read "starts through npm run, which is a Node program itself".
+  pm_name="npm"
 fi
 
 # Source .env right before exec so the dev server sees DATABASE_URL /
@@ -237,7 +242,7 @@ if [ "$mode" = "command" ]; then
 fi
 
 if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
-  explain_no_inspector "$pm"
+  explain_no_inspector "$pm_name"
 fi
 
 echo "[madock] starting: $pm $script"

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "golden.test:host-gateway"
+    depends_on:
+      - nodejs
     restart: no
 
 volumes:

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/ctx/nodejs.Dockerfile
@@ -1,187 +1,16 @@
-FROM ubuntu:22.04
+FROM node:22.14.0
 
-ARG DEBIAN_FRONTEND="noninteractive"
-ARG DEBCONF_NOWARNINGS="yes"
+RUN rm -f /var/log/faillog && rm -f /var/log/lastlog
 
-RUN ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo UTC > /etc/timezone \
-    && apt-get clean && apt-get -y --allow-releaseinfo-change update && apt-get install -y locales \
-    curl \
-    wget \
-    ca-certificates \
-    software-properties-common \
-    git \
-    zip \
-    gzip \
-    mc \
-    mariadb-client \
-    telnet \
-    libmagickwand-dev \
-    imagemagick \
-    libmcrypt-dev \
-    procps \
-    openssh-client \
-    lsof \
-    openssl \
-    msmtp \
-    xdg-utils \
-    libssh2-1-dev \
-    libssh2-1 \
-    jq \
-    && locale-gen en_US.UTF-8 \
-    && LC_ALL=en_US.UTF-8 add-apt-repository ppa:ondrej/php
+RUN apt-get update && apt-get install -y --no-install-recommends xdg-utils && rm -rf /var/lib/apt/lists/*
+RUN npm install -g grunt-cli
 
-RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bcmath \
-    php8.4-cli \
-    php8.4-common \
-    php8.4-curl \
-    php8.4-dev \
-    php8.4-fpm \
-    php8.4-gd \
-    php8.4-intl \
-    php8.4-mbstring \
-    php8.4-mysql \
-    php8.4-soap \
-    php8.4-sqlite3 \
-    php8.4-xml \
-    php8.4-xsl \
-    php8.4-zip \
-    php8.4-imagick \
-    php8.4-ctype \
-    php8.4-dom \
-    php8.4-fileinfo \
-    php8.4-iconv \
-    php8.4-simplexml \
-    php8.4-sockets \
-    php8.4-tokenizer \
-    php8.4-xmlwriter \
-    php8.4-ssh2 \
-    php8.4-redis
+RUN apt-get update && apt-get install -y cron && rm -rf /var/lib/apt/lists/*
 
-# Optional packages: not all PHP versions ship them as separate packages
-# (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
-# from PHP core in 8.0 and may be missing in newer ondrej builds). Install
-# each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
-RUN apt-get install -y php8.4-xmlrpc || true
-
-SHELL ["/bin/bash", "-c"]
-RUN IFS='.' read major minor patch <<< "8.4" \
-    && if [[ "${major}" -ge "9" ]] || [[ "${major}" = "8" && "${minor}" -ge "4" ]]; then \
-        # PHP 8.4+ — no compatible pecl mcrypt release, skip it
-        apt-get install -y pkg-config libmcrypt-dev \
-        && pecl channel-update pecl.php.net \
-        && echo "Skipping pecl mcrypt for PHP ${major}.${minor} (no compatible release)" \
-    ; elif [[ "${major}" > "7" || ("${major}" = "7" && "${minor}" > "1") ]]; then \
-        pecl install mcrypt-1.0.7 \
-        && EXTENSION_DIR="$( php -i | grep ^extension_dir | awk -F '=>' '{print $2}' | xargs )" \
-        && bash -c "echo extension=${EXTENSION_DIR}/mcrypt.so > /etc/php/8.4/cli/conf.d/mcrypt.ini" \
-        && bash -c "echo extension=${EXTENSION_DIR}/mcrypt.so > /etc/php/8.4/fpm/conf.d/mcrypt.ini" \
-    ; fi \
-    && if [[ "${major}" < "7" || ("${major}" = "7" && "${minor}" < "2") ]]; then \
-        apt-get install -y php8.4-mcrypt \
-    ; fi \
-    && if [[ "${major}" < "7" ]]; then \
-        apt-get install -y php8.4-json \
-    ; fi
-
-RUN sed -i -e "s/pid =.*/pid = \/var\/run\/php8.4-fpm.pid/" /etc/php/8.4/fpm/php-fpm.conf \
-    && sed -i -e "s/error_log =.*/error_log = \/proc\/self\/fd\/2/" /etc/php/8.4/fpm/php-fpm.conf \
-    && sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" /etc/php/8.4/fpm/php-fpm.conf \
-    && sed -i "s/listen = .*/listen = 9000/" /etc/php/8.4/fpm/pool.d/www.conf \
-    && sed -i "s/;catch_workers_output = .*/catch_workers_output = yes/" /etc/php/8.4/fpm/pool.d/www.conf \
-    && sed -i "s/^pm.max_children = .*/pm.max_children = 40/" /etc/php/8.4/fpm/pool.d/www.conf \
-    && sed -i "s/^pm.start_servers = .*/pm.start_servers = 2/" /etc/php/8.4/fpm/pool.d/www.conf \
-    && sed -i "s/^pm.min_spare_servers = .*/pm.min_spare_servers = 1/" /etc/php/8.4/fpm/pool.d/www.conf \
-    && sed -i "s/^pm.max_spare_servers = .*/pm.max_spare_servers = 3/" /etc/php/8.4/fpm/pool.d/www.conf
-
-# Unlock ImageMagick PDF coder (default Debian/Ubuntu policy blocks PDF reads,
-# which breaks Imagick-based PDF previews in PHP apps). Local dev only.
-RUN if [ -f /etc/ImageMagick-6/policy.xml ]; then \
-        sed -i 's#rights="none" pattern="PDF"#rights="read|write" pattern="PDF"#' /etc/ImageMagick-6/policy.xml; \
-    fi
-
-
-RUN if [[ "false" = "true" ]]; then set -eux && EXTENSION_DIR="$( php -i | grep ^extension_dir | awk -F '=>' '{print $2}' | xargs )" \
-    && curl -o ioncube.tar.gz http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_<ARCH>.tar.gz \
-    && tar xvfz ioncube.tar.gz \
-    && cd ioncube \
-    && cp ioncube_loader_lin_8.4.so ${EXTENSION_DIR}/ioncube.so \
-    && cd ../ \
-    && rm -rf ioncube \
-    && rm -rf ioncube.tar.gz \
-    && echo "zend_extension=ioncube.so" >> /etc/php/8.4/mods-available/ioncube.ini \
-    && ln -s /etc/php/8.4/mods-available/ioncube.ini /etc/php/8.4/cli/conf.d/10-ioncube.ini \
-    && ln -s /etc/php/8.4/mods-available/ioncube.ini /etc/php/8.4/fpm/conf.d/10-ioncube.ini; fi
-RUN is_composer_version_one="" \
-    && if [[ "2" = "2" ]]; then is_composer_version_one="1" && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer; fi && if [[ "2" = "1" ]]; then  is_composer_version_one="1" && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer && composer self-update --1; fi \
-    && if [[ -z "${is_composer_version_one}" ]]; then php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer --version=2; fi
-RUN if [[ "false" = "true" ]]; then pecl install -f xdebug-3.4.4 \
-    && touch /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "zend_extension=xdebug.so" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.mode=debug" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.output_dir=/var/www/html/var" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.profiler_output_name=\"cachegrind.out.%t\"" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.remote_enable=1" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.start_with_request=on" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.remote_autostart=on" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.idekey=PHPSTORM" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.client_host=host.docker.internal" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.remote_host=host.docker.internal" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.remote_port=9003" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.client_port=9003" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.log=/var/www/var/log/xdebug.log" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.log_level=7" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && ln -s /etc/php/8.4/mods-available/xdebug.ini /etc/php/8.4/cli/conf.d/11-xdebug.ini \
-    && ln -s /etc/php/8.4/mods-available/xdebug.ini /etc/php/8.4/fpm/conf.d/11-xdebug.ini; fi
-
-RUN if [[ "false" = "true" && "debug" = "profile" ]]; then echo "xdebug.profiler_enable=1" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.profiler_output_dir=/var/www/html/var" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.xdebug.profiler_enable_trigger=0" >> /etc/php/8.4/mods-available/xdebug.ini \
-    && echo "xdebug.profiler_append=0" >> /etc/php/8.4/mods-available/xdebug.ini; fi
-RUN sed -i 's/session.cookie_lifetime = 0/session.cookie_lifetime = 2592000/g' /etc/php/8.4/fpm/php.ini \
-    && sed -i 's/post_max_size = 8M/post_max_size = 80M/g' /etc/php/8.4/fpm/php.ini \
-    && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 50M/g' /etc/php/8.4/fpm/php.ini \
-    && sed -i 's/;max_input_vars = 1000/max_input_vars = 50000/g' /etc/php/8.4/fpm/php.ini
-
-# Where PHP's mail() sends. Written only when there is somewhere for it to go.
-#
-# This used to be unconditional and hardcoded to the mailpit port, which meant
-# that with mailpit disabled every mail() call handed the message to msmtp,
-# which connected to a port nobody was listening on. Mail did not arrive and
-# nothing said so — the setting looked right in php.ini, and the port was the
-# only wrong part of it.
-#
-# php/sendmail/host and php/sendmail/port point somewhere else when they are set:
-# a real relay on the host, another container, a smarthost. Editing php.ini
-# inside a running container is not an alternative — the image is rebuilt from
-# this file and the edit goes with it, which is exactly how a working mail
-# configuration disappears at the next rebuild.
-#
-# php/sendmail/from is the envelope sender. msmtp refuses to send without one —
-# `msmtp: envelope-from address is missing`, exit 78 — and there is no msmtprc
-# here to supply a default. A mail transport passes it (PHP's mail() takes it as
-# the fifth argument, `-f`), so Magento and Laravel are fine either way; a plain
-# mail() call with four arguments is not, and that is what anyone testing their
-# own site tries first. Setting this makes both work.
-RUN sed -i 's/;sendmail_path =/sendmail_path = "\/usr\/bin\/msmtp -t --port=1025 --host=host.docker.internal"/g' /etc/php/8.4/fpm/php.ini \
-    && sed -i 's/;sendmail_path =/sendmail_path = "\/usr\/bin\/msmtp -t --port=1025 --host=host.docker.internal"/g' /etc/php/8.4/cli/php.ini
-
-WORKDIR /var/www
-
-RUN apt-get install -y cron
-RUN mkdir /var/www/.ssh/ && mkdir /var/www/.composer/ && mkdir /var/www/scripts/ && mkdir /var/www/scripts/php && mkdir /var/www/patches/ && mkdir /var/www/var/ && mkdir /var/www/var/log/ && touch /var/www/var/log/xdebug.log && chmod 0777 /var/www/var/log/xdebug.log
-RUN usermod -u <UID> -o www-data && groupmod -g <GID> -o www-data \
-    && chown -R <UID>:<GID> /var/www \
-    && chown -R <UID>:<GID> /usr/bin/composer
-
-RUN npm install -g yarn
-
+RUN usermod -u <UID> -o node && groupmod -g <GID> -o node
+RUN usermod -u <UID> -o www-data && groupmod -g <GID> -o www-data
+RUN mkdir -p /var/www && chown <UID>:<GID> /var/www
 WORKDIR /var/www/html
-
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && rm -f /var/log/faillog && rm -f /var/log/lastlog
-
-EXPOSE 9001 9003 35729 5173 9998 9999
 
 
 # madock: permissive umask (002) for cross-user file writes in dev — makes
@@ -196,4 +25,219 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
-CMD ["bash", "-c", "exec php-fpm8.4"]
+
+# madock smart entrypoint:
+#   - if nodejs/script is set, run that (see nodejs/script_type)
+#   - else pick from package.json: "dev" in development, "start" in production
+#   - else fall back to plain `node` REPL
+# Picks the package manager from lockfiles (yarn/pnpm/npm).
+# Refuses to start the dev server when node_modules is missing —
+# the user should run `madock install` first.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+set -e
+umask 0002
+
+cd "${WORKDIR:-/var/www/html}" 2>/dev/null || cd /var/www/html
+
+# run_app execs the long-running command as the application user.
+#
+# The entrypoint itself needs root: it waits for code that madock writes after
+# the container starts, and reads files whose ownership is not settled yet. The
+# dev server does not, and running it as root is how every file it writes ends
+# up owned by root on the host — `.medusa/client/` was the one that made this
+# visible, and the user could not delete their own project afterwards.
+#
+# This is the arrangement the php side has always had: the php-fpm master starts
+# as root and its workers run as www-data, whose uid is remapped to the host
+# user at build time. `node` is remapped the same way, so dropping to it here
+# makes the two languages agree.
+#
+# HOME comes from passwd rather than being assumed: yarn and npm write caches
+# and logs into it, and leaving root's HOME behind would send them somewhere the
+# app user cannot write.
+run_app() {
+  if [ "$(id -u)" = "0" ] && id node >/dev/null 2>&1; then
+    HOME=$(getent passwd node | cut -d: -f6)
+    export HOME
+    exec setpriv --reuid=node --regid=node --init-groups "$@"
+  fi
+  exec "$@"
+}
+
+# Wait for the project code to appear. madock setup -d clones the
+# starter AFTER the container starts; rather than dropping to a Node
+# REPL and never recovering, idle here until package.json shows up.
+# A bare `node` container (no project) waits forever — that's fine,
+# the user can `docker exec` in or run madock setup -d to populate.
+if [ ! -f package.json ]; then
+  echo "[madock] no package.json in $(pwd) — waiting for project code."
+  while [ ! -f package.json ]; do
+    sleep 5
+  done
+  echo "[madock] package.json detected — continuing."
+fi
+
+# has_script <name> — true when package.json declares that script.
+#
+# NODE_OPTIONS is cleared for it deliberately. This helper is a Node process
+# like any other, so an inspector flag in the environment applies to it too —
+# and with --inspect-brk it stops before its first line and waits for a debugger
+# that is not coming. Its stderr goes to /dev/null, so the container would hang
+# here with nothing said at all.
+has_script() {
+  NODE_OPTIONS= node -e 'try{var p=require("./package.json").scripts||{};process.exit(p[process.argv[1]]?0:1)}catch(e){process.exit(1)}' "$1" 2>/dev/null
+}
+
+# enable_inspector — put the debugger on the process this entrypoint is about to
+# become. Only ever called where that process is the application itself.
+enable_inspector() {
+  flag="--inspect"
+  if [ "${MADOCK_DEBUG_BREAK:-}" = "true" ]; then
+    flag="--inspect-brk"
+  fi
+
+  # 0.0.0.0 and not node's default loopback: the IDE connects from outside the
+  # container, where a debugger bound to 127.0.0.1 inside it is reachable by
+  # nothing.
+  NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }$flag=0.0.0.0:${MADOCK_DEBUG_PORT}"
+  export NODE_OPTIONS
+
+  echo "[madock] debugger listening on 0.0.0.0:${MADOCK_DEBUG_PORT} — madock info:ports has the port on your side"
+  if [ "${MADOCK_DEBUG_BREAK:-}" = "true" ]; then
+    echo "[madock] nodejs/debug/break is on: nothing runs until a debugger attaches."
+  fi
+}
+
+# explain_no_inspector — say why debugging was asked for and not arranged.
+#
+# Refusing to start would be worse: the container is otherwise fine, and the
+# person asked for a debugger, not for the project to stop.
+explain_no_inspector() {
+  echo "[madock] debugging is enabled, and this project starts through $1, which is a Node program itself."
+  echo "[madock] It would take the inspector port and the dev server would start without a debugger,"
+  echo "[madock] so the IDE would attach to $1 rather than to your application. Nothing was changed."
+  echo "[madock] Set nodejs/script_type=command with the command to run, or add --inspect to the script in package.json."
+}
+
+configured=""
+configured_type="auto"
+node_env="${NODE_ENV:-development}"
+
+# mode is "package" (run through the project's package manager) or "command"
+# (hand it to a shell). A path to a file is a command.
+mode="package"
+
+if [ -n "$configured" ]; then
+  case "$configured_type" in
+    package)
+      mode="package"
+      ;;
+    command)
+      mode="command"
+      ;;
+    *)
+      # auto: a name package.json declares is a script, anything else is a
+      # command. Said out loud, because the difference decides what runs and
+      # a typo would otherwise become a shell command that fails at exec.
+      if has_script "$configured"; then
+        mode="package"
+      else
+        mode="command"
+        echo "[madock] \"$configured\" is not a script in package.json — running it as a command."
+      fi
+      ;;
+  esac
+  script="$configured"
+else
+  # No script configured. In production "dev" is the wrong guess: for a
+  # Shopify app it is `shopify app dev`, which prints a verification code and
+  # waits for a human. On a server nobody logs in, it gives up, and the
+  # container dies with it — start reported success minutes earlier.
+  if [ "$node_env" = "production" ]; then
+    if has_script start; then script="start"; elif has_script dev; then script="dev"; fi
+  else
+    if has_script dev; then script="dev"; elif has_script start; then script="start"; fi
+  fi
+fi
+
+if [ -z "$script" ]; then
+  # A bare REPL is the application here, so the inspector belongs on it.
+  if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
+    enable_inspector
+  fi
+  run_app node
+fi
+
+if [ "$mode" = "package" ] && ! has_script "$script"; then
+  echo "[madock] package.json has no \"$script\" script (nodejs/script_type=package)."
+  echo "[madock] Set nodejs/script to a script it declares, or nodejs/script_type=command to run it as a command."
+  exit 1
+fi
+
+deps_installed() {
+  # node_modules dir is created EARLY in yarn/npm install (during the
+  # link step) — it's not a reliable "install finished" signal. Look
+  # for a real completion marker instead:
+  #   yarn 4: .yarn/install-state.gz written on successful install
+  #   yarn 1: .yarn-integrity hash file in node_modules
+  #   npm:    node_modules/.package-lock.json
+  #   pnpm:   node_modules/.modules.yaml
+  [ -d node_modules ] || return 1
+  [ -f .yarn/install-state.gz ] && return 0
+  [ -f node_modules/.yarn-integrity ] && return 0
+  [ -f node_modules/.package-lock.json ] && return 0
+  [ -f node_modules/.modules.yaml ] && return 0
+  return 1
+}
+
+if ! deps_installed; then
+  echo "[madock] node_modules not ready in $(pwd) — waiting."
+  echo "[madock] Run \"madock install\" (or yarn install) to bootstrap; the dev server will start automatically once the install completes."
+  while ! deps_installed; do
+    sleep 5
+  done
+  echo "[madock] node_modules ready — starting dev server."
+fi
+
+if [ -f yarn.lock ]; then
+  pm="yarn"
+elif [ -f pnpm-lock.yaml ]; then
+  pm="pnpm"
+else
+  pm="npm run"
+fi
+
+# Source .env right before exec so the dev server sees DATABASE_URL /
+# REDIS_URL / SECRET_KEY etc. in process env. We can't source earlier
+# because madock setup -d writes .env only during the install phase,
+# which runs AFTER the container starts — at boot the file does not
+# exist yet. By this point the install has completed (we already
+# waited for its marker), so .env is guaranteed to be present.
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+if [ "$mode" = "command" ]; then
+  # The command is the application, so the first Node process it starts is the
+  # one worth attaching to.
+  if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
+    enable_inspector
+  fi
+  echo "[madock] starting: $script"
+  run_app sh -c "$script"
+fi
+
+if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
+  explain_no_inspector "$pm"
+fi
+
+echo "[madock] starting: $pm $script"
+run_app $pm $script
+MADOCK_EOF
+
+ENV WORKDIR=/var/www/html
+
+CMD ["/usr/local/bin/madock-entrypoint"]

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/ctx/nodejs.Dockerfile
@@ -202,10 +202,15 @@ fi
 
 if [ -f yarn.lock ]; then
   pm="yarn"
+  pm_name="yarn"
 elif [ -f pnpm-lock.yaml ]; then
   pm="pnpm"
+  pm_name="pnpm"
 else
   pm="npm run"
+  # The name on its own, because $pm carries the subcommand: a message built
+  # from it read "starts through npm run, which is a Node program itself".
+  pm_name="npm"
 fi
 
 # Source .env right before exec so the dev server sees DATABASE_URL /
@@ -231,7 +236,7 @@ if [ "$mode" = "command" ]; then
 fi
 
 if [ -n "${MADOCK_DEBUG_PORT:-}" ]; then
-  explain_no_inspector "$pm"
+  explain_no_inspector "$pm_name"
 fi
 
 echo "[madock] starting: $pm $script"

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "golden.test:host-gateway"
+    depends_on:
+      - nodejs
     restart: no
   nodejs:
     init: true

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-saleor/ctx/nginx.conf
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-saleor/ctx/nginx.conf
@@ -82,3 +82,100 @@ map $forwarded_proto $fastcgi_https {
     https   on;
 }
 
+server {
+    listen      80;
+    server_name golden.test;
+
+    set $SITE_PUBLIC /var/www/html/;
+
+    root $SITE_PUBLIC;
+
+    autoindex off;
+    charset UTF-8;
+
+    client_max_body_size       2G;
+
+    location / {
+        proxy_pass http://python:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $forwarded_host;
+        proxy_set_header X-Forwarded-Host $forwarded_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+
+    # Dotfiles and dot-directories at any path segment: .git, .env, .htaccess,
+    # .DS_Store. /.well-known/ is exempt, so an ACME challenge still reaches the
+    # application through location / above.
+    #
+    # First among the regex locations on purpose — nginx takes the first regex
+    # that matches, and the static-file block below matched `/.git/config.css`
+    # before the old rule at the bottom of this file ever got a chance.
+    #
+    # The dot has to follow a slash, which is what the old `(\.htaccess$|\.git)`
+    # got wrong: unanchored, it matched any URI merely containing ".git", so
+    # /media/logo.github.png was answered 403.
+    location ~ /\.(?!well-known/) {
+        deny all;
+    }
+
+    # Static files - try serving directly, then proxy to app.
+    #
+    # These headers reach only the files that really are in public_dir; anything
+    # missing goes to @proxy, which is a different location and keeps its own
+    # headers. In other words they land precisely on the files somebody edits by
+    # hand, which is why this used to be `expires 30d` plus `Cache-Control:
+    # public, immutable`: the browser stopped revalidating even on reload and
+    # served a month-old copy of a file that had just been changed. A long cache
+    # is right for names carrying a content hash, and this location matches every
+    # .css and .js by extension.
+    #
+    # `expires -1` sends `Cache-Control: no-cache`, which stores the file but
+    # revalidates it — with the ETag nginx puts on files, an unchanged one costs
+    # a 304 with no body. An installation that wants the long cache back can
+    # override this snippet per project from .madock/docker/snippets/nginx/.
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|map)$ {
+        try_files $uri @proxy;
+        expires -1;
+    }
+
+    location @proxy {
+        proxy_pass http://python:8000;
+        # Without this nginx talks 1.0 to the application, as it did here while
+        # location / above spoke 1.1: no keepalive, so every asset that is not on
+        # disk opened a new connection to the dev server, and a chunked response
+        # had to be delimited by closing the connection instead.
+        proxy_http_version 1.1;
+        proxy_set_header Host $forwarded_host;
+        proxy_set_header X-Forwarded-Host $forwarded_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    }
+
+    gzip on;
+    gzip_disable "msie6";
+
+    gzip_comp_level 6;
+    gzip_min_length 1100;
+    gzip_buffers 16 8k;
+    gzip_proxied any;
+    gzip_types
+        text/plain
+        text/css
+        text/js
+        text/xml
+        text/javascript
+        application/javascript
+        application/x-javascript
+        application/json
+        application/xml
+        application/xml+rss
+        image/svg+xml;
+    gzip_vary on;
+}

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-saleor/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-saleor/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "golden.test:host-gateway"
+    depends_on:
+      - python
     restart: no
   python:
     init: true

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-spree/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-spree/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "golden.test:host-gateway"
+    depends_on:
+      - ruby
     restart: no
   ruby:
     init: true

--- a/src/helper/configs/fpm.go
+++ b/src/helper/configs/fpm.go
@@ -3,6 +3,7 @@ package configs
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // fpmPool is the set of pool keys that have to agree with each other.
@@ -35,9 +36,23 @@ func ValidateFpmPool(conf map[string]string) error {
 
 	for _, key := range fpmPool {
 		raw, ok := conf[key]
-		if !ok || raw == "" {
-			// Nothing set — the embedded defaults answer for it, and those agree.
+		if !ok {
+			// Absent — the embedded defaults answer for it, and those agree.
 			continue
+		}
+
+		// Present and empty is a different thing, and it used to be waved
+		// through here on the same reasoning as absent. It is not the same: the
+		// defaults only fill keys that are *missing* (ConfigMapping skips any
+		// key already in the map, whatever its value), so an empty one survives
+		// all the way into the template and renders `pm.max_children = `. Then
+		// php-fpm refuses to start, from inside the container, after a full
+		// image build — which is the answer this function exists to move
+		// earlier.
+		if strings.TrimSpace(raw) == "" {
+			return fmt.Errorf("%s is set to nothing. Remove the key to take the default, or give it a number — "+
+				"an empty one reaches php-fpm as `pm.%s = ` and it refuses to start",
+				key, strings.TrimPrefix(key, "php/fpm/"))
 		}
 
 		value, err := strconv.Atoi(raw)
@@ -52,9 +67,10 @@ func ValidateFpmPool(conf map[string]string) error {
 	}
 
 	if len(values) != len(fpmPool) {
-		// A partially configured pool is answered by the defaults for the rest,
-		// and mixing the two here would compare a number against one this
-		// installation may not be using.
+		// Some keys are absent entirely and the defaults answer for those. What
+		// this installation will actually run is a mixture of the two, and
+		// comparing a configured number against a default it may not be using
+		// would refuse a pool that works.
 		return nil
 	}
 

--- a/src/helper/configs/fpm_test.go
+++ b/src/helper/configs/fpm_test.go
@@ -60,6 +60,21 @@ func TestValidateFpmPool(t *testing.T) {
 			wantErr: "not a number",
 		},
 		{
+			// Present and empty is not the same as absent, and treating it as
+			// such was a hole in the first version of this check: the defaults
+			// only fill keys that are *missing*, so an empty one survives into
+			// the template as `pm.max_children = ` and php-fpm refuses to start
+			// — from inside the container, after a full image build.
+			name:    "set to nothing",
+			conf:    pool("", "2", "1", "3"),
+			wantErr: "set to nothing",
+		},
+		{
+			name:    "set to whitespace",
+			conf:    pool("40", "  ", "1", "3"),
+			wantErr: "set to nothing",
+		},
+		{
 			// Half a pool is answered by the embedded defaults for the rest, and
 			// comparing against numbers this installation may not be using would
 			// refuse a configuration that works.


### PR DESCRIPTION
Two commits, both from reviewing what 4.0.4 had just changed rather than from anything failing.

## The platform fixtures pinned a php image for a Node platform

`writePlatformDefaults` called the platform's env writer directly and skipped the two keys the shared setup path writes first: `platform` and `language`.

`language` is what decides which template tree answers when a platform ships no file of its own — the resolver tries `docker/<platform>/`, then `docker/languages/<language>/`, then `docker/general/service/`. With the key empty the language step never applied, so **Medusa, which has no `Dockerfile` of its own, had its application image pinned as ubuntu with `CMD php-fpm8.4`**:

```diff
-FROM ubuntu:22.04
+FROM node:22.14.0
-CMD ["bash", "-c", "exec php-fpm8.4"]
+CMD ["/usr/local/bin/madock-entrypoint"]
```

A real `madock setup --platform=medusa` has always got the Node image — the product was right and the fixture was blessing something else, which is worse than no fixture: if the real resolution broke, this would have stayed green.

The version providers are blank-imported because they register in `init()` and in the real binary they arrive with the platform controllers, which cannot be imported here. A missing one now fails by name — **the first attempt at this fix set the keys without them, `GetVersionsForPlatform` answered "no such platform", and the whole change did nothing while the suite stayed green.** bigcommerce, saleor and spree fixtures move too.

## An empty pool value walked past the check that exists for it

`ValidateFpmPool` treated *present and empty* as *absent*, reasoning that the embedded defaults would answer for it. They do not: `ConfigMapping` fills only keys missing from the map, whatever their value. So `<max_children></max_children>` survives into the template as `pm.max_children = `, php-fpm refuses to start from inside the container after a full image build — exactly the answer the validator exists to move earlier — and the other three numbers were never compared either.

## `debug:enable` promised a port nothing would listen on

It finished by pointing at `info:ports` whenever the project had a node container. With anything but an explicit command the container starts through its package manager, the entrypoint declines to hand that the inspector, and nothing listens: the IDE answers "connection refused" and the explanation sits in the container's log, minutes after the command reported success. The refusal is now said where the switch is thrown, with the setting that changes it.

The one case this calls conservatively is a project with no `dev` or `start` script, where the entrypoint falls back to a bare `node` and the inspector does attach; the wording allows for it rather than pretending it cannot happen.

Also: the entrypoint's explanation called the package manager `npm run` — `$pm` carries the subcommand — in a message whose whole job is to be understood.
