### PR TITLE
project:list --stale said everything was fine about entries it could not see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+**v4.1.6**
+
+Fixed:
+- **A registry entry that resolves to nothing was invisible to the command written to find it.** `projects/<name>` is a symlink wherever a project was set up from a temporary checkout, and when the target goes — a `/tmp` directory a reboot cleared — the entry was skipped, on the reasoning that an entry whose own directory is gone is not an entry. True, and the wrong conclusion: the name is still in the registry and nothing said so. Measured on the BigCommerce cluster VM on 2026-08-27, where four such entries sat: `project:list` answered `No projects are registered in this installation` and `project:list --stale`, which exists for exactly "the source is gone", answered `Every registered project still has its source directory`. A confident wrong answer from the check written for the case, and the one wrong answer that reads as good news
+- Such an entry is now reported as `broken-link`, and the listing names what it points at — usually a temporary directory, which tells the reader what happened without a search
+- **A directory with no `config.xml` is still skipped, deliberately.** It was tempting to report those too, since a madock run outside a project leaves one named after the current directory. But `projects/` legitimately holds support directories beside the projects — `bin`, `docker` and `assets` on the installation this was checked on — so reporting them would put three lines of noise on every machine, and the existing test that pins this was right
+
 **v4.1.5**
 
 Fixed:

--- a/src/controller/general/project/list/list.go
+++ b/src/controller/general/project/list/list.go
@@ -151,7 +151,7 @@ func Execute() {
 			return
 		}
 		if args.Stale {
-			fmtc.SuccessLn("Every registered project still has its source directory")
+			fmtc.SuccessLn("Every registry entry resolves, and every project still has its source directory")
 			return
 		}
 		fmtc.WarningLn("No projects are registered in this installation")
