### PR TITLE
Two false alarms and the registry login that let them be seen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,40 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # Sign in to the registry before anything pulls an image.
+      #
+      # A runner pulls anonymously and shares its outbound address with
+      # thousands of others, so the rate limit is spent by strangers. Measured
+      # 2026-08-27 23:23: three shards of one run failed inside the same minute,
+      # each on a different image — `unauthorized: authentication required` for
+      # mailcatcher, `failed to resolve source metadata` for postgres:16 and for
+      # ubuntu:22.04. No test reported a wrong answer; three of them could not
+      # fetch what they needed, and the run reads exactly like a regression in
+      # the change under review. The change under review was the first thing
+      # suspected, which is the real cost of this.
+      #
+      # An authenticated pull is counted against the account rather than the
+      # address, and a free account is enough.
+      #
+      # **The check is inside the step, not in an `if`.** The `secrets` context
+      # is not available to a step's condition — `if: secrets.X != ''` evaluates
+      # against nothing and skips the step every time, which is a login that is
+      # never performed and never reported. A fork has no secret, and there the
+      # run should fail on the limit if it must, not on an empty password.
+      #
+      # Plain CLI rather than an action: this is two lines of shell, and an
+      # action is a supply chain.
+      - name: Sign in to the image registry
+        env:
+          REGISTRY_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "$REGISTRY_USER" ] || [ -z "$REGISTRY_TOKEN" ]; then
+            echo "No registry credentials on this run — pulling anonymously, which is rate limited by address."
+            exit 0
+          fi
+          printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
+
       # run-local refuses to touch a daemon that might be somebody's own; CI=true
       # is what tells it this one is disposable. GitHub sets it.
       - name: Run the end-to-end suite
@@ -221,6 +255,40 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+
+      # Sign in to the registry before anything pulls an image.
+      #
+      # A runner pulls anonymously and shares its outbound address with
+      # thousands of others, so the rate limit is spent by strangers. Measured
+      # 2026-08-27 23:23: three shards of one run failed inside the same minute,
+      # each on a different image — `unauthorized: authentication required` for
+      # mailcatcher, `failed to resolve source metadata` for postgres:16 and for
+      # ubuntu:22.04. No test reported a wrong answer; three of them could not
+      # fetch what they needed, and the run reads exactly like a regression in
+      # the change under review. The change under review was the first thing
+      # suspected, which is the real cost of this.
+      #
+      # An authenticated pull is counted against the account rather than the
+      # address, and a free account is enough.
+      #
+      # **The check is inside the step, not in an `if`.** The `secrets` context
+      # is not available to a step's condition — `if: secrets.X != ''` evaluates
+      # against nothing and skips the step every time, which is a login that is
+      # never performed and never reported. A fork has no secret, and there the
+      # run should fail on the limit if it must, not on an empty password.
+      #
+      # Plain CLI rather than an action: this is two lines of shell, and an
+      # action is a supply chain.
+      - name: Sign in to the image registry
+        env:
+          REGISTRY_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "$REGISTRY_USER" ] || [ -z "$REGISTRY_TOKEN" ]; then
+            echo "No registry credentials on this run — pulling anonymously, which is rate limited by address."
+            exit 0
+          fi
+          printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
 
       - name: Install Shopware and Medusa for real
         run: ./test/e2e/e2e.sh run-local --platforms -run 'TestMagentoInstallsAndAnswers|TestShopwareInstallsAndAnswers|TestMedusaInstallsAndAnswers'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+**v4.1.9**
+
+Fixed:
+- **A project with `db/enabled=false` was still given a database image.** `MakeDBDockerfile` is called from twelve places and only two of them checked whether the project has a database; with the database off there is no version to render — the platform default supplies the repository and nothing supplies the tag — so the file came out as `FROM mariadb:`, which is not a valid reference and would not build
+- It broke nothing, which is why it lasted: compose renders no `db` service for a disabled database, so nothing ever built the file. What it cost was a reader's time. Found on the BigCommerce cluster VM while chasing something else, where two cluster consumers — projects whose database comes from the provider — each carried one, and it reads exactly like a broken image until you establish that neither has a database at all
+- The gate is in `MakeDBDockerfile` rather than at the call sites, because the call sites are what got it wrong. The `mariadb` in it was never the defect: that is the BigCommerce platform default, not a global one
+
 **v4.1.8**
 
 Fixed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v4.1.10**
