### PR TITLE
The overridden-setting warning pointed into a release, not at the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v4.1.1**
+
+Fixed:
+- **The warning about an overridden `cron/enabled` named a file that a deploy replaces.** 4.1.0 started saying which copy of the config wins, and pointed at `<path>/.madock/config.xml`. Where deployer manages the project that path is a symlink to `current/.madock`, so it resolves into `releases/<n>/` — an edit there is real, and it lasts until the next release brings the file back from the repository. Measured on `extmag` on 2026-08-27: turning cron off for one project took three edits, in the runtime copy, in the release, and in git, and only the last one survives a deploy. The warning now says the path is a release and that the repository has to be changed as well
+
 **v4.1.0**
 
 Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 **v4.1.1**
 
 Fixed:
-- **The warning about an overridden `cron/enabled` named a file that a deploy replaces.** 4.1.0 started saying which copy of the config wins, and pointed at `<path>/.madock/config.xml`. Where deployer manages the project that path is a symlink to `current/.madock`, so it resolves into `releases/<n>/` — an edit there is real, and it lasts until the next release brings the file back from the repository. Measured on `extmag` on 2026-08-27: turning cron off for one project took three edits, in the runtime copy, in the release, and in git, and only the last one survives a deploy. The warning now says the path is a release and that the repository has to be changed as well
+- **The warning about an overridden `cron/enabled` sent the reader to a file a deploy replaces.** 4.1.0 started saying which copy of the config wins and pointed at `<path>/.madock/config.xml` with "edit it there". On a checkout that is the right file. Where deployer manages the project it is a symlink to `current/.madock` and resolves into `releases/<n>/`, so the edit works and is undone by the next release — worse than not working, because the value is right for a week and wrong afterwards with nothing said. The warning now names the repository, which is where that file is edited in either case, and says the path is a release when it is one. Measured on `extmag` on 2026-08-27, where turning cron off for one project was done in three files
+- Which of those three decides is settled rather than assumed: `ConfigMapping` fills only keys that are **missing**, and the project's own `.madock/config.xml` is read before the installation's copy — so the release wins, and editing the runtime copy under `/opt/madock/projects/<name>/` changes nothing while the project's file names the key
 
 **v4.1.0**
 

--- a/src/controller/general/cron/cron.go
+++ b/src/controller/general/cron/cron.go
@@ -79,8 +79,8 @@ func reportOverriddenSetting(projectName, want string) {
 		dir := strings.TrimRight(path, "/") + "/.madock"
 		own := dir + "/config.xml"
 		if paths.IsFileExist(own) {
-			fmtc.WarningLn("  " + own + " is merged over madock's own copy and wins. Edit cron/enabled there.")
-			reportReleaseCopy(dir)
+			fmtc.WarningLn("  " + own + " is merged over madock's own copy and wins.")
+			reportWhereToEdit(dir, own)
 		}
 	}
 
@@ -89,31 +89,36 @@ func reportOverriddenSetting(projectName, want string) {
 	}
 }
 
-// reportReleaseCopy says when the file just named is not a file but a way into
-// the current release.
+// reportWhereToEdit names the place this setting is actually changed.
 //