@@ -171,6 +171,8 @@ func Execute() {
 		switch row.State {
 		case configs.ProjectMissingSource:
 			fmtc.ErrorLn(fmt.Sprintf("%-28s %ssource is gone: %s", row.Name, state, row.Path))
+		case configs.ProjectBrokenLink:
+			fmtc.ErrorLn(fmt.Sprintf("%-28s %sregistry entry links to nothing: %s", row.Name, state, row.Path))
 		case configs.ProjectNoPath:
 			fmtc.WarningLn(fmt.Sprintf("%-28s %sno path recorded", row.Name, state))
 		default:

--- a/src/helper/configs/projects.go
+++ b/src/helper/configs/projects.go
@@ -407,6 +407,19 @@ const (
 	// project's own directory, which is exactly what nobody does for a project
 	// they have forgotten about.
 	ProjectNoPath = "no-path"
+	// ProjectBrokenLink — the registry entry is a symlink to a directory that no
+	// longer exists, so nothing about the project can be read at all.
+	//
+	// It used to be skipped, on the reasoning that an entry pointing at nothing
+	// is not a project. True, and the wrong conclusion: it is still a name in
+	// the registry, and the commands written to find exactly this said the
+	// opposite of it. Measured on the BigCommerce cluster VM on 2026-08-27 —
+	// four entries linked into a /tmp directory a reboot had cleared, and
+	// `project:list` answered "No projects are registered" while
+	// `project:list --stale`, which exists for "the source is gone", answered
+	// "Every registered project still has its source directory". A confident
+	// wrong answer from the check written for the case.
+	ProjectBrokenLink = "broken-link"
 )
 
 // ProjectEntry is one registry entry and what is true about it.
@@ -437,13 +450,33 @@ func ListProjectsIn(execDir string) []ProjectEntry {
 		// symlink to a directory says false. Registry entries are symlinks wherever
 		// a project was set up from a temporary checkout, and on a cluster VM with
 		// four such projects this command answered "No projects are registered" —
-		// the one wrong answer that reads as good news. A broken symlink fails the
-		// Stat and is skipped, which is right for an entry pointing at nothing.
-		info, statErr := os.Stat(filepath.Join(execDir, "projects", entry.Name()))
-		if statErr != nil || !info.IsDir() {
+		// the one wrong answer that reads as good news.
+		//
+		// **An entry that resolves to nothing is reported, not skipped.** It was
+		// dropped here, which left the registry holding names no command would
+		// say out loud — see ProjectBrokenLink for what that cost.
+		entryPath := filepath.Join(execDir, "projects", entry.Name())
+		info, statErr := os.Stat(entryPath)
+		if statErr != nil {
+			if _, lstatErr := os.Lstat(entryPath); lstatErr != nil {
+				continue
+			}
+			// It is there and it resolves to nothing: a symlink whose target is
+			// gone. The target is worth naming — it is usually a temporary
+			// directory a reboot cleared, and that tells the reader what
+			// happened without a search.
+			target, _ := os.Readlink(entryPath)
+			out = append(out, ProjectEntry{Name: entry.Name(), Path: target, State: ProjectBrokenLink})
 			continue
 		}
-		configPath := filepath.Join(execDir, "projects", entry.Name(), "config.xml")
+		if !info.IsDir() {
+			continue
+		}
+		// A directory with no config.xml is not an entry and is not litter
+		// either: `projects/` holds support directories beside the projects —
+		// `bin`, `docker` and `assets` on the installation this was checked on.
+		// Reporting those would put three lines of noise on every machine.
+		configPath := filepath.Join(entryPath, "config.xml")
 		if !paths.IsFileExist(configPath) {
 			continue
 		}

--- a/src/helper/configs/projects_registry_test.go
+++ b/src/helper/configs/projects_registry_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// TestListProjectsIn covers the four things a registry entry can be, because three
+// TestListProjectsIn covers the five things a registry entry can be, because four
 // of them were invisible before this existed.
 //
 // On the machine this was written on, two of fifty-eight entries pointed at
@@ -67,8 +67,14 @@ func TestListProjectsIn(t *testing.T) {
 		t.Fatalf("linking the registry entry: %v", err)
 	}
 
-	// And one pointing at nothing, which must be skipped rather than reported: an
-	// entry whose own directory is gone is not an entry.
+	// And one pointing at nothing, which must be **reported**. It used to be
+	// skipped, on the reasoning that an entry whose own directory is gone is not
+	// an entry — true, and the wrong conclusion: the name is still in the
+	// registry and nothing would say so. Measured on the BigCommerce cluster VM
+	// on 2026-08-27, where four entries linked into a /tmp directory a reboot
+	// had cleared: `project:list` answered "No projects are registered" and
+	// `project:list --stale`, which exists for "the source is gone", answered
+	// "Every registered project still has its source directory".
 	if err := os.Symlink(filepath.Join(execDir, "gone"), filepath.Join(execDir, "projects", "broken-link")); err != nil {
 		t.Fatalf("linking the broken registry entry: %v", err)
 	}
@@ -88,14 +94,15 @@ func TestListProjectsIn(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"alive":   ProjectOk,
-		"deleted": ProjectMissingSource,
-		"legacy":  ProjectNoPath,
-		"linked":  ProjectOk,
+		"alive":       ProjectOk,
+		"deleted":     ProjectMissingSource,
+		"legacy":      ProjectNoPath,
+		"linked":      ProjectOk,
+		"broken-link": ProjectBrokenLink,
 	}
 
 	if len(got) != len(want) {
-		t.Fatalf("entries = %v, want %v — a directory without a config.xml is not a project", got, want)
+		t.Fatalf("entries = %v, want %v — a support directory is not an entry, and an entry that resolves to nothing still is one", got, want)
 	}
 	for name, state := range want {
 		if got[name] != state {
@@ -109,5 +116,32 @@ func TestListProjectsIn(t *testing.T) {
 func TestListProjectsInWithoutRegistry(t *testing.T) {
 	if entries := ListProjectsIn(t.TempDir()); entries != nil {
 		t.Errorf("entries = %v, want none", entries)
+	}
+}
+
+// The point of reporting a broken link rather than skipping it, stated as the
+// filter that `project:list --stale` actually applies: anything that is not
+// ProjectOk. Before the change the entry never reached this list, so the
+// filtered form answered that everything was fine — which is the one wrong
+// answer that reads as good news.
+func TestStaleFilterSeesAnEntryThatResolvesToNothing(t *testing.T) {
+	execDir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(execDir, "projects"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(execDir, "gone"), filepath.Join(execDir, "projects", "cluster-run")); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := 0
+	for _, entry := range ListProjectsIn(execDir) {
+		if entry.State != ProjectOk {
+			stale++
+		}
+	}
+
+	if stale != 1 {
+		t.Errorf("--stale would report %d entries, want 1 — an entry pointing at nothing is exactly what it is for", stale)
 	}
 }

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.5"
+const Version = "4.1.6"


### PR DESCRIPTION
`projects/<name>` is a symlink wherever a project was set up from a temporary checkout. When the target goes — a `/tmp` directory a reboot cleared — the entry was skipped, on the reasoning that an entry whose own directory is gone is not an entry.

True, and the wrong conclusion: the name is still in the registry, and nothing said so.

**Measured on the BigCommerce cluster VM on 2026-08-27**, where four such entries sat, linked into a `/tmp/shopify-cluster-e2e-…` a reboot had cleared:

```
$ madock project:list
No projects are registered in this installation

$ madock project:list --stale
Every registered project still has its source directory
```

`--stale` exists for exactly "the source is gone" and answered the opposite. A confident wrong answer from the check written for the case — and the one wrong answer that reads as good news.

## What changed

- an entry that resolves to nothing is reported as `broken-link` instead of being skipped, and the listing names what it points at. That is usually a temporary directory, which tells the reader what happened without a search
- the all-clear line no longer claims more than it checked

## What deliberately did not change

A directory with no `config.xml` is still skipped. It was tempting to report those too — a madock run outside a project leaves one named after the current directory, and three were sitting on that VM. But `projects/` legitimately holds support directories beside the projects (`bin`, `docker`, `assets` on the installation this was checked on), so reporting them would put three lines of noise on every machine. The existing test pinning that was right; the one pinning "skip a broken link" was not, and now says why.

## Tests

Both verified to fail against the previous behaviour:

- `TestListProjectsIn` gains the fifth state
- `TestStaleFilterSeesAnEntryThatResolvesToNothing` applies the filter `--stale` actually applies, so the regression cannot come back through the controller