+
+Fixed:
+- **The cron check cried wolf on every healthy deploy.** `cron:remove && cron:install && cron:run` exits 1 in the ordinary case on every deploy after the first: `cron:remove` leaves the last block in the crontab whatever it reports, so `cron:install` finds one already there, prints "Crontab has already been generated and saved" and stops the chain. That exit code was read as failure, and "Magento cron setup failed — scheduled jobs may NOT run" went out on deploys where cron was fine. Measured on extmag.com, release 174: the crontab held exactly one `cron:run` naming that release, `cron` was running by name, a job had completed successfully 23 seconds earlier, and the alarm printed four times in one day
+- **The setup is judged by what is installed now, not by how the sequence exited.** The crontab is read back and matched against the base path the project resolves to in the container; a workdir that cannot be resolved says so rather than being rounded to "fine"
+- **The two messages are separated, and that is most of the fix.** "The old entry could not be removed" is Magento behaving as it always has and belongs in the log; "cron is not installed" is an outage and belongs on the screen. One text for both is what made the alarm meaningless
+- This is the second wrong answer from this probe, in the opposite direction. The first — `service cron status` reporting a daemon that was gone — let production run six hours with nothing scheduled. Crying wolf is the more expensive of the two: it teaches people to look away from the one occasion the check is right
+
 **v4.1.9**
 
 Fixed:

--- a/src/helper/configs/aruntime/project/project.go
+++ b/src/helper/configs/aruntime/project/project.go
@@ -247,15 +247,38 @@ func resolveMainServicePort(projectConf map[string]string) string {
 	return "3000"
 }
 
+// MakeDBDockerfile renders the database image, and only when the project has a
+// database.
+//
+// The gate is here rather than at the call sites because ten of the twelve
+// callers did not have one. With `db/enabled=false` there is no version to
+// render — the platform default supplies the repository and nothing supplies
+// the tag — so the file came out as `FROM mariadb:`, which is not a valid
+// reference and would not build.
+//
+// It broke nothing, and that is why it survived: compose renders no `db`
+// service for a disabled database, so nothing ever built the file. What it cost
+// was a reader's time. Found on the BigCommerce cluster VM on 2026-08-27 while
+// chasing something else, it reads as a broken image for two projects and took
+// a while to be dismissed — the two projects are cluster consumers whose
+// database comes from the provider, and neither has any business owning an
+// image.
+//
+// The `mariadb` in it is not a mystery worth chasing either: it is the
+// BigCommerce platform default (model/versions/bigcommerce), not a global one.
+// Only the empty tag was the defect.
 func MakeDBDockerfile(projectName string) {
+	projectConf := configs.GetProjectConfig(projectName)
+	if strings.ToLower(projectConf["db/enabled"]) == "false" {
+		return
+	}
+
 	pp := paths.NewProjectPaths(projectName)
 	ctx := paths.MakeDirsByPath(pp.CtxDir())
 
 	file := GetDockerConfigFile(projectName, "/db/Dockerfile", "")
 	str := Render(projectName, file, "db/Dockerfile", nil)
 	write(ctx+"/db.Dockerfile", dockertransform.ApplyDockerfileTransform("db.Dockerfile", str))
-
-	projectConf := configs.GetProjectConfig(projectName)
 
 	// my.cnf is only needed for MySQL/MariaDB
 	if configs.GetDbType(projectConf) == "mysql" {

--- a/src/helper/configs/aruntime/project/project_integration_test.go
+++ b/src/helper/configs/aruntime/project/project_integration_test.go
@@ -266,3 +266,37 @@ func TestMakeConf_VolumesNeverEmpty(t *testing.T) {
 		t.Errorf("volumes section is empty; compose would fail with \"volumes must be a mapping\". Next line: %q", firstLine)
 	}
 }
+
+// A project whose database is switched off must not be handed a database image.
+//
+// Ten of the twelve callers of MakeDBDockerfile had no gate, and with
+// `db/enabled=false` there is no version to render — the platform default
+// supplies the repository and nothing supplies the tag — so the file came out
+// as `FROM mariadb:`, which is not a valid reference.
+//
+// Nothing broke, and that is why it lasted: compose renders no `db` service for
+// a disabled database, so the file was never built. It cost a reader instead.
+// Found on the BigCommerce cluster VM, where two cluster consumers — projects
+// whose database comes from the provider — each carried one, and it reads
+// exactly like a broken image until you check that neither has a database at
+// all.
+func TestNoDatabaseImageWhenTheDatabaseIsOff(t *testing.T) {
+	env := testenv.SetupWith(t, "consumer", "consumer.test", map[string]string{
+		"db/enabled": "false",
+	})
+
+	MakeConf(env.ProjectName)
+
+	ctxDir := filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName, "ctx")
+
+	if _, err := os.Stat(filepath.Join(ctxDir, "db.Dockerfile")); err == nil {
+		body, _ := os.ReadFile(filepath.Join(ctxDir, "db.Dockerfile"))
+		t.Errorf("a project with no database was given a database image:\n%s", string(body))
+	}
+
+	// The rest of the project is still rendered — the gate is about the
+	// database, not about the project.
+	if _, err := os.Stat(filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName, "docker-compose.yml")); err != nil {
+		t.Errorf("the project was not rendered at all: %v", err)
+	}
+}