-// Where deployer manages a project, `<path>/.madock` is a symlink to
-// `current/.madock`, so the path above resolves into `releases/<n>/` — a
-// directory the next deploy replaces. Editing there works, and lasts until the
-// next release, at which point the value comes back from the repository and the
-// setting silently reverts. Measured on `extmag` on 2026-08-27: fixing this for
-// one project took three edits, and only the one in git survives a deploy.
-func reportReleaseCopy(dir string) {
+// That place is the project's repository, always: `.madock/config.xml` is
+// written by a person and committed, and no madock command writes into it. On a
+// checkout the file named above *is* that file. On a machine where deployer
+// manages the project it is not — `<path>/.madock` is a symlink to
+// `current/.madock`, so it resolves into `releases/<n>/`, which the next deploy
+// replaces. Editing there works and then silently reverts, which is worse than
+// not working: the value is right for a week and wrong afterwards, with nothing
+// said.
+//
+// Measured on `extmag` on 2026-08-27: turning cron off for one project was done
+// in three files, and only the one in git decides what the next release has.
+func reportWhereToEdit(dir, own string) {
 	info, err := os.Lstat(dir)
 	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		fmtc.WarningLn("  Change cron/enabled in " + own + " — that file is the project's own and belongs in its repository.")
 		return
 	}
 
 	resolved, err := filepath.EvalSymlinks(dir)
 	if err != nil {
-		// The link is there and its target cannot be read. Still worth saying,
-		// because the half that matters — this is a release, not the source —
-		// does not depend on knowing where it points.
+		// The link is there and its target cannot be read. Still worth saying:
+		// the half that matters is that this is a release rather than the
+		// source, and that does not depend on knowing where it points.
 		resolved = "the current release"
 	}
 
-	fmtc.WarningLn("  That path is a symlink into the current release (" + resolved + ").")
-	fmtc.WarningLn("  An edit there holds until the next deploy, which brings the file back from the repository — change it in the project's repository as well.")
+	fmtc.WarningLn("  That path is a symlink into the current release (" + resolved + "), which the next deploy replaces.")
+	fmtc.WarningLn("  Change cron/enabled in the project's repository and deploy — an edit made here is undone by the next release.")
 }
 
 func Disable() {

--- a/src/controller/general/cron/cron.go
+++ b/src/controller/general/cron/cron.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/faradey/madock/v4/src/command"
@@ -75,15 +76,44 @@ func reportOverriddenSetting(projectName, want string) {
 	fmtc.WarningLn("cron/enabled is " + inEffect + " for this project, not " + want + " — something is overriding what was just written.")
 
 	if path := conf["path"]; path != "" {
-		own := strings.TrimRight(path, "/") + "/.madock/config.xml"
+		dir := strings.TrimRight(path, "/") + "/.madock"
+		own := dir + "/config.xml"
 		if paths.IsFileExist(own) {
 			fmtc.WarningLn("  " + own + " is merged over madock's own copy and wins. Edit cron/enabled there.")
+			reportReleaseCopy(dir)
 		}
 	}
 
 	if want == "true" {
 		fmtc.WarningLn("  Cron is running now, and the next `start` will read the effective value and stop it again.")
 	}
+}
+
+// reportReleaseCopy says when the file just named is not a file but a way into
+// the current release.
+//
+// Where deployer manages a project, `<path>/.madock` is a symlink to
+// `current/.madock`, so the path above resolves into `releases/<n>/` — a
+// directory the next deploy replaces. Editing there works, and lasts until the
+// next release, at which point the value comes back from the repository and the
+// setting silently reverts. Measured on `extmag` on 2026-08-27: fixing this for
+// one project took three edits, and only the one in git survives a deploy.
+func reportReleaseCopy(dir string) {
+	info, err := os.Lstat(dir)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return
+	}
+
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		// The link is there and its target cannot be read. Still worth saying,
+		// because the half that matters — this is a release, not the source —
+		// does not depend on knowing where it points.
+		resolved = "the current release"
+	}
+
+	fmtc.WarningLn("  That path is a symlink into the current release (" + resolved + ").")
+	fmtc.WarningLn("  An edit there holds until the next deploy, which brings the file back from the repository — change it in the project's repository as well.")
 }
 
 func Disable() {

--- a/src/controller/general/cron/cron.go
+++ b/src/controller/general/cron/cron.go
@@ -77,10 +77,10 @@ func reportOverriddenSetting(projectName, want string) {
 
 	if path := conf["path"]; path != "" {
 		dir := strings.TrimRight(path, "/") + "/.madock"
-		own := dir + "/config.xml"
-		if paths.IsFileExist(own) {
-			fmtc.WarningLn("  " + own + " is merged over madock's own copy and wins.")
-			reportWhereToEdit(dir, own)
+		if own := dir + "/config.xml"; paths.IsFileExist(own) {
+			for _, line := range whereToEditLines(dir, own) {
+				fmtc.WarningLn("  " + line)
+			}
 		}
 	}
 
@@ -89,24 +89,27 @@ func reportOverriddenSetting(projectName, want string) {
 	}
 }
 
-// reportWhereToEdit names the place this setting is actually changed.
+// whereToEditLines says which file overrides the setting and where it is
+// actually changed.
 //
-// That place is the project's repository, always: `.madock/config.xml` is
-// written by a person and committed, and no madock command writes into it. On a
-// checkout the file named above *is* that file. On a machine where deployer
-// manages the project it is not — `<path>/.madock` is a symlink to
-// `current/.madock`, so it resolves into `releases/<n>/`, which the next deploy
-// replaces. Editing there works and then silently reverts, which is worse than
-// not working: the value is right for a week and wrong afterwards, with nothing
-// said.
+// The place is the project's repository in both cases: `.madock/config.xml` is
+// written by a person and committed, and no madock command writes into it. What
+// differs is whether the path on this machine *is* that file. On a checkout it
+// is. Where deployer manages the project it is not — `<path>/.madock` is a
+// symlink to `current/.madock` and resolves into `releases/<n>/`, which the next
+// deploy replaces. An edit there works and then silently reverts, which is worse
+// than not working: the value is right for a week and wrong afterwards, with
+// nothing said.
 //
 // Measured on `extmag` on 2026-08-27: turning cron off for one project was done
-// in three files, and only the one in git decides what the next release has.
-func reportWhereToEdit(dir, own string) {
+// in three files, and only the one in git decides what the next release carries.
+func whereToEditLines(dir, own string) []string {
 	info, err := os.Lstat(dir)
 	if err != nil || info.Mode()&os.ModeSymlink == 0 {
-		fmtc.WarningLn("  Change cron/enabled in " + own + " — that file is the project's own and belongs in its repository.")
-		return
+		return []string{
+			own + " is the project's own file and wins over madock's copy.",
+			"Change cron/enabled there — it is committed to the project's repository.",
+		}
 	}
 
 	resolved, err := filepath.EvalSymlinks(dir)
@@ -117,8 +120,10 @@ func reportWhereToEdit(dir, own string) {
 		resolved = "the current release"
 	}
 
-	fmtc.WarningLn("  That path is a symlink into the current release (" + resolved + "), which the next deploy replaces.")
-	fmtc.WarningLn("  Change cron/enabled in the project's repository and deploy — an edit made here is undone by the next release.")
+	return []string{
+		own + " wins over madock's copy, and that path is a symlink into the current release (" + resolved + ").",
+		"Change cron/enabled in the project's repository and deploy — an edit made here is undone by the next release.",
+	}
 }
 
 func Disable() {

--- a/src/controller/general/cron/cron_override_test.go
+++ b/src/controller/general/cron/cron_override_test.go
@@ -1,0 +1,80 @@
+package cron
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// On a plain checkout the path madock reads is the file a person edits, so the
+// message is short and names it once.
+func TestOverrideMessageNamesTheProjectFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".madock")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", dir, err)
+	}
+	own := filepath.Join(dir, "config.xml")
+
+	lines := whereToEditLines(dir, own)
+	joined := strings.Join(lines, "\n")
+
+	if !strings.Contains(joined, own) {
+		t.Errorf("the message does not name the file that overrides the setting:\n%s", joined)
+	}
+	if strings.Contains(joined, "release") {
+		t.Errorf("a checkout was described as a release:\n%s", joined)
+	}
+	if strings.Count(joined, own) != 1 {
+		t.Errorf("the path is repeated; say it once:\n%s", joined)
+	}
+}
+
+// Where deployer manages the project, `.madock` is a symlink into the current
+// release. The path is still the one madock reads, and it is emphatically not
+// the one to edit: the next deploy restores the file from the repository, so an
+// edit there is right until a release undoes it with nothing said.
+func TestOverrideMessageSendsADeployedProjectToItsRepository(t *testing.T) {
+	root := t.TempDir()
+	release := filepath.Join(root, "releases", "46", ".madock")
+	if err := os.MkdirAll(release, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", release, err)
+	}
+	if err := os.WriteFile(filepath.Join(release, "config.xml"), []byte("<config/>"), 0o644); err != nil {
+		t.Fatalf("writing the release config: %v", err)
+	}
+	if err := os.Symlink(filepath.Join("releases", "46", ".madock"), filepath.Join(root, ".madock")); err != nil {
+		t.Fatalf("linking .madock: %v", err)
+	}
+
+	dir := filepath.Join(root, ".madock")
+	lines := whereToEditLines(dir, filepath.Join(dir, "config.xml"))
+	joined := strings.Join(lines, "\n")
+
+	if !strings.Contains(joined, "repository") {
+		t.Errorf("a deployed project was not sent to its repository:\n%s", joined)
+	}
+	if !strings.Contains(joined, "releases/46") {
+		t.Errorf("the message does not say where the path actually leads:\n%s", joined)
+	}
+	if !strings.Contains(joined, "undone by the next release") {
+		t.Errorf("the message does not say what happens to an edit made here:\n%s", joined)
+	}
+}
+
+// A broken link still answers the half that matters. Refusing to speak because
+// the target cannot be read would leave the reader editing a release believing
+// it is the source.
+func TestOverrideMessageSpeaksThroughABrokenLink(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Symlink(filepath.Join(root, "gone"), filepath.Join(root, ".madock")); err != nil {
+		t.Fatalf("linking .madock: %v", err)
+	}
+
+	dir := filepath.Join(root, ".madock")
+	joined := strings.Join(whereToEditLines(dir, filepath.Join(dir, "config.xml")), "\n")
+
+	if !strings.Contains(joined, "repository") {
+		t.Errorf("a broken link silenced the advice:\n%s", joined)
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.0"
+const Version = "4.1.1"


### PR DESCRIPTION
Follow-up to #87, from a real fix on production this evening.

4.1.0 started saying which copy of the config overrides what `cron:enable` wrote, naming `<path>/.madock/config.xml`. On a deployer-managed project that path is a symlink to `current/.madock` and resolves into `releases/<n>/` — so the edit is real and lasts exactly until the next deploy restores the file from the repository.

Measured on `extmag`: turning cron off for `multilangwords-com` took three edits — runtime copy, release, git — and only the last survives a deploy. The warning now names the release and says the repository has to change too.

No rollout planned for this on its own; it ships with the next release.