### PR TITLE
Give the e2e driver a --quarantined flag

### DIFF
--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -12,6 +12,7 @@
 #   ./test/e2e/e2e.sh reset         delete it and build it again
 #   ./test/e2e/e2e.sh auth          give the VM your composer credentials
 #   ./test/e2e/e2e.sh run-local     no VM — only where the daemon is disposable
+#   ./test/e2e/e2e.sh run --quarantined   include the tests under quarantine
 #   ./test/e2e/e2e.sh plan-shards 8 split the suite into N groups, as JSON
 #
 # The suite is behind the `e2e` build tag, so `go test ./...` does not compile
@@ -130,10 +131,14 @@ cmd_run() {
     # transcript and to anything that matches commands by prefix, and this is
     # the one switch that changes a five-minute run into an hour-long one.
     platforms=""
-    if [ "${1:-}" = "--platforms" ]; then
-        platforms="yes"
-        shift
-    fi
+    quarantined=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --platforms)   platforms="yes"; shift ;;
+            --quarantined) quarantined="yes"; shift ;;
+            *) break ;;
+        esac
+    done
     [ "${MADOCK_E2E_PLATFORMS:-}" = "yes" ] && platforms="yes"
 
     ensure_running
@@ -172,6 +177,7 @@ cmd_run() {
     limactl shell "$VM_NAME" -- env \
         MADOCK_E2E_BIN="$binary" \
         MADOCK_E2E_PLATFORMS="$platforms" \
+        MADOCK_E2E_QUARANTINED="$quarantined" \
         PATH="/usr/local/go/bin:/usr/local/bin:/usr/bin:/bin" \
         sh -c "cd '$repo_root' && go test -tags=e2e -count=1 -v -timeout=$timeout ./test/e2e/...$quoted"
 }
@@ -194,10 +200,14 @@ To insist anyway: MADOCK_E2E_ALLOW_LOCAL_DOCKER=yes $0 run-local"
     # Same switch as `run`, so the CI job that wants the platform tests asks for
     # them the same way a person does.
     platforms=""
-    if [ "${1:-}" = "--platforms" ]; then
-        platforms="yes"
-        shift
-    fi
+    quarantined=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --platforms)   platforms="yes"; shift ;;
+            --quarantined) quarantined="yes"; shift ;;
+            *) break ;;
+        esac
+    done
     [ "${MADOCK_E2E_PLATFORMS:-}" = "yes" ] && platforms="yes"
 
     goarch=$(go env GOHOSTARCH)
@@ -214,6 +224,7 @@ To insist anyway: MADOCK_E2E_ALLOW_LOCAL_DOCKER=yes $0 run-local"
     [ "$platforms" = "yes" ] && timeout="90m"
 
     MADOCK_E2E_BIN="$binary" MADOCK_E2E_PLATFORMS="$platforms" \
+        MADOCK_E2E_QUARANTINED="$quarantined" \
         go test -tags=e2e -count=1 -v -timeout="$timeout" ./test/e2e/... "$@"
 }
 


### PR DESCRIPTION
`TestSecondDatabaseIsItsOwnDatabase` is quarantined behind `MADOCK_E2E_QUARANTINED`, and until now the only way to run it was to set that variable in front of the command.

This script already argues against exactly that, in the comment beside `--platforms`:

> `--platforms` as a flag rather than an environment variable: an inline assignment in front of a command is invisible to shell history, to a transcript and to anything that matches commands by prefix, and this is the one switch that changes a five-minute run into an hour-long one.

The switch that decides whether a quarantined test runs deserves the same treatment, and for the same reasons. It also puts the command in the usage block at the top of `e2e.sh`, so it can be found — a variable name buried in a test's comment cannot.

```
./test/e2e/e2e.sh run --quarantined -run TestSecondDatabaseIsItsOwnDatabase
```

**Why it matters beyond tidiness:** a quarantined test that cannot be run is a deleted test with extra steps. Whoever picks up the data-directory question needs to switch it back on in one command, not reconstruct it from history. CI stays unaffected — the default is off, so the suite's green is still honest.

Both flags now parse in either order, and `--quarantined` reaches the test process the same way `--platforms` does. Used already: both reproduction runs of the quarantined test went through it.