--- a/src/helper/docker/cron.go
+++ b/src/helper/docker/cron.go
@@ -152,12 +152,12 @@ func CronExecute(projectName string, flag, manual bool) {
 			// has been the proven sequence in madock from 2022 until commit ca6a668.
 			cmd := "cd " + workdir + " && php bin/magento cron:remove && php bin/magento cron:install && php bin/magento cron:run"
 			if manual {
-				err = ContainerExec(containerName, "www-data", false, "bash", "-c", cmd)
-				if err != nil {
-					logger.Println(err)
-					fmtc.WarningLn(err.Error())
-				}
+				// Silent, then judged by state — the same reason as the deploy
+				// path below: this sequence exits 1 in the ordinary case, and
+				// printing that as an error taught everyone to ignore it.
+				out, cerr := containerExecSilent(containerName, "www-data", "bash", "-c", cmd)
 				dropStaleMagentoBlocks(projectConf, projectName, containerName, workdir)
+				reportMagentoCronState(projectConf, projectName, containerName, workdir, out, cerr)
 			} else {
 				// Auto-invocation (start/rebuild). On a fresh container the Magento DI
 				// can be in a "warming up" state for the first several seconds:
@@ -191,14 +191,8 @@ func CronExecute(projectName string, flag, manual bool) {
 					logger.Println(fmt.Sprintf("magento2 cron: cron:* namespace still empty after %d attempts; cron:install/cron:run skipped. Last probe output:\n%s", probeAttempts, probeOut))
 				} else {
 					out, cerr := containerExecSilent(containerName, "www-data", "bash", "-c", cmd)
-					if cerr != nil {
-						fmtc.WarningLn("Magento cron setup failed — scheduled jobs may NOT run. Details: " + logger.Path())
-						logger.Println(cerr)
-						if out != "" {
-							logger.Println(out)
-						}
-					}
 					dropStaleMagentoBlocks(projectConf, projectName, containerName, workdir)
+					reportMagentoCronState(projectConf, projectName, containerName, workdir, out, cerr)
 				}
 			}
 		} else if projectConf["platform"] == "shopify" {
@@ -331,6 +325,52 @@ func CronExecute(projectName string, flag, manual bool) {
 			}
 		}
 	}
+}
+
+// reportMagentoCronState says whether cron is set up, by looking at what is
+// installed rather than at how the install sequence exited.
+//
+// The sequence is `cron:remove && cron:install && cron:run`, and on every
+// deploy after the first it exits 1 in the ordinary case: `cron:remove` leaves
+// the last block in the crontab whatever it reports, so `cron:install` finds
+// one already there, prints "Crontab has already been generated and saved" and
+// stops the chain. Reading that as failure printed "Magento cron setup failed —
+// scheduled jobs may NOT run" on healthy deploys — measured on extmag.com,
+// release 174, four times in one day, each time with the crontab holding one
+// cron:run for that very release, `cron` running by name, and a job that had
+// completed 23 seconds earlier.
+//
+// **The two messages are separated, and that is most of the point.** "The old
+// entry could not be removed" is Magento behaving as it always has and belongs
+// in the log; "cron is not installed" is an outage and belongs on the screen.
+// Printing one text for both is what made the alarm meaningless — and this is
+// the second wrong answer from this probe, the first having been silence while
+// production had no scheduler for six hours.
+func reportMagentoCronState(projectConf map[string]string, projectName, containerName, workdir, out string, cerr error) {
+	if cerr != nil {
+		logger.Println(cerr)
+		if out != "" {
+			logger.Println(out)
+		}
+	}
+
+	resolved, err := containerExecSilent(containerName, "www-data", "sh", "-c", "cd "+workdir+" && pwd -P")
+	basePath := strings.TrimSpace(resolved)
+	if err != nil || basePath == "" {
+		// Could not ask. Never rounded to "fine": an unanswered check is its own
+		// answer, and the exit code is not a substitute for it.
+		logger.Println(fmt.Errorf("magento cron: could not resolve %s in the container: %w", workdir, err))
+		fmtc.WarningLn("Could not tell whether Magento cron is installed — see " + logger.Path())
+		return
+	}
+
+	if magentoBlockCovers(readCrontab(projectConf, projectName), basePath) {
+		// Installed. If the sequence complained on the way, that is Magento's
+		// own refusal to install over an existing block, and it is in the log.
+		return
+	}
+
+	fmtc.WarningLn("Magento cron is not installed — scheduled jobs will NOT run. Details: " + logger.Path())
 }
 
 // dropStaleMagentoBlocks removes the Magento crontab blocks left behind by

--- a/src/helper/docker/crontab_block.go
+++ b/src/helper/docker/crontab_block.go
@@ -248,3 +248,42 @@ func lineContains(s, delimiter string) bool {
 	}
 	return false
 }
+
+// magentoBlockCovers reports whether the crontab already holds a Magento block
+// for this base path — that is, whether cron is installed for the release the
+// project resolves to now.
+//
+// It exists because the exit code of the install sequence cannot answer that.
+// `cron:remove` leaves the last block in the file whatever it reports, so the
+// `cron:install` that follows finds one already there, prints "Crontab has
+// already been generated and saved" and exits 1 — the normal case on every
+// deploy after the first. The chain is joined by `&&`, so that 1 stopped it and
+// was read as a failure to set cron up.
+//
+// Measured on extmag.com, release 174: the alarm printed on a deploy where the
+// crontab held exactly one cron:run naming that release, `cron` was running by
+// name, and a job had completed successfully 23 seconds earlier. Four such
+// alarms in one day, all of them wrong.
+//
+// This is the second wrong answer from the same probe. The first, in
+// MADOCK-CRON-DEPLOY.md, was the opposite: `service cron status` reported a
+// daemon that was gone, and production went six hours with nothing scheduled.
+// A check that cries wolf is the more expensive of the two, because it teaches
+// people to look away from the one occasion it is right.
+func magentoBlockCovers(existing, basePath string) bool {
+	if strings.TrimSpace(basePath) == "" {
+		return false
+	}
+
+	found := false
+	filterMagentoBlocks(existing, func(block []string) bool {
+		for _, line := range block {
+			if strings.Contains(line, basePath) {
+				found = true
+			}
+		}
+		return true
+	})
+
+	return found
+}

--- a/src/helper/docker/crontab_block_test.go
+++ b/src/helper/docker/crontab_block_test.go
@@ -129,3 +129,47 @@ func TestWriteCrontabScriptRemovesWhenEmpty(t *testing.T) {
 		t.Errorf("expected a removal:\n%s", script)
 	}
 }
