### PR TITLE
The stale-job check flagged working jobs, then flagged nothing at all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,12 @@ jobs:
   e2e:
     name: End-to-end
     needs: test
+    # 45 was five minutes over the suite's own budget, so the two ran out
+    # together and the job was killed at whichever fired first. The inner
+    # timeout is 60m now; this one has to be able to outlive it, or a suite that
+    # would have said which test hung gets replaced by a job that says nothing.
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v4.1.3**
+
+Fixed:
+- **The stale-job check called six working jobs broken the first time it met a real crontab.** It tested every absolute-looking word in the command, and `pricer-shopify` schedules `.../poke.sh /api/cron/apply-due` — where the second word is a URL route, not a path. Only the program is checked now, and the script after it when the program is an interpreter; arguments are left alone. A check that cries wolf on a healthy project is worse than no check, because it is the one people learn to skip
+- **And before that it reported nothing at all, for a reason worth writing down.** A crontab line begins with five fields that are usually `*`, and splitting it without `set -f` expands them into the names of whatever files are in the working directory — so the fields shifted and the program was never examined. Both faults were found by running the check against the machines rather than against the tests, which passed throughout
+
 **v4.1.2**
 
 Fixed:

--- a/src/helper/docker/cron.go
+++ b/src/helper/docker/cron.go
@@ -523,21 +523,45 @@ func CronJobCount(projectName string) (int, bool) {
 	return count, true
 }
 
-// cronDeadPathProbe prints every installed job whose command names a path the
-// container does not have.
+// cronDeadPathProbe prints every installed job whose *executable* the container
+// does not have.
 //
-// The redirect is cut off first: a job writing into a log file that has not been
-// created yet is healthy, and reporting it would make the check unusable on the
-// day it matters. What is left is the interpreter and the script, which have to
-// exist for the job to do anything at all.
-const cronDeadPathProbe = `crontab -u www-data -l 2>/dev/null | while IFS= read -r line; do
+// Only the program is checked, and the script when the program is an
+// interpreter. An argument is not a path, however much it looks like one:
+// pricer-shopify schedules
+// `.../poke.sh /api/cron/apply-due >> .../cron.log`, where the second word is a
+// URL route — checking every absolute-looking token reported all six of its
+// working jobs as broken the first time this ran against a real crontab. A
+// check that cries wolf on a healthy project is worse than no check, because it
+// is the one people learn to skip.
+//
+// The redirect is cut off first for the same reason: a job writing into a log
+// file that does not exist yet is healthy.
+// `set -f` is not decoration: a crontab line starts with five fields that are
+// usually `*`, and splitting it without disabling globbing expands those into
+// the names of whatever files happen to be in the working directory. The first
+// version of this probe did exactly that and silently reported nothing at all,
+// including for a job whose script was demonstrably missing.
+const cronDeadPathProbe = `set -f
+crontab -u www-data -l 2>/dev/null | while IFS= read -r line; do
 	case "$line" in ''|'#'*) continue ;; esac
 	command=${line%%>*}
-	for token in $command; do
-		case "$token" in
-			/*) [ -e "$token" ] || { printf '%s\n' "$line"; break; } ;;
-		esac
-	done
+	set -- $command
+	# Five schedule fields, then the program.
+	[ $# -ge 6 ] || continue
+	shift 5
+	program=$1
+	script=$2
+	case "$program" in
+		/*) [ -e "$program" ] || { printf '%s\n' "$line"; continue; } ;;
+	esac
+	case "${program##*/}" in
+		php|php[0-9]*|python|python[0-9]*|node|perl|ruby|sh|bash)
+			case "$script" in
+				/*) [ -e "$script" ] || printf '%s\n' "$line" ;;
+			esac
+			;;
+	esac
 done`
 
 // CronJobsWithMissingPaths lists the installed jobs that name something the

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.2"
+const Version = "4.1.3"

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -204,7 +204,12 @@ To insist anyway: MADOCK_E2E_ALLOW_LOCAL_DOCKER=yes $0 run-local"
     printf 'building madock for linux/%s\n' "$goarch"
     ( cd "$repo_root" && GOOS=linux GOARCH="$goarch" go build -o "$binary" . )
 
-    timeout="40m"
+    # 40m was the suite's own running time, not a margin. It passed at 33–36
+    # minutes for months and then began being killed mid-test on a slower
+    # runner, with `panic: test timed out` — which reads exactly like a hung
+    # command and is nothing of the sort. The suite grows; the budget has to
+    # leave room for that, and for a runner having a bad morning.
+    timeout="60m"
     [ "$platforms" = "yes" ] && timeout="90m"
 
     MADOCK_E2E_BIN="$binary" MADOCK_E2E_PLATFORMS="$platforms" \


### PR DESCRIPTION
Follow-up to #89, found by running the new check against the servers rather than against its tests.

**It called six working jobs broken.** The probe tested every absolute-looking word in the command, and `pricer-shopify` schedules `.../poke.sh /api/cron/apply-due` — the second word is a URL route, not a path. Only the program is checked now, plus the script after it when the program is an interpreter.

**The fix for that then reported nothing at all**, including for a job whose script was missing: a crontab line starts with five fields that are usually `*`, and splitting it without `set -f` expands them into filenames from the working directory, so the fields shifted and the program was never examined.

Both are invisible to the unit tests, which pass either way — the probe is shell running inside a container, and a real crontab is the only place it can be wrong. Verified by hand against three job shapes: interpreter with a missing script (flagged), program missing (flagged), and a working job whose argument looks like a path (not flagged).