### PR TITLE
The node container set NODE_ENV, so next build built production in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+**v4.1.8**
+
+Fixed:
+- **The node container set `NODE_ENV=development`, so `next build` built a production bundle in development mode.** Next obeys the variable instead of setting `production` itself, and React's internals then disagree with themselves: prerendering `/_global-error` dies on `useContext` with a null dispatcher. No Next application in madock could be built for production
+- The cost was in the finding. Next prints `You are using a non-standard "NODE_ENV" value` as the first line of every build, and that line went past about ten times — a warning printed always is indistinguishable from noise until it is the cause. React 19.1 against 19.2, Node 22 against 24, Next 16.2 against 16.3, styled-components, `transpilePackages`, the root layout and a custom error page were all ruled out first; an application of two files with none of our dependencies failed the same way, which is what finally pointed at the environment
+- **madock needs the value, but not the name.** It decides one thing — whether the entrypoint starts `dev` or `start` when `nodejs/script` is not configured — and under the standard name that private choice was published to every tool in the container. It travels as `MADOCK_NODE_ENV` now; a project's own `NODE_ENV` is still honoured, so anything that set it deliberately keeps working
+- **The same line was hardcoded in the Medusa and Spree storefronts**, both of which run Next, so two shipped platforms had the defect as well. Removed there: `next dev` and `next build` each decide for themselves. `sylius-encore` is left alone — Encore takes its mode from its command, and there is no measurement for it
+- The test is in the container rather than in the rendered file, because the question is what the container ends up with. It checks both directions: `NODE_ENV` is unset, and `MADOCK_NODE_ENV` is there — without the second, the entrypoint could no longer tell `dev` from `start` and the fix would have broken starting instead
+
 **v4.1.7**
 
 Added:

--- a/docker/snippets/docker-compose/nodejs.yml
+++ b/docker/snippets/docker-compose/nodejs.yml
@@ -6,10 +6,25 @@
       dockerfile: nodejs.Dockerfile
     tty: true
     environment:
-      # Was hardcoded to "development", which is wrong the moment a project
-      # runs on a server: libraries branch on it, and the entrypoint reads it
-      # when no nodejs/script is configured.
-      NODE_ENV: "{{{.nodejs.env}}}"
+      # **Not NODE_ENV.** This is madock's own decision — which script the
+      # entrypoint starts when `nodejs/script` is not configured — and naming it
+      # NODE_ENV published a private choice to every tool in the container.
+      #
+      # `next build` obeys it instead of setting `production` itself, so a
+      # production bundle was built in development mode and React's internals
+      # disagreed with themselves: prerendering `/_global-error` died on
+      # `useContext` with a null dispatcher. Next says so in the first line of
+      # every build — "You are using a non-standard NODE_ENV value" — and that
+      # line went past about ten times, because a warning printed always is
+      # indistinguishable from noise until it is the cause. The search cost an
+      # hour and ruled out React, Node, Next, styled-components and the app's
+      # own layout before an application of two files failed the same way.
+      #
+      # Nothing has to set NODE_ENV: `next dev` sets development, `next build`
+      # and `next start` set production. A project that genuinely wants it can
+      # put it in its own package.json script, where it applies to one command
+      # rather than to everything that runs in the container.
+      MADOCK_NODE_ENV: "{{{.nodejs.env}}}"
       # Polling-based file watching for macOS bind mounts (no inotify forwarding).
       # Harmless on Linux. Picked up by next/webpack/chokidar/medusa watcher.
       WATCHPACK_POLLING: "true"

--- a/docker/snippets/docker-compose/spree-storefront.yml
+++ b/docker/snippets/docker-compose/spree-storefront.yml
@@ -11,7 +11,11 @@
     volumes:
       - ./src/{{{.spree.storefront.path}}}:{{{.spree.storefront.workdir}}}:cached
     environment:
-      NODE_ENV: "development"
+      # No NODE_ENV here: this container runs Next, and `next build` obeys the
+      # variable instead of setting `production` itself — a production bundle
+      # built in development mode, with React's internals disagreeing with
+      # themselves. `next dev` and `next build` each decide for themselves. See
+      # the nodejs service for the measurement this comes from.
       # Server-side calls (Next.js SSR) hit the Rails backend inside
       # the docker network.
       SPREE_API_URL: "http://ruby:3000"