+
+// The state the exit code cannot answer: is cron installed for the release this
+// project resolves to now?
+//
+// `cron:remove && cron:install && cron:run` exits 1 in the ordinary case on
+// every deploy after the first — cron:remove leaves the last block whatever it
+// reports, so cron:install finds one and refuses. Reading that as failure
+// printed "Magento cron setup failed — scheduled jobs may NOT run" on healthy
+// deploys: measured on extmag.com release 174, four times in one day, each time
+// with the crontab holding one cron:run for that release and a job finished 23
+// seconds earlier.
+func TestMagentoBlockCovers(t *testing.T) {
+	const crontab = `MAILTO=""
+#~ MAGENTO START 5f4dcc3b
+* * * * * /usr/bin/php /var/www/html/releases/173/bin/magento cron:run 2>&1
+#~ MAGENTO END 5f4dcc3b
+#~ MAGENTO START 7c6a180b
+* * * * * /usr/bin/php /var/www/html/releases/174/bin/magento cron:run 2>&1
+#~ MAGENTO END 7c6a180b
+`
+
+	if !magentoBlockCovers(crontab, "/var/www/html/releases/174") {
+		t.Error("the block for the current release was not found, so a healthy deploy would raise the alarm")
+	}
+	// A block for a release that is gone is not this release being installed —
+	// that is exactly the state a deploy leaves behind and the one the alarm is
+	// actually for.
+	if magentoBlockCovers(crontab, "/var/www/html/releases/175") {
+		t.Error("a release with no block of its own was reported as installed")
+	}
+	if magentoBlockCovers("", "/var/www/html/releases/174") {
+		t.Error("an empty crontab was reported as having cron installed")
+	}
+	// An unresolved workdir must not read as installed: an unanswered question
+	// is not a yes.
+	if magentoBlockCovers(crontab, "") {
+		t.Error("an empty base path was reported as covered")
+	}
+	// A line outside a Magento block is somebody else's job and says nothing
+	// about Magento's cron.
+	if magentoBlockCovers("* * * * * /var/www/html/releases/174/bin/other\n", "/var/www/html/releases/174") {
+		t.Error("a line outside a Magento block was counted as the Magento block")
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.8"
+const Version = "4.1.9"

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.9"
+const Version = "4.1.10"


### PR DESCRIPTION
Three changes, and the third is why the first two waited.

## A project with no database was still given a database image

`MakeDBDockerfile` is called from twelve places and only two checked whether the project has a database. With `db/enabled=false` there is no version to render — the platform default supplies the repository and nothing supplies the tag — so the file came out as `FROM mariadb:`, which is not a valid reference and would not build.

It broke nothing, and that is why it lasted: compose renders no `db` service for a disabled database, so nothing ever built the file. What it cost was a reader's time — found on the BigCommerce cluster VM while chasing something else, where two cluster consumers each carried one, and reported as "two projects whose database will not come up" before that was checked. Neither has a database at all.

The gate goes in the function rather than at the call sites, because the call sites are what got it wrong. The `mariadb` was never the defect: that is the BigCommerce platform default.

The test asserts the file is **absent** rather than that its tag is filled in — the invariant that holds in both shapes. Verified to fail without the gate.

## The cron check cried wolf on every healthy deploy

`cron:remove && cron:install && cron:run` exits 1 in the ordinary case on every deploy after the first: `cron:remove` leaves the last block in the crontab whatever it reports, so `cron:install` finds one already there, prints `Crontab has already been generated and saved` and stops the chain. That exit code was read as failure.

Measured on extmag.com, release 174, by the session that runs the site: the alarm printed on a deploy where the crontab held exactly one `cron:run` naming that release, `cron` was running by name, and a job had completed successfully 23 seconds earlier. Four such alarms in one day.

- the setup is judged by state — the crontab read back and matched against the base path the project resolves to **in the container**
- a workdir that cannot be resolved says so instead of being rounded to "fine"
- the two messages are separated, which is most of the fix: "the old entry could not be removed" is Magento behaving as it always has and belongs in the log; "cron is not installed" is an outage and belongs on the screen

This is the second wrong answer from the same probe, in the opposite direction. The first let production run six hours with no scheduler. Crying wolf is the more expensive of the two: it teaches people to look away from the one occasion the check is right.

## Sign in to the image registry

Three shards of the run on this branch failed inside the same minute, each on a different image: `unauthorized: authentication required` for mailcatcher, `failed to resolve source metadata` for postgres:16 and for ubuntu:22.04. No test reported a wrong answer.

A runner pulls anonymously and shares its outbound address with thousands of others, so the limit is spent by strangers. The cost this removes is not the failed run — it is the diagnosis: a red suite on a pull request reads exactly like a regression in the change under review, and that is what was suspected first.

Both container jobs get it, the platform installs included. The guard is inside the step, not in an `if`: the `secrets` context is not available to a step's condition, so `if: secrets.X != ''` would skip the step every time — a login never performed and never reported. Plain CLI rather than an action.
