### PR TITLE
project:orphans — what is left of projects the registry has forgotten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v4.1.7**
+
+Added:
+- **`project:orphans`** — what is left on this machine of projects the registry no longer knows. A project's volume outlives its directory, and after that nothing named it: it is not in the registry, `project:list` reads the registry, and `project:remove` needs a registry entry there is none of. On a server, where destructive commands are switched off as shipped, the only cleanup available was to delete the directories and leave the volumes — turning litter that can be seen into litter that cannot. Found a real one on the machine it was written on the first time it ran: three volumes belonging to a project retired long ago
+- **It removes nothing and prints the command rather than running it.** Deleting these stays with `project:remove`, behind `allow_destructive_commands`. A `--remove` flag here would be a second route past that switch, and the switch is what stops a habit from becoming an accident
+- Only what madock made: the compose label is on every stack on the machine, and reporting somebody else's would be calling a stranger's disk our mess. A name the registry still holds is left alone even when madock cannot read its entry — that is `project:list --stale`'s business, and two commands arguing about one thing is how both stop being believed
+- `--json` for tooling, and a non-zero exit when something is found, the way `project:list --stale` answers
+
 **v4.1.6**
 
 Fixed:

--- a/src/controller/all/all.go
+++ b/src/controller/all/all.go
@@ -54,6 +54,7 @@ import (
 	_ "github.com/faradey/madock/v4/src/controller/bigcommerce"
 	_ "github.com/faradey/madock/v4/src/controller/bigcommerce/setup"
 	_ "github.com/faradey/madock/v4/src/controller/custom/setup"
+	_ "github.com/faradey/madock/v4/src/controller/general/project/orphans"
 	_ "github.com/faradey/madock/v4/src/controller/general/snapshot/create"
 	_ "github.com/faradey/madock/v4/src/controller/general/snapshot/restore"
 	_ "github.com/faradey/madock/v4/src/controller/general/ssl"

--- a/src/controller/all/global_commands_test.go
+++ b/src/controller/all/global_commands_test.go
@@ -23,7 +23,9 @@ import (
 // usually that something about the registry is wrong; template:convert because a
 // directory of templates is a directory of templates — refusing to run it outside
 // a project would be refusing it in exactly the place somebody keeps a copy of
-// their overrides; and project:remove because an orphan — a registry entry whose
+// their overrides; project:orphans because what it reports is precisely what has
+// no project directory left to stand in — a volume that outlived the project it
+// belonged to; and project:remove because an orphan — a registry entry whose
 // source directory is gone — has nowhere to be removed from. project:list has been
 // able to name those since 3.8.50 and nothing could act on them: the tool described
 // a problem it could not fix. The exemption is narrow in the handler, not here —
@@ -37,6 +39,7 @@ func TestGlobalCommands(t *testing.T) {
 		"mcp",
 		"project:clone",
 		"project:list",
+		"project:orphans",
 		"project:remove",
 		"proxy:logs",
 		"setup",

--- a/src/controller/general/project/orphans/orphans.go
+++ b/src/controller/general/project/orphans/orphans.go
@@ -1,0 +1,87 @@
+package orphans
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/faradey/madock/v4/src/command"
+	"github.com/faradey/madock/v4/src/helper/cli/arg_struct"
+	"github.com/faradey/madock/v4/src/helper/cli/attr"
+	"github.com/faradey/madock/v4/src/helper/cli/fmtc"
+	"github.com/faradey/madock/v4/src/helper/cli/output"
+	"github.com/faradey/madock/v4/src/helper/configs"
+	"github.com/faradey/madock/v4/src/helper/docker"
+)
+
+func init() {
+	command.Register(&command.Definition{
+		Aliases:    []string{"project:orphans"},
+		JSONOutput: true,
+		Handler:    Execute,
+		Help:       "List docker volumes, networks and images left by projects the registry no longer knows. Supports --json (-j) output",
+		Category:   "project",
+		// Global for the same reason project:list is: it describes the
+		// installation rather than a project, and the reason to run it is
+		// usually that a project is gone.
+		Global: true,
+	})
+}
+
+// Output is the --json payload.
+type Output struct {
+	Orphans []docker.Orphan `json:"orphans"`
+}
+
+// Execute prints what is left on the machine of projects that no longer exist.
+//
+// A project's volume outlives its directory, and after that nothing named it:
+// it is not in the registry, `project:list` reads the registry, and
+// `project:remove` needs a registry entry there is none of. On a server, where
+// destructive commands are switched off as shipped, the only cleanup available
+// was to delete the directories and leave the volumes — turning litter that can
+// be seen into litter that cannot.
+//
+// **It removes nothing, and prints the command rather than running it.**
+// Deleting these stays with `project:remove` behind
+// `allow_destructive_commands`; a removal here would be a second route past
+// that switch.
+func Execute() {
+	args := attr.Parse(new(arg_struct.ControllerGeneralProjectOrphans)).(*arg_struct.ControllerGeneralProjectOrphans)
+
+	// Every name the registry holds counts as known, including entries it can no
+	// longer read: a broken entry is somebody's to fix and belongs to
+	// `project:list --stale`, not here.
+	known := map[string]bool{}
+	for _, entry := range configs.ListProjects() {
+		known[entry.Name] = true
+	}
+
+	found := docker.FindOrphans(known)
+
+	if args.Json {
+		output.PrintJSON(Output{Orphans: found})
+		return
+	}
+
+	if len(found) == 0 {
+		fmtc.SuccessLn("Nothing on this machine belongs to a project the registry has forgotten")
+		return
+	}
+
+	current := ""
+	for _, orphan := range found {
+		if orphan.Project != current {
+			current = orphan.Project
+			fmtc.WarningLn(fmt.Sprintf("%s — no entry in this installation", current))
+		}
+		fmt.Printf("  %-8s %s\n", orphan.Kind, orphan.Name)
+	}
+
+	fmt.Println()
+	fmtc.ToDoLn("These are not removed here. Set up the project again and use project:remove, " +
+		"or remove them by hand — docker volume rm <name>, docker network rm <name>, docker image rm <name>")
+
+	// Non-zero so a check can ask the question, the way project:list --stale
+	// does. What is found is not an error, but it is something to act on.
+	os.Exit(1)
+}

--- a/src/helper/cli/arg_struct/args.go
+++ b/src/helper/cli/arg_struct/args.go
@@ -219,6 +219,10 @@ type ControllerGeneralServiceList struct {
 	attr.Arguments
 }
 
+type ControllerGeneralProjectOrphans struct {
+	attr.Arguments
+}
+
 type ControllerGeneralDbExecute struct {
 	attr.Arguments
 	DBServiceName string `arg:"-s,--service" help:"DB service name. For example: db"`

--- a/src/helper/docker/orphans.go
+++ b/src/helper/docker/orphans.go
@@ -1,0 +1,116 @@
+package docker
+
+import (
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Orphan is one docker resource whose compose project no longer has an entry in
+// madock's registry.
+type Orphan struct {
+	// Kind is volume, network or image.
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+	// Project is the madock project name, with the compose prefix stripped —
+	// the name somebody would type, not the label docker stores.
+	Project string `json:"project"`
+}
+
+// composeLabel is what `docker compose up` writes on everything it creates, and
+// the only thing that still connects a volume to the project it belonged to
+// once the project's directory is gone.
+const composeLabel = "com.docker.compose.project"
+
+// FindOrphans reports docker resources left behind by projects the registry no
+// longer knows.
+//
+// It exists because nothing could answer the question. A project's volume
+// survives its directory, and after that no madock command mentions it: the
+// volume is not in the registry, `project:list` reads the registry, and
+// `project:remove` works from a registry entry there is none of. On a machine
+// where destructive commands are switched off — which is every server, as
+// shipped — the only cleanup available was to delete the directories and leave
+// the volumes, which turns visible litter into invisible litter.
+//
+// **Read-only, and deliberately so.** Removing what this finds stays with
+// `project:remove`, behind `allow_destructive_commands`. A `--remove` flag here
+// would be a second route to deleting volumes that does not pass that switch,
+// and the switch is the thing that stops a habit from becoming an accident.
+//
+// `known` is the set of project names the registry holds, including the ones it
+// can no longer read: a broken registry entry is somebody's to fix, not an
+// orphan, and `project:list --stale` is where it belongs.
+func FindOrphans(known map[string]bool) []Orphan {
+	var out []Orphan
+
+	out = append(out, orphansOf("volume", dockerLines("volume", "ls"), known)...)
+	out = append(out, orphansOf("network", dockerLines("network", "ls"), known)...)
+	out = append(out, orphansOf("image", dockerLines("image", "ls"), known)...)
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Project != out[j].Project {
+			return out[i].Project < out[j].Project
+		}
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	return out
+}
+
+// dockerLines asks docker for everything of one kind that carries the compose
+// label, as "<name>\t<project label>" per line.
+//
+// A failure is an empty list rather than an error: this command reports what it
+// can see, and a docker that cannot be asked is a machine where there is
+// nothing to report anyway — every other madock command will have said so
+// first, and louder.
+func dockerLines(kind, verb string) []string {
+	cmd := exec.Command("docker", kind, verb,
+		"--filter", "label="+composeLabel,
+		"--format", "{{.Name}}\t{{.Label \""+composeLabel+"\"}}")
+
+	// `docker image ls` prints the repository under .Name only for images that
+	// have one; the format is the same otherwise.
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	return strings.Split(strings.TrimSpace(string(out)), "\n")
+}
+
+// orphansOf keeps the resources whose project is one of madock's and is not in
+// the registry.
+//
+// Split from the docker call so the rule can be tested without a daemon, which
+// matters more here than usual: the rule is what decides whether somebody is
+// shown their own leftovers or somebody else's containers.
+func orphansOf(kind string, lines []string, known map[string]bool) []Orphan {
+	var out []Orphan
+
+	for _, line := range lines {
+		name, label, ok := strings.Cut(strings.TrimSpace(line), "\t")
+		if !ok || name == "" || label == "" {
+			continue
+		}
+
+		// Only what madock made. Another compose project on the same machine —
+		// somebody's own stack, a CI runner's — carries this label too, and
+		// listing it would be reporting a stranger's disk as our mess.
+		project, isOurs := strings.CutPrefix(label, "madock_")
+		if !isOurs || project == "" {
+			continue
+		}
+		if known[project] {
+			continue
+		}
+
+		out = append(out, Orphan{Kind: kind, Name: name, Project: project})
+	}
+
+	return out
+}

--- a/src/helper/docker/orphans_test.go
+++ b/src/helper/docker/orphans_test.go
@@ -1,0 +1,55 @@
+package docker
+
+import "testing"
+
+// The rule this tests is the one that decides whether somebody is shown their
+// own leftovers or a stranger's disk, so it is separated from the docker call
+// and tested without a daemon.
+func TestOrphansOf(t *testing.T) {
+	known := map[string]bool{"live-project": true}
+
+	lines := []string{
+		// Belongs to a project that is still registered.
+		"madock_live-project_dbdata\tmadock_live-project",
+		// The case the command exists for: a volume that outlived its project.
+		"madock_gone-project_dbdata\tmadock_gone-project",
+		// Somebody else's compose stack on the same machine. Reporting it would
+		// be calling a stranger's disk our mess.
+		"someone_elses_data\tsomeone-elses-stack",
+		// Malformed or unlabelled lines are not guesses to make.
+		"no-tab-here",
+		"\tmadock_gone-project",
+		"orphan-with-no-label\t",
+		// A label that is exactly the prefix names no project.
+		"weird\tmadock_",
+	}
+
+	got := orphansOf("volume", lines, known)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d orphans, want 1: %+v", len(got), got)
+	}
+	if got[0].Name != "madock_gone-project_dbdata" {
+		t.Errorf("name = %q", got[0].Name)
+	}
+	// The name somebody would type, not the label docker stores.
+	if got[0].Project != "gone-project" {
+		t.Errorf("project = %q, want the prefix stripped", got[0].Project)
+	}
+	if got[0].Kind != "volume" {
+		t.Errorf("kind = %q", got[0].Kind)
+	}
+}
+
+// A registry entry madock cannot read is still an entry. It belongs to
+// `project:list --stale`, which now reports it, and listing it here as well
+// would ask two commands to argue about the same thing.
+func TestOrphansOfLeavesRegisteredNamesAlone(t *testing.T) {
+	known := map[string]bool{"broken-entry": true}
+
+	got := orphansOf("network", []string{"madock_broken-entry_default\tmadock_broken-entry"}, known)
+
+	if len(got) != 0 {
+		t.Errorf("a name the registry still holds was reported as an orphan: %+v", got)
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.6"
+const Version = "4.1.7"


### PR DESCRIPTION
A project's volume outlives its directory, and after that nothing names it: it is not in the registry, `project:list` reads the registry, and `project:remove` needs a registry entry there is none of.

On a server — where destructive commands are switched off as shipped — the only cleanup available was to delete the directories and leave the volumes, which turns litter that can be seen into litter that cannot. That gap is also why the question of where a fresh project finds someone else's MariaDB data directory has been argued from logs rather than measured.

**It found a real one the first time it ran**, on the machine it was written on: three volumes belonging to a project retired long ago.

```
$ madock project:orphans
owens-illinois-old — no entry in this installation
  volume   madock_owens-illinois-old_dbdata
  volume   madock_owens-illinois-old_dbdata2
  volume   madock_owens-illinois-old_opensearch_vlm_3.0.0

These are not removed here. Set up the project again and use project:remove, or
remove them by hand — docker volume rm <name>, …
```

## The boundaries, which are the design

- **It removes nothing, and prints the command rather than running it.** Deleting these stays with `project:remove`, behind `allow_destructive_commands`. A `--remove` flag here would be a second route past that switch, and the switch is what stops a habit from becoming an accident
- **Only what madock made.** `com.docker.compose.project` is on every compose stack on the machine; reporting somebody else's would be calling a stranger's disk our mess. The filter is the `madock_` prefix the generator already uses
- **A name the registry still holds is left alone**, even when madock cannot read its entry. A broken entry is `project:list --stale`'s business — two commands arguing about one thing is how both stop being believed
- Global, because what it reports is precisely what has no project directory left to stand in. Added to the pinned list in `TestGlobalCommands`, which is a deliberate edit in two places by design
- `--json`, and a non-zero exit when something is found, the way `project:list --stale` answers

## Tests

The filtering rule is a pure function tested without a daemon — it is what decides whether somebody sees their own leftovers or a stranger's containers. Covered: a live project's volume is not an orphan, a dead project's is, another stack's is ignored, malformed and unlabelled lines are not guesses, and a bare `madock_` label names no project.