--- a/docker/snippets/docker-compose/storefront.yml
+++ b/docker/snippets/docker-compose/storefront.yml
@@ -11,7 +11,11 @@
     volumes:
       - ./src/{{{.medusa.storefront.path}}}:{{{.medusa.storefront.workdir}}}:cached
     environment:
-      NODE_ENV: "development"
+      # No NODE_ENV here: this container runs Next, and `next build` obeys the
+      # variable instead of setting `production` itself — a production bundle
+      # built in development mode, with React's internals disagreeing with
+      # themselves. `next dev` and `next build` each decide for themselves. See
+      # the nodejs service for the measurement this comes from.
       # Server-side calls (Next.js SSR) hit the backend inside the docker network.
       MEDUSA_BACKEND_URL: "http://nodejs:9000"
       # Browser-side calls (CSR) cannot resolve the docker hostname, so route

--- a/docker/snippets/dockerfile/nodejs/footer
+++ b/docker/snippets/dockerfile/nodejs/footer
@@ -101,7 +101,12 @@ explain_no_inspector() {
 
 configured="{{{.nodejs.script}}}"
 configured_type="{{{.nodejs.script_type}}}"
-node_env="${NODE_ENV:-development}"
+# madock's own, not NODE_ENV: the value decides which script to start and
+# nothing else, and under the standard name every tool in the container obeyed
+# it — `next build` built a production bundle in development mode. NODE_ENV is
+# still honoured when a project sets it itself, so an existing project that
+# relies on it keeps working.
+node_env="${MADOCK_NODE_ENV:-${NODE_ENV:-development}}"
 
 # mode is "package" (run through the project's package manager) or "command"
 # (hand it to a shell). A path to a file is a command.

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/ctx/nodejs.Dockerfile
@@ -133,7 +133,12 @@ explain_no_inspector() {
 
 configured="docker-start"
 configured_type="command"
-node_env="${NODE_ENV:-development}"
+# madock's own, not NODE_ENV: the value decides which script to start and
+# nothing else, and under the standard name every tool in the container obeyed
+# it — `next build` built a production bundle in development mode. NODE_ENV is
+# still honoured when a project sets it itself, so an existing project that
+# relies on it keeps working.
+node_env="${MADOCK_NODE_ENV:-${NODE_ENV:-development}}"
 
 # mode is "package" (run through the project's package manager) or "command"
 # (hand it to a shell). A path to a file is a command.

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/docker-compose.yml
@@ -42,10 +42,25 @@ services:
       dockerfile: nodejs.Dockerfile
     tty: true
     environment:
-      # Was hardcoded to "development", which is wrong the moment a project
-      # runs on a server: libraries branch on it, and the entrypoint reads it
-      # when no nodejs/script is configured.
-      NODE_ENV: "production"
+      # **Not NODE_ENV.** This is madock's own decision — which script the
+      # entrypoint starts when `nodejs/script` is not configured — and naming it
+      # NODE_ENV published a private choice to every tool in the container.
+      #
+      # `next build` obeys it instead of setting `production` itself, so a
+      # production bundle was built in development mode and React's internals
+      # disagreed with themselves: prerendering `/_global-error` died on
+      # `useContext` with a null dispatcher. Next says so in the first line of
+      # every build — "You are using a non-standard NODE_ENV value" — and that
+      # line went past about ten times, because a warning printed always is
+      # indistinguishable from noise until it is the cause. The search cost an
+      # hour and ruled out React, Node, Next, styled-components and the app's
+      # own layout before an application of two files failed the same way.
+      #
+      # Nothing has to set NODE_ENV: `next dev` sets development, `next build`
+      # and `next start` set production. A project that genuinely wants it can
+      # put it in its own package.json script, where it applies to one command
+      # rather than to everything that runs in the container.
+      MADOCK_NODE_ENV: "production"
       # Polling-based file watching for macOS bind mounts (no inotify forwarding).
       # Harmless on Linux. Picked up by next/webpack/chokidar/medusa watcher.
       WATCHPACK_POLLING: "true"

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/ctx/nodejs.Dockerfile
@@ -122,7 +122,12 @@ explain_no_inspector() {
 
 configured=""
 configured_type="auto"
-node_env="${NODE_ENV:-development}"
+# madock's own, not NODE_ENV: the value decides which script to start and
+# nothing else, and under the standard name every tool in the container obeyed
+# it — `next build` built a production bundle in development mode. NODE_ENV is
+# still honoured when a project sets it itself, so an existing project that
+# relies on it keeps working.
+node_env="${MADOCK_NODE_ENV:-${NODE_ENV:-development}}"
 
 # mode is "package" (run through the project's package manager) or "command"
 # (hand it to a shell). A path to a file is a command.

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/docker-compose.yml
@@ -42,10 +42,25 @@ services:
       dockerfile: nodejs.Dockerfile
     tty: true
     environment:
-      # Was hardcoded to "development", which is wrong the moment a project
-      # runs on a server: libraries branch on it, and the entrypoint reads it
-      # when no nodejs/script is configured.
-      NODE_ENV: "development"
+      # **Not NODE_ENV.** This is madock's own decision — which script the
+      # entrypoint starts when `nodejs/script` is not configured — and naming it
+      # NODE_ENV published a private choice to every tool in the container.
+      #
+      # `next build` obeys it instead of setting `production` itself, so a
+      # production bundle was built in development mode and React's internals
+      # disagreed with themselves: prerendering `/_global-error` died on
+      # `useContext` with a null dispatcher. Next says so in the first line of
+      # every build — "You are using a non-standard NODE_ENV value" — and that
+      # line went past about ten times, because a warning printed always is
+      # indistinguishable from noise until it is the cause. The search cost an
+      # hour and ruled out React, Node, Next, styled-components and the app's
+      # own layout before an application of two files failed the same way.
+      #
+      # Nothing has to set NODE_ENV: `next dev` sets development, `next build`
+      # and `next start` set production. A project that genuinely wants it can
+      # put it in its own package.json script, where it applies to one command
+      # rather than to everything that runs in the container.
+      MADOCK_NODE_ENV: "development"
       # Polling-based file watching for macOS bind mounts (no inotify forwarding).
       # Harmless on Linux. Picked up by next/webpack/chokidar/medusa watcher.
       WATCHPACK_POLLING: "true"

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/ctx/nodejs.Dockerfile
@@ -122,7 +122,12 @@ explain_no_inspector() {
 
 configured=""
 configured_type="auto"
-node_env="${NODE_ENV:-development}"
+# madock's own, not NODE_ENV: the value decides which script to start and
+# nothing else, and under the standard name every tool in the container obeyed
+# it — `next build` built a production bundle in development mode. NODE_ENV is
+# still honoured when a project sets it itself, so an existing project that
+# relies on it keeps working.
+node_env="${MADOCK_NODE_ENV:-${NODE_ENV:-development}}"
 
 # mode is "package" (run through the project's package manager) or "command"
 # (hand it to a shell). A path to a file is a command.

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/docker-compose.yml
@@ -42,10 +42,25 @@ services:
       dockerfile: nodejs.Dockerfile
     tty: true
     environment:
-      # Was hardcoded to "development", which is wrong the moment a project
-      # runs on a server: libraries branch on it, and the entrypoint reads it
-      # when no nodejs/script is configured.
-      NODE_ENV: "development"
+      # **Not NODE_ENV.** This is madock's own decision — which script the
+      # entrypoint starts when `nodejs/script` is not configured — and naming it
+      # NODE_ENV published a private choice to every tool in the container.
+      #
+      # `next build` obeys it instead of setting `production` itself, so a
+      # production bundle was built in development mode and React's internals
+      # disagreed with themselves: prerendering `/_global-error` died on
+      # `useContext` with a null dispatcher. Next says so in the first line of
+      # every build — "You are using a non-standard NODE_ENV value" — and that
+      # line went past about ten times, because a warning printed always is
+      # indistinguishable from noise until it is the cause. The search cost an
+      # hour and ruled out React, Node, Next, styled-components and the app's
+      # own layout before an application of two files failed the same way.
+      #
+      # Nothing has to set NODE_ENV: `next dev` sets development, `next build`
+      # and `next start` set production. A project that genuinely wants it can
+      # put it in its own package.json script, where it applies to one command
+      # rather than to everything that runs in the container.
+      MADOCK_NODE_ENV: "development"
       # Polling-based file watching for macOS bind mounts (no inotify forwarding).
       # Harmless on Linux. Picked up by next/webpack/chokidar/medusa watcher.
       WATCHPACK_POLLING: "true"

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/ctx/nodejs.Dockerfile
@@ -120,7 +120,12 @@ explain_no_inspector() {
 
 configured=""
 configured_type="auto"
-node_env="${NODE_ENV:-development}"
+# madock's own, not NODE_ENV: the value decides which script to start and
+# nothing else, and under the standard name every tool in the container obeyed
+# it — `next build` built a production bundle in development mode. NODE_ENV is
+# still honoured when a project sets it itself, so an existing project that
+# relies on it keeps working.
+node_env="${MADOCK_NODE_ENV:-${NODE_ENV:-development}}"
 
 # mode is "package" (run through the project's package manager) or "command"
 # (hand it to a shell). A path to a file is a command.

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/docker-compose.yml
@@ -42,10 +42,25 @@ services:
       dockerfile: nodejs.Dockerfile
     tty: true
     environment:
-      # Was hardcoded to "development", which is wrong the moment a project
-      # runs on a server: libraries branch on it, and the entrypoint reads it
-      # when no nodejs/script is configured.
-      NODE_ENV: "development"
+      # **Not NODE_ENV.** This is madock's own decision — which script the
+      # entrypoint starts when `nodejs/script` is not configured — and naming it
+      # NODE_ENV published a private choice to every tool in the container.
+      #
+      # `next build` obeys it instead of setting `production` itself, so a
+      # production bundle was built in development mode and React's internals
+      # disagreed with themselves: prerendering `/_global-error` died on
+      # `useContext` with a null dispatcher. Next says so in the first line of
+      # every build — "You are using a non-standard NODE_ENV value" — and that
+      # line went past about ten times, because a warning printed always is
+      # indistinguishable from noise until it is the cause. The search cost an
+      # hour and ruled out React, Node, Next, styled-components and the app's
+      # own layout before an application of two files failed the same way.
+      #
+      # Nothing has to set NODE_ENV: `next dev` sets development, `next build`
+      # and `next start` set production. A project that genuinely wants it can
+      # put it in its own package.json script, where it applies to one command
+      # rather than to everything that runs in the container.
+      MADOCK_NODE_ENV: "development"
       # Polling-based file watching for macOS bind mounts (no inotify forwarding).
       # Harmless on Linux. Picked up by next/webpack/chokidar/medusa watcher.
       WATCHPACK_POLLING: "true"

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/ctx/nodejs.Dockerfile
@@ -128,7 +128,12 @@ explain_no_inspector() {
 
 configured=""
 configured_type="auto"
-node_env="${NODE_ENV:-development}"
+# madock's own, not NODE_ENV: the value decides which script to start and
+# nothing else, and under the standard name every tool in the container obeyed
+# it — `next build` built a production bundle in development mode. NODE_ENV is
+# still honoured when a project sets it itself, so an existing project that
+# relies on it keeps working.
+node_env="${MADOCK_NODE_ENV:-${NODE_ENV:-development}}"
 
 # mode is "package" (run through the project's package manager) or "command"
 # (hand it to a shell). A path to a file is a command.

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/docker-compose.yml
@@ -7,10 +7,25 @@ services:
       dockerfile: nodejs.Dockerfile
     tty: true
     environment:
-      # Was hardcoded to "development", which is wrong the moment a project
-      # runs on a server: libraries branch on it, and the entrypoint reads it
-      # when no nodejs/script is configured.
-      NODE_ENV: "development"
+      # **Not NODE_ENV.** This is madock's own decision — which script the
+      # entrypoint starts when `nodejs/script` is not configured — and naming it
+      # NODE_ENV published a private choice to every tool in the container.
+      #
+      # `next build` obeys it instead of setting `production` itself, so a
+      # production bundle was built in development mode and React's internals
+      # disagreed with themselves: prerendering `/_global-error` died on
+      # `useContext` with a null dispatcher. Next says so in the first line of
+      # every build — "You are using a non-standard NODE_ENV value" — and that
+      # line went past about ten times, because a warning printed always is
+      # indistinguishable from noise until it is the cause. The search cost an
+      # hour and ruled out React, Node, Next, styled-components and the app's
+      # own layout before an application of two files failed the same way.
+      #
+      # Nothing has to set NODE_ENV: `next dev` sets development, `next build`
+      # and `next start` set production. A project that genuinely wants it can
+      # put it in its own package.json script, where it applies to one command
+      # rather than to everything that runs in the container.
+      MADOCK_NODE_ENV: "development"
       # Polling-based file watching for macOS bind mounts (no inotify forwarding).
       # Harmless on Linux. Picked up by next/webpack/chokidar/medusa watcher.
       WATCHPACK_POLLING: "true"

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/ctx/nodejs.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/ctx/nodejs.Dockerfile
@@ -122,7 +122,12 @@ explain_no_inspector() {
 
 configured=""
 configured_type="auto"
-node_env="${NODE_ENV:-development}"
+# madock's own, not NODE_ENV: the value decides which script to start and
+# nothing else, and under the standard name every tool in the container obeyed
+# it — `next build` built a production bundle in development mode. NODE_ENV is
+# still honoured when a project sets it itself, so an existing project that
+# relies on it keeps working.
+node_env="${MADOCK_NODE_ENV:-${NODE_ENV:-development}}"
 
 # mode is "package" (run through the project's package manager) or "command"
 # (hand it to a shell). A path to a file is a command.

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/docker-compose.yml
@@ -24,10 +24,25 @@ services:
       dockerfile: nodejs.Dockerfile
     tty: true
     environment:
-      # Was hardcoded to "development", which is wrong the moment a project
-      # runs on a server: libraries branch on it, and the entrypoint reads it
-      # when no nodejs/script is configured.
-      NODE_ENV: "development"
+      # **Not NODE_ENV.** This is madock's own decision — which script the
+      # entrypoint starts when `nodejs/script` is not configured — and naming it
+      # NODE_ENV published a private choice to every tool in the container.
+      #
+      # `next build` obeys it instead of setting `production` itself, so a
+      # production bundle was built in development mode and React's internals
+      # disagreed with themselves: prerendering `/_global-error` died on
+      # `useContext` with a null dispatcher. Next says so in the first line of
+      # every build — "You are using a non-standard NODE_ENV value" — and that
+      # line went past about ten times, because a warning printed always is
+      # indistinguishable from noise until it is the cause. The search cost an
+      # hour and ruled out React, Node, Next, styled-components and the app's
+      # own layout before an application of two files failed the same way.
+      #
+      # Nothing has to set NODE_ENV: `next dev` sets development, `next build`
+      # and `next start` set production. A project that genuinely wants it can
+      # put it in its own package.json script, where it applies to one command
+      # rather than to everything that runs in the container.
+      MADOCK_NODE_ENV: "development"
       # Polling-based file watching for macOS bind mounts (no inotify forwarding).
       # Harmless on Linux. Picked up by next/webpack/chokidar/medusa watcher.
       WATCHPACK_POLLING: "true"
@@ -50,7 +65,11 @@ services:
     volumes:
       - ./src/storefront:/var/www/html/storefront:cached
     environment:
-      NODE_ENV: "development"
+      # No NODE_ENV here: this container runs Next, and `next build` obeys the
+      # variable instead of setting `production` itself — a production bundle
+      # built in development mode, with React's internals disagreeing with
+      # themselves. `next dev` and `next build` each decide for themselves. See
+      # the nodejs service for the measurement this comes from.
       # Server-side calls (Next.js SSR) hit the backend inside the docker network.
       MEDUSA_BACKEND_URL: "http://nodejs:9000"
       # Browser-side calls (CSR) cannot resolve the docker hostname, so route

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-spree/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-spree/docker-compose.yml
@@ -43,7 +43,11 @@ services:
     volumes:
       - ./src/storefront:/var/www/html/storefront:cached
     environment:
-      NODE_ENV: "development"
+      # No NODE_ENV here: this container runs Next, and `next build` obeys the
+      # variable instead of setting `production` itself — a production bundle
+      # built in development mode, with React's internals disagreeing with
+      # themselves. `next dev` and `next build` each decide for themselves. See
+      # the nodejs service for the measurement this comes from.
       # Server-side calls (Next.js SSR) hit the Rails backend inside
       # the docker network.
       SPREE_API_URL: "http://ruby:3000"

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.7"
+const Version = "4.1.8"

--- a/test/e2e/node_env_test.go
+++ b/test/e2e/node_env_test.go
@@ -1,0 +1,68 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNodeContainerDoesNotSetNodeEnv pins the one thing the rendered file cannot
+// prove: what the container actually ends up with.
+//
+// madock used to put NODE_ENV in the node container's environment, because the
+// entrypoint needs to know whether to start `dev` or `start` when no
+// nodejs/script is configured. That is madock's own decision under a name every
+// tool in the container obeys — and `next build` obeys it instead of setting
+// `production` itself, so a production bundle is built in development mode and
+// React's internals disagree with themselves: prerendering `/_global-error`
+// dies on `useContext` with a null dispatcher.
+//
+// The cost was in the finding, not the fix. Next prints "You are using a
+// non-standard NODE_ENV value" as the first line of every build, and that line
+// went past about ten times — a warning printed always is indistinguishable
+// from noise until it is the cause. React, Node, Next, styled-components and
+// the application's own layout were all ruled out first, and an application of
+// two files failed the same way.
+//
+// The decision now travels as MADOCK_NODE_ENV. A project that wants NODE_ENV
+// sets it itself, in a package.json script, where it applies to one command
+// rather than to everything in the container.
+func TestNodeContainerDoesNotSetNodeEnv(t *testing.T) {
+	p := newProject(t, "e2enodeenv")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=nodejs",
+		"--hosts=e2enodeenv.test",
+	)
+	p.run(20*time.Minute, "start")
+
+	// printenv exits non-zero when the variable is unset, which is the passing
+	// case here — so this asks rather than asserts through the exit code.
+	out, err := p.tryRun(2*time.Minute, "cli", "--service", "nodejs", "printenv", "NODE_ENV")
+	if err == nil && strings.TrimSpace(lastLine(out)) != "" {
+		t.Errorf("the node container carries NODE_ENV=%s, so `next build` will build a production bundle in development mode:\n%s",
+			strings.TrimSpace(lastLine(out)), out)
+	}
+
+	// And the decision madock does need is still there, under its own name.
+	own := p.run(2*time.Minute, "cli", "--service", "nodejs", "printenv", "MADOCK_NODE_ENV")
+	if !strings.Contains(own, "development") {
+		t.Errorf("MADOCK_NODE_ENV is not set, so the entrypoint cannot tell dev from start:\n%s", own)
+	}
+}
+
+// lastLine returns the last non-empty line, which is where a command's answer
+// is when madock has printed anything of its own first.
+func lastLine(out string) string {
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return lines[i]
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
`next build` obeys `NODE_ENV` instead of setting `production` itself. The node container set it to `development`, so a production bundle was built in development mode and React's internals disagreed with themselves:

```
TypeError: Cannot read properties of null (reading 'useContext')
Error occurred prerendering page "/_global-error"
```

No Next application in madock could be built for production.

**The cost was in the finding.** Next says so in the first line of every build — `You are using a non-standard "NODE_ENV" value in your environment` — and that line went past about ten times. A warning printed always is indistinguishable from noise until it is the cause. Ruled out first: React 19.1 against 19.2, Node 22 against 24, Next 16.2 against 16.3, styled-components, `transpilePackages`, the root layout, a custom error page. An application of two files with none of our dependencies failed the same way, which is what pointed at the environment rather than the code.

## madock needs the value, not the name

The variable decides exactly one thing: whether the entrypoint starts `dev` or `start` when `nodejs/script` is not configured. That is madock's own choice, and the standard name published it to every tool in the container.

It travels as `MADOCK_NODE_ENV` now. A project's own `NODE_ENV` is still honoured by the entrypoint, so anything that set it deliberately keeps working.

## Wider than the report

The same line was hardcoded in two more services — the **Medusa** and **Spree** storefronts, both of which run Next, as the comments beside them say. So two shipped platforms carried the defect as well, not only our own applications. Removed there: `next dev` and `next build` each decide for themselves.

`sylius-encore` is deliberately left alone. Encore takes its mode from its command, and there is no measurement for it — changing something I have not reasoned about is worse than leaving it.

## The test is in the container

The golden files prove what was generated; the question is what the container ends up with, and the image could have set the variable too. So the check runs `printenv` inside it, and in both directions:

- `NODE_ENV` unset — the defect
- `MADOCK_NODE_ENV` present — without it the entrypoint can no longer tell `dev` from `start`, and the fix would have broken starting instead of building

Verified to fail against the previous template, naming what it found:

```
node_env_test.go:46: the node container carries NODE_ENV=development,
    so `next build` will build a production bundle in development mode
```
