### PR TITLE
Make CI say what it ran, and stop it depending on an hourly pull quota

### DIFF
--- a/.github/actions/load-images/action.yml
+++ b/.github/actions/load-images/action.yml
@@ -1,0 +1,29 @@
+name: Load the warmed images
+description: >
+  Restores the image tar warmed once per run and loads it into this job's daemon,
+  so the suite does not pull from Docker Hub. Silent and harmless on a miss — the
+  suite then pulls as it always did, which is slower and rate limited but not
+  broken.
+
+runs:
+  using: composite
+  steps:
+    - id: cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ~/.docker-images
+        key: docker-images-${{ hashFiles('test/e2e/images.txt') }}
+
+    # A miss must not fail the job. The cache is an optimisation against a
+    # third party's rate limit, and a job that refuses to run without it would
+    # turn a slow run into a red one — which is the failure this whole thing
+    # exists to stop.
+    - name: Load
+      shell: bash
+      run: |
+        if [ ! -f ~/.docker-images/images.tar.gz ]; then
+          echo "No warmed images on this run — the suite will pull, as it did before."
+          exit 0
+        fi
+        gunzip -c ~/.docker-images/images.tar.gz | docker load
+        docker image ls --format '{{.Repository}}:{{.Tag}}' | sort -u

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,67 @@ jobs:
       - name: Check the end-to-end tests still compile
         run: go vet -tags=e2e ./test/...
 
+  # Pull the images once per run instead of once per job.
+  #
+  # Docker Hub allows an authenticated free account 200 pulls an hour. One pull
+  # request is two runs — the push to staging and the merge result — of nine jobs
+  # each, and on 2026-08-29 three of them in a morning spent the budget: every
+  # shard and Platforms went red on `toomanyrequests`, which reads exactly like a
+  # regression in the change under review. That is the cost being paid here, and
+  # it is paid by whoever happens to open the next pull request.
+  #
+  # The measurement that sized it, taken with the same credentials rather than
+  # read: the authenticated probe answers `ratelimit-limit: 200;w=3600` against
+  # the anonymous 100 — so the login does reach the pull and the mechanism is
+  # sound — with `ratelimit-remaining: 0`. Docker's own error says
+  # "unauthenticated" to an authenticated account that has run out, which is what
+  # made a healthy mechanism look broken.
+  #
+  # GitHub's cache is not counted by anybody's registry, and the tar is loaded in
+  # the jobs that need it. A cache miss costs one set of pulls for the whole run.
+  images:
+    name: Warm the image cache
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.docker-images
+          key: docker-images-${{ hashFiles('test/e2e/images.txt') }}
+
+      - name: Sign in to the image registry
+        if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          REGISTRY_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          REGISTRY_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "$REGISTRY_USER" ] || [ -z "$REGISTRY_TOKEN" ]; then
+            echo "No registry credentials on this run — pulling anonymously, which is rate limited by address."
+            exit 0
+          fi
+          printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
+
+      # The sizes are printed rather than assumed. The repository's cache holds
+      # 10 GB in total and evicts by least-recent use, so a tar that grows past
+      # its share does not fail — it quietly starts costing other caches, and the
+      # only place that is visible is here.
+      - name: Pull and save
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.docker-images
+          images=$(grep -v '^\s*#' test/e2e/images.txt | grep -v '^\s*$')
+          echo "$images" | while read -r image; do
+            echo "== $image"
+            docker pull -q "$image"
+          done
+          # shellcheck disable=SC2086
+          docker save -o ~/.docker-images/images.tar $images
+          gzip -1 ~/.docker-images/images.tar
+          ls -lh ~/.docker-images/
+
   # The suite is split across runners, and the split is computed rather than
   # written down.
   #
@@ -124,7 +185,7 @@ jobs:
 
   e2e-shard:
     name: e2e shard ${{ matrix.shard }}
-    needs: e2e-plan
+    needs: [e2e-plan, images]
     runs-on: ubuntu-latest
     # A shard is an eighth of a suite that used to take 45 minutes, so 40 is
     # room for a runner having a bad morning rather than a budget. It still has
@@ -179,12 +240,16 @@ jobs:
           fi
           printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
 
+      - name: Load the warmed images
+        uses: ./.github/actions/load-images
+
       # run-local refuses to touch a daemon that might be somebody's own; CI=true
       # is what tells it this one is disposable. GitHub sets it.
       - name: Run the end-to-end suite
         run: |
           set -o pipefail
           ./test/e2e/e2e.sh run-local -run '${{ matrix.run }}' | tee shard.log
+
 
       # The other half of computing the split: this shard was given a number of
       # tests, and it has to have run that many. A regex that matches nothing —
@@ -199,6 +264,16 @@ jobs:
             echo "shard ${{ matrix.shard }} was given ${{ matrix.count }} tests and ran $ran" >&2
             exit 1
           fi
+
+      # What this job's daemon ended up holding, which is how test/e2e/images.txt
+      # grows. An image here that is not in that file was fetched from the
+      # registry and is still being paid for. The list is kept from evidence
+      # rather than from reading the templates: madock renders image names out of
+      # config at run time, so no file in the repository states them, and a list
+      # written by reading would be a guess that goes stale silently.
+      - name: Images this job actually used
+        if: always()
+        run: docker image ls --format '{{.Repository}}:{{.Tag}}' | sort -u
 
   # The name of this job is the name of the required status check on master, and
   # that is the whole reason it exists.
@@ -245,7 +320,7 @@ jobs:
   # a local test and this job carries the two that can be public.
   platforms:
     name: Platforms
-    needs: test
+    needs: [test, images]
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
@@ -290,8 +365,15 @@ jobs:
           fi
           printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
 
+      - name: Load the warmed images
+        uses: ./.github/actions/load-images
+
       - name: Install Shopware and Medusa for real
         run: ./test/e2e/e2e.sh run-local --platforms -run 'TestMagentoInstallsAndAnswers|TestShopwareInstallsAndAnswers|TestMedusaInstallsAndAnswers'
+
+      - name: Images this job actually used
+        if: always()
+        run: docker image ls --format '{{.Repository}}:{{.Tag}}' | sort -u
 
   # The tests under quarantine, run where the defect actually appears.
   #
@@ -317,7 +399,7 @@ jobs:
   # project name cannot collide.
   quarantine:
     name: Quarantined tests (not a gate)
-    needs: test
+    needs: [test, images]
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -347,6 +429,9 @@ jobs:
       # The output is the entire point of this job, so the log is kept whatever
       # happens: the probe prints the upgrade-info file, the schema names and the
       # account list, and a failed run whose log was thrown away costs a night.
+      - name: Load the warmed images
+        uses: ./.github/actions/load-images
+
       - name: Run the quarantined tests
         run: |
           set -o pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,21 +17,44 @@ name: CI
 # `staging` is where work is verified and `master` is where verified work lands.
 # The end-to-end suite only ever runs here — the build tag keeps it out of the
 # pre-push hook, and the Lima VM on a laptop is the iteration loop, not the
-# verdict — so a branch that CI does not watch is a branch whose e2e nobody has
-# run. master then receives a fast-forward of exactly the tree that was green.
+# verdict.
 #
-# It costs a second run of the same tree on master. That is deliberate: the run
-# on master is the record of what master did, and re-running is cheaper than
-# reasoning about whether a green run on another ref still applies.
+# **One run per landing, and until 2026-08-29 there were three.** The push to
+# staging, the pull request, and master after the merge — all of the same commit,
+# every job in each, including the eight e2e shards and the two platform
+# installs. That is what spent an hourly Docker Hub quota in a morning and turned
+# somebody else's pull request red.
 #
-# The nightly schedule is for the platform job below, which installs Magento,
-# Shopware and Medusa from their vendors. What that job catches is mostly not
-# ours: an image tag withdrawn, a starter repository moved, a package that no
-# longer resolves. None of it arrives with a commit, so waiting for a push to
-# find out means finding out from a customer instead.
+# The one kept is the strongest of the three, which is why this is a deletion
+# rather than a trade. A push run tests a branch head. A pull request run tests
+# the **merge result** — head merged into master — and branch protection has
+# `strict: true`, so a branch that is behind cannot land until it is updated.
+# The tree the pull request proves green is therefore the tree master becomes.
+#
+# That is also what makes the post-merge run on master redundant rather than
+# merely expensive: it re-ran a tree that had already been tested in exactly that
+# shape. The argument for keeping it was that it is "the record of what master
+# did", and the record is real — it is just a record of a question already
+# answered, bought at a full suite. The nightly run below is on the default
+# branch, so master is still exercised on its own every day, against the world as
+# it is that morning rather than as it was at the merge.
+#
+# What this gives up, said plainly rather than left to be discovered:
+#
+#   - a push to staging with no pull request open gets no run. Work lands through
+#     a pull request here, so verification happens when landing is proposed
+#     instead of when the branch moves. `workflow_dispatch` covers a branch
+#     parked for later.
+#   - a direct push to master gets no run. `enforce_admins` is off, so the owner
+#     can still push past the gate; that is meant to be a deliberate act in an
+#     incident, and it now has no CI behind it until the nightly.
+#
+# The nightly schedule is also what the platform job below is for: it installs
+# Magento, Shopware and Medusa from their vendors, and what it catches is mostly
+# not ours — an image tag withdrawn, a starter repository moved, a package that
+# no longer resolves. None of that arrives with a commit, so waiting for a push
+# to find out means finding out from a customer instead.
 on:
-  push:
-    branches: [master, staging]
   pull_request:
   schedule:
     - cron: '17 3 * * *'
@@ -43,15 +66,16 @@ permissions:
   contents: read
 
 # A pull request that gets three pushes in a minute should run the third one,
-# not all three. Every commit on the default branch gets its own run, because
-# those runs are the record of what master did.
+# not all three. Everything else — the nightly, a run asked for by hand — gets
+# its own group and is never cancelled.
 #
 # The exemption has to be in the group and not only in cancel-in-progress.
 # GitHub keeps one run in progress and one waiting per group: a third arrival
 # replaces the one that was waiting, and the replaced run is cancelled before it
-# starts a single job. Three pushes in quick succession therefore left the middle
-# commit with no run at all — observed twice on master before this was written
-# down. Putting the commit in the group means pushes never share one.
+# starts a single job. Three arrivals in quick succession therefore left the
+# middle one with no run at all — observed twice on master, back when pushes
+# there were a trigger. Putting the commit in the group is what stops those
+# sharing one.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,23 @@ jobs:
           set -o pipefail
           ./test/e2e/e2e.sh run-local --quarantined -run 'TestSecondDatabaseIsItsOwnDatabase' | tee quarantine.log
 
+      # The same guard the shards carry, and here it matters more. `-run` with a
+      # name that matches nothing — a rename, a test finally deleted — makes
+      # `go test` exit 0 having run nothing, and this job would go green. On any
+      # other job that reads as "it passed". On this one it reads as "the flake
+      # has stopped", which is the single conclusion it exists to support and the
+      # one nobody would check.
+      #
+      # A SKIP counts: it means the test ran and the quarantine flag did not
+      # reach it, which is its own defect and exactly the state this job was
+      # created to end.
+      - name: The quarantined test actually ran
+        run: |
+          if ! grep -q '^--- \(PASS\|FAIL\|SKIP\): TestSecondDatabaseIsItsOwnDatabase' quarantine.log; then
+            echo "no top-level result for TestSecondDatabaseIsItsOwnDatabase — it was renamed, removed, or -run matched nothing" >&2
+            exit 1
+          fi
+
       - name: Keep the log
         if: always()
         uses: actions/upload-artifact@v4

--- a/config.xml
+++ b/config.xml
@@ -501,6 +501,26 @@
                          reached through an ssh tunnel. Empty means all
                          interfaces, which on a server means anyone. -->
                     <interface_ip>127.0.0.1:</interface_ip>
+                    <!-- Named here like every other service, rather than written
+                         into the compose template, so it can be raised in one
+                         place and overridden per project.
+
+                         It was `axllent/mailpit:latest` until 2026-08-29, and a
+                         floating tag is not merely untidy: compose has to
+                         resolve it before it can know whether the local image is
+                         current, so it asks the registry on every `madock start`
+                         whatever is already on the daemon. Measured in CI that
+                         day — the image was loaded from a cache, the log said
+                         `Loaded image: axllent/mailpit:latest`, and compose
+                         still reported `mailcatcher Pulling` and failed on
+                         Docker Hub's rate limit, while `nginx`, which has no tag
+                         to resolve, said `Skipped - No image to be pulled` in
+                         the same run.
+
+                         So the proxy no longer changes underneath everybody
+                         either: it moves when this number moves. -->
+                    <repository>axllent/mailpit</repository>
+                    <version>v1.31.0</version>
                 </mailpit>
             </proxy>
             <container_name_prefix>madock_</container_name_prefix>

--- a/config.xml
+++ b/config.xml
@@ -501,24 +501,23 @@
                          reached through an ssh tunnel. Empty means all
                          interfaces, which on a server means anyone. -->
                     <interface_ip>127.0.0.1:</interface_ip>
-                    <!-- Named here like every other service, rather than written
-                         into the compose template, so it can be raised in one
-                         place and overridden per project.
+                    <!-- Named here like every other service, rather than
+                         written into the compose template, so it can be raised
+                         in one place and overridden per project or per machine.
 
-                         It was `axllent/mailpit:latest` until 2026-08-29, and a
-                         floating tag is not merely untidy: compose has to
-                         resolve it before it can know whether the local image is
-                         current, so it asks the registry on every `madock start`
-                         whatever is already on the daemon. Measured in CI that
-                         day — the image was loaded from a cache, the log said
-                         `Loaded image: axllent/mailpit:latest`, and compose
-                         still reported `mailcatcher Pulling` and failed on
-                         Docker Hub's rate limit, while `nginx`, which has no tag
-                         to resolve, said `Skipped - No image to be pulled` in
-                         the same run.
+                         It was `axllent/mailpit:latest` until 2026-08-29. The
+                         reason for pinning is reproducibility and nothing more:
+                         the proxy is shared by every project on the machine, and
+                         a floating tag means it changes underneath all of them
+                         on whatever day upstream publishes. It moves when this
+                         number moves now.
 
-                         So the proxy no longer changes underneath everybody
-                         either: it moves when this number moves. -->
+                         Said plainly because the first attempt got it wrong:
+                         pinning does NOT stop the registry being asked. That was
+                         `docker compose pull`, which asks about every image
+                         whether or not the machine has it, and it is fixed where
+                         it lives — dockerComposePull now passes compose's
+                         missing pull policy unless this really is a rebuild. -->
                     <repository>axllent/mailpit</repository>
                     <version>v1.31.0</version>
                 </mailpit>

--- a/docker/general/nginx/docker-compose-proxy.yml
+++ b/docker/general/nginx/docker-compose-proxy.yml
@@ -25,21 +25,7 @@ services:
 
 {{{- if .proxy.mailpit.enabled}}}
   mailcatcher:
-    # Pinned, and `:latest` here was not merely untidy — it was a request to the
-    # registry on every `madock start` anybody ever runs.
-    #
-    # A floating tag has to be resolved before compose can know whether the local
-    # image is current, so it asks, whatever is on the daemon. Measured
-    # 2026-08-29 in CI: the image was loaded from a cache and present, the log
-    # says `Loaded image: axllent/mailpit:latest`, and compose still reported
-    # `mailcatcher Pulling` and then failed on Docker Hub's rate limit — while
-    # `nginx`, which has no tag to resolve, reported `Skipped - No image to be
-    # pulled` in the same run. Every project start was paying for that question.
-    #
-    # Pinning also means the proxy stops silently changing under everybody. It
-    # moves when this line moves, which is the behaviour every other service here
-    # already has.
-    image: axllent/mailpit:v1.31.0
+    image: {{{.proxy.mailpit.repository}}}:{{{.proxy.mailpit.version}}}
     ports:
       # SMTP. Published on every interface on purpose: the php containers reach
       # it through host.docker.internal, which resolves to the host gateway

--- a/docker/general/nginx/docker-compose-proxy.yml
+++ b/docker/general/nginx/docker-compose-proxy.yml
@@ -25,7 +25,21 @@ services:
 
 {{{- if .proxy.mailpit.enabled}}}
   mailcatcher:
-    image: axllent/mailpit:latest
+    # Pinned, and `:latest` here was not merely untidy — it was a request to the
+    # registry on every `madock start` anybody ever runs.
+    #
+    # A floating tag has to be resolved before compose can know whether the local
+    # image is current, so it asks, whatever is on the daemon. Measured
+    # 2026-08-29 in CI: the image was loaded from a cache and present, the log
+    # says `Loaded image: axllent/mailpit:latest`, and compose still reported
+    # `mailcatcher Pulling` and then failed on Docker Hub's rate limit — while
+    # `nginx`, which has no tag to resolve, reported `Skipped - No image to be
+    # pulled` in the same run. Every project start was paying for that question.
+    #
+    # Pinning also means the proxy stops silently changing under everybody. It
+    # moves when this line moves, which is the behaviour every other service here
+    # already has.
+    image: axllent/mailpit:v1.31.0
     ports:
       # SMTP. Published on every interface on purpose: the php containers reach
       # it through host.docker.internal, which resolves to the host gateway

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -501,6 +501,26 @@
                          reached through an ssh tunnel. Empty means all
                          interfaces, which on a server means anyone. -->
                     <interface_ip>127.0.0.1:</interface_ip>
+                    <!-- Named here like every other service, rather than written
+                         into the compose template, so it can be raised in one
+                         place and overridden per project.
+
+                         It was `axllent/mailpit:latest` until 2026-08-29, and a
+                         floating tag is not merely untidy: compose has to
+                         resolve it before it can know whether the local image is
+                         current, so it asks the registry on every `madock start`
+                         whatever is already on the daemon. Measured in CI that
+                         day — the image was loaded from a cache, the log said
+                         `Loaded image: axllent/mailpit:latest`, and compose
+                         still reported `mailcatcher Pulling` and failed on
+                         Docker Hub's rate limit, while `nginx`, which has no tag
+                         to resolve, said `Skipped - No image to be pulled` in
+                         the same run.
+
+                         So the proxy no longer changes underneath everybody
+                         either: it moves when this number moves. -->
+                    <repository>axllent/mailpit</repository>
+                    <version>v1.31.0</version>
                 </mailpit>
             </proxy>
             <container_name_prefix>madock_</container_name_prefix>

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -501,24 +501,23 @@
                          reached through an ssh tunnel. Empty means all
                          interfaces, which on a server means anyone. -->
                     <interface_ip>127.0.0.1:</interface_ip>
-                    <!-- Named here like every other service, rather than written
-                         into the compose template, so it can be raised in one
-                         place and overridden per project.
+                    <!-- Named here like every other service, rather than
+                         written into the compose template, so it can be raised
+                         in one place and overridden per project or per machine.
 
-                         It was `axllent/mailpit:latest` until 2026-08-29, and a
-                         floating tag is not merely untidy: compose has to
-                         resolve it before it can know whether the local image is
-                         current, so it asks the registry on every `madock start`
-                         whatever is already on the daemon. Measured in CI that
-                         day — the image was loaded from a cache, the log said
-                         `Loaded image: axllent/mailpit:latest`, and compose
-                         still reported `mailcatcher Pulling` and failed on
-                         Docker Hub's rate limit, while `nginx`, which has no tag
-                         to resolve, said `Skipped - No image to be pulled` in
-                         the same run.
+                         It was `axllent/mailpit:latest` until 2026-08-29. The
+                         reason for pinning is reproducibility and nothing more:
+                         the proxy is shared by every project on the machine, and
+                         a floating tag means it changes underneath all of them
+                         on whatever day upstream publishes. It moves when this
+                         number moves now.
 
-                         So the proxy no longer changes underneath everybody
-                         either: it moves when this number moves. -->
+                         Said plainly because the first attempt got it wrong:
+                         pinning does NOT stop the registry being asked. That was
+                         `docker compose pull`, which asks about every image
+                         whether or not the machine has it, and it is fixed where
+                         it lives — dockerComposePull now passes compose's
+                         missing pull policy unless this really is a rebuild. -->
                     <repository>axllent/mailpit</repository>
                     <version>v1.31.0</version>
                 </mailpit>

--- a/src/helper/docker/compose_version.go
+++ b/src/helper/docker/compose_version.go
@@ -1,0 +1,65 @@
+package docker
+
+import (
+	"os/exec"
+	"strings"
+	"sync"
+
+	configs2 "github.com/faradey/madock/v4/src/helper/configs"
+)
+
+// The compose version, asked once and only when something depends on it.
+//
+// madock declares no minimum docker or compose version anywhere — not in the
+// README, not in code — so every feature added to compose after 2021 is a
+// feature we cannot assume. That was fine while nothing needed one, and stopped
+// being fine when `docker compose pull` turned out to contact the registry even
+// for an image already on the machine: the flag that fixes it, `--policy`,
+// arrived in compose v2.22.0 on 2023-09-21.
+//
+// Passing an unknown flag is not a degradation, it is a hard failure — compose
+// exits with "unknown flag" and `madock start` dies on somebody's machine over
+// an optimisation that saves one request. So it is asked rather than assumed,
+// and when the answer cannot be had the old behaviour stands.
+const composePullPolicySince = "2.22.0"
+
+var (
+	composeVersionOnce sync.Once
+	composeVersion     string
+)
+
+// ComposeVersion is the version of the compose plugin on this machine, or empty
+// when it could not be determined.
+//
+// Empty is a real answer and is treated as "assume nothing", never as "old" or
+// "new": docker may be absent, the plugin may be a fork, and the output format
+// has changed before. A caller that cannot tell must keep doing what it did.
+func ComposeVersion() string {
+	composeVersionOnce.Do(func() {
+		out, err := exec.Command("docker", "compose", "version", "--short").Output()
+		if err != nil {
+			return
+		}
+		// `--short` prints "2.29.7" on most builds and "v2.29.7" on some.
+		composeVersion = strings.TrimPrefix(strings.TrimSpace(string(out)), "v")
+	})
+
+	return composeVersion
+}
+
+// composeSupportsPullPolicy reports whether `docker compose pull` here takes
+// `--policy`.
+func composeSupportsPullPolicy() bool {
+	return versionHasPullPolicy(ComposeVersion())
+}
+
+// versionHasPullPolicy is the decision on its own, so it can be tested without
+// a docker daemon — the part worth testing is the comparison, and the part that
+// needs a machine is not.
+func versionHasPullPolicy(version string) bool {
+	if version == "" {
+		return false
+	}
+
+	return configs2.CompareVersions(version, composePullPolicySince) >= 0
+}

--- a/src/helper/docker/compose_version_test.go
+++ b/src/helper/docker/compose_version_test.go
@@ -1,0 +1,32 @@
+package docker
+
+import "testing"
+
+// The boundary is a real date and a real release — compose v2.22.0, 2023-09-21,
+// is where `docker compose pull --policy` first appears in the command's own
+// reference. Below it the flag is not "ignored", it is an unknown flag and
+// compose exits non-zero, so a wrong answer here does not slow madock down, it
+// stops it.
+func TestPullPolicyIsAskedForNotAssumed(t *testing.T) {
+	cases := []struct {
+		version   string
+		supported bool
+		why       string
+	}{
+		{"2.22.0", true, "the release that added the flag"},
+		{"2.22.1", true, "later patch of the same minor"},
+		{"2.29.7", true, "a current build"},
+		{"3.0.0", true, "a future major must not read as older"},
+		{"2.21.0", false, "the release before it"},
+		{"2.9.0", false, "a minor that sorts above 2.22 as a string and below it as a number"},
+		{"1.29.2", false, "compose v1, which has no such flag and never will"},
+		{"", false, "no answer is not an old answer, but it must not enable the flag either"},
+	}
+
+	for _, c := range cases {
+		got := versionHasPullPolicy(c.version)
+		if got != c.supported {
+			t.Errorf("versionHasPullPolicy(%q) = %v, want %v — %s", c.version, got, c.supported, c.why)
+		}
+	}
+}

--- a/src/helper/docker/compose_version_test.go
+++ b/src/helper/docker/compose_version_test.go
@@ -30,3 +30,68 @@ func TestPullPolicyIsAskedForNotAssumed(t *testing.T) {
 		}
 	}
 }
+
+// What madock actually asks compose for.
+//
+// The distinction this guards is the one the 2021 commit made and the code lost:
+// a rebuild goes and looks for a newer image, an ordinary start only needs the
+// image present. Getting it backwards is invisible — both spellings work, one
+// of them just talks to the registry about images the machine already has, on
+// every first start of every installation.
+func TestPullAsksForAPolicyOnlyWhenItShould(t *testing.T) {
+	files := []string{"compose", "-f", "docker-compose.yml"}
+
+	cases := []struct {
+		name      string
+		refresh   bool
+		supported bool
+		quiet     bool
+		want      []string
+	}{
+		{
+			name: "an ordinary start on a compose that understands policies",
+			want: []string{"compose", "-f", "docker-compose.yml", "pull", "--policy", "missing"},
+		},
+		{
+			name:    "a rebuild, which is the one case that means to look for a newer image",
+			refresh: true,
+			want:    []string{"compose", "-f", "docker-compose.yml", "pull"},
+		},
+		{
+			name: "compose too old to be told, where the old behaviour has to stand",
+			want: []string{"compose", "-f", "docker-compose.yml", "pull"},
+		},
+		{
+			name:  "quiet comes last, and does not displace the policy",
+			quiet: true,
+			want:  []string{"compose", "-f", "docker-compose.yml", "pull", "--policy", "missing", "--quiet"},
+		},
+	}
+
+	// Only the first, second and fourth run against a compose that supports it;
+	// the third is the whole point of the flag being conditional.
+	cases[0].supported = true
+	cases[1].supported = true
+	cases[3].supported = true
+
+	for _, c := range cases {
+		got := pullArgs(files, c.refresh, c.supported, c.quiet)
+		if len(got) != len(c.want) {
+			t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("%s: got %v, want %v", c.name, got, c.want)
+				break
+			}
+		}
+	}
+
+	// The caller's slice is not to be scribbled on: dockerComposePull is handed
+	// a literal at three call sites today, and an append that reuses the backing
+	// array would leak "pull" into whatever else shared it.
+	if len(files) != 3 {
+		t.Errorf("pullArgs modified the slice it was given: %v", files)
+	}
+}

--- a/src/helper/docker/docker.go
+++ b/src/helper/docker/docker.go
@@ -562,19 +562,31 @@ func upProjectWithBuild(projectName string, withChown bool, refresh bool) {
 // When compose is too old to be told, the old behaviour stands — see
 // composeSupportsPullPolicy for why that direction and not the other.
 func dockerComposePull(composeFiles []string, refresh bool) {
-	composeFiles = append(composeFiles, "pull")
-	if !refresh && composeSupportsPullPolicy() {
-		composeFiles = append(composeFiles, "--policy", "missing")
-	}
-	if attr.IsQuiet {
-		composeFiles = append(composeFiles, "--quiet")
-	}
-	cmd := exec.Command("docker", composeFiles...)
+	cmd := exec.Command("docker", pullArgs(composeFiles, refresh, composeSupportsPullPolicy(), attr.IsQuiet)...)
 	attachOutput(cmd)
 	err := cmd.Run()
 	if err != nil {
 		logger.Fatal(err)
 	}
+}
+
+// pullArgs builds the argument list, separated so it can be asserted.
+//
+// Worth its own function because the green run does not answer this: the e2e
+// harness logs a madock command and its duration and keeps the output unless
+// the command fails, so a suite that passes says nothing about whether the flag
+// was on. Whether compose then honours it is compose's business and documented;
+// whether madock asks for it is ours.
+func pullArgs(composeFiles []string, refresh, policySupported, quiet bool) []string {
+	args := append(append([]string{}, composeFiles...), "pull")
+	if !refresh && policySupported {
+		args = append(args, "--policy", "missing")
+	}
+	if quiet {
+		args = append(args, "--quiet")
+	}
+
+	return args
 }
 
 // attachOutput connects cmd stdout/stderr to os.Stdout/os.Stderr unless quiet mode is active

--- a/src/helper/docker/docker.go
+++ b/src/helper/docker/docker.go
@@ -79,7 +79,7 @@ func dockerRun(subject string, args ...string) {
 // UpWithBuild starts both nginx proxy and project containers with build
 func UpWithBuild(projectName string, withChown bool) {
 	UpNginxWithBuild(projectName, true)
-	UpProjectWithBuild(projectName, withChown)
+	UpProjectWithBuildRefresh(projectName, withChown)
 }
 
 // Down stops project containers. When the compose file is present it
@@ -407,8 +407,29 @@ func prepareHomeDirs() (string, error) {
 	return home, nil
 }
 
-// UpProjectWithBuild starts project containers with build
+// UpProjectWithBuild starts project containers with build, fetching only the
+// images this machine does not already have.
+//
+// This is the ordinary path — creating containers, recreating them after a
+// config change, recovering from a failed `compose start`. None of those is a
+// reason to go and look for a newer image, and madock-pro's branch environments
+// call it too, so the signature is left alone deliberately: the better default
+// reaches every caller without a coordinated version bump across two
+// repositories.
 func UpProjectWithBuild(projectName string, withChown bool) {
+	upProjectWithBuild(projectName, withChown, false)
+}
+
+// UpProjectWithBuildRefresh is the same, and also looks for newer images.
+//
+// Only rebuild and clone want this. It is what the pull was added for in 2021,
+// and separating it is what lets every other caller stop asking the registry
+// about images it already has.
+func UpProjectWithBuildRefresh(projectName string, withChown bool) {
+	upProjectWithBuild(projectName, withChown, true)
+}
+
+func upProjectWithBuild(projectName string, withChown bool, refresh bool) {
 	var err error
 	globalComposer := paths.ComposerDir()
 	if !paths.IsFileExist(globalComposer) {
@@ -482,7 +503,7 @@ func UpProjectWithBuild(projectName string, withChown bool) {
 		"--no-deps",
 		"-d",
 	}
-	dockerComposePull([]string{"compose", "-f", composeFile, "-f", composeFileOS})
+	dockerComposePull([]string{"compose", "-f", composeFile, "-f", composeFileOS}, refresh)
 	cmd := exec.Command("docker", profilesOn...)
 	attachOutput(cmd)
 	err = cmd.Run()
@@ -522,9 +543,29 @@ func UpProjectWithBuild(projectName string, withChown bool) {
 	project.RecordApplied(projectName)
 }
 
-// dockerComposePull pulls images for docker-compose
-func dockerComposePull(composeFiles []string) {
+// dockerComposePull fetches the images a compose file names.
+//
+// `refresh` is the difference between the two reasons this is ever called, and
+// it was one reason until 2026-08-29 because compose had no way to say the
+// other. It was added in 2021 for exactly one of them — the commit says so:
+// "add pulling images from docker hub with rebuild command run" — and a rebuild
+// does mean go and see whether there is a newer image. Starting a project does
+// not; there it only has to be present.
+//
+// Told apart, because `docker compose pull` asks the registry about every image
+// whether or not the machine already has it. Measured in CI on 2026-08-29: the
+// image had just been loaded from a cache, the log said `Loaded image:`, and
+// compose reported `Pulling` and then failed on Docker Hub's rate limit. Every
+// first start of every installation was paying for a question it knew the
+// answer to.
+//
+// When compose is too old to be told, the old behaviour stands — see
+// composeSupportsPullPolicy for why that direction and not the other.
+func dockerComposePull(composeFiles []string, refresh bool) {
 	composeFiles = append(composeFiles, "pull")
+	if !refresh && composeSupportsPullPolicy() {
+		composeFiles = append(composeFiles, "--policy", "missing")
+	}
 	if attr.IsQuiet {
 		composeFiles = append(composeFiles, "--quiet")
 	}
@@ -556,7 +597,9 @@ func UpSnapshot(projectName string) {
 		"--no-deps",
 		"-d",
 	}
-	dockerComposePull([]string{"compose", "-f", composerFile})
+	// A snapshot only needs the image present; it is not a place to go
+	// looking for a newer one.
+	dockerComposePull([]string{"compose", "-f", composerFile}, false)
 	cmd := exec.Command("docker", profilesOn...)
 	attachOutput(cmd)
 	err := cmd.Run()

--- a/src/helper/docker/proxy.go
+++ b/src/helper/docker/proxy.go
@@ -84,7 +84,13 @@ func UpNginxWithBuild(projectName string, force bool) {
 				nginx.GenerateSslCert(ctxPath, false)
 			}
 
-			dockerComposePull([]string{"compose", "-f", proxyCompose})
+			// force is proxy:rebuild, and only there is looking for a newer
+			// image the point. Every other start reaches here through
+			// UpNginx, which passes false: the proxy image only has to be
+			// present, and asking the registry about one already on the
+			// machine is what this used to do on the first start of every
+			// installation.
+			dockerComposePull([]string{"compose", "-f", proxyCompose}, force)
 
 			err := os.WriteFile(confCache, []byte("config cache"), 0755)
 			if err != nil {

--- a/test/e2e/images.txt
+++ b/test/e2e/images.txt
@@ -9,18 +9,18 @@
 #
 # One line per image, exact tags. Comments and blank lines are ignored.
 #
-# **Keep `:latest` out of here, and out of the templates.** A floating tag has to
-# be resolved before compose can know whether the local image is current, so it
-# asks the registry on every `up` whatever is on the daemon — and that question
-# is counted against the limit.
+# **Keep `:latest` out of here, and out of the templates** — for
+# reproducibility, not for the rate limit. A floating tag means the proxy every
+# project on the machine shares changes on whatever day upstream publishes.
 #
-# This is measured, and it is why caching alone was not enough. On 2026-08-29 a
-# shard loaded mailpit out of the cache, the log said `Loaded image:
-# axllent/mailpit:latest`, and compose still reported `mailcatcher Pulling` and
-# failed on the rate limit — while `nginx`, with no tag to resolve, said
-# `Skipped - No image to be pulled` in the same run. The cache put the image
-# there; the tag made it ask anyway. mailpit is pinned in
-# docker/general/nginx/docker-compose-proxy.yml now.
+# It is worth saying which of those two this is, because the first explanation
+# here was the wrong one. The registry was being asked about images the machine
+# already had, and the cause was `docker compose pull`, which asks about every
+# image whether or not it is present — measured on 2026-08-29, when a shard
+# loaded mailpit out of this cache, logged `Loaded image:`, and compose still
+# reported `Pulling` and failed on the limit. Pinning the tag changed nothing
+# about that; the fix is in dockerComposePull, which now asks only for what is
+# missing unless the run really is a rebuild.
 #
 # **This list is grown from evidence, not from reading the templates.** The
 # images come out of madock's config at render time, so which ones a given test

--- a/test/e2e/images.txt
+++ b/test/e2e/images.txt
@@ -9,11 +9,18 @@
 #
 # One line per image, exact tags. Comments and blank lines are ignored.
 #
-# **Keep `:latest` out of here where a version tag exists.** A floating tag makes
-# compose ask the registry on every `up`, even when the image is already on the
-# daemon, and that question is itself counted against the limit. A pinned tag
-# that is present locally is not asked about at all — which is why the built
-# services report "Skipped - No image to be pulled" and mailpit does not.
+# **Keep `:latest` out of here, and out of the templates.** A floating tag has to
+# be resolved before compose can know whether the local image is current, so it
+# asks the registry on every `up` whatever is on the daemon — and that question
+# is counted against the limit.
+#
+# This is measured, and it is why caching alone was not enough. On 2026-08-29 a
+# shard loaded mailpit out of the cache, the log said `Loaded image:
+# axllent/mailpit:latest`, and compose still reported `mailcatcher Pulling` and
+# failed on the rate limit — while `nginx`, with no tag to resolve, said
+# `Skipped - No image to be pulled` in the same run. The cache put the image
+# there; the tag made it ask anyway. mailpit is pinned in
+# docker/general/nginx/docker-compose-proxy.yml now.
 #
 # **This list is grown from evidence, not from reading the templates.** The
 # images come out of madock's config at render time, so which ones a given test
@@ -21,7 +28,7 @@
 # holding, under "Images this job actually used"; anything appearing there and
 # missing here is a pull that is still being paid for.
 
-axllent/mailpit:latest
+axllent/mailpit:v1.31.0
 ubuntu:22.04
 
 # Added 2026-08-29 from the first run of the list above, which is exactly what

--- a/test/e2e/images.txt
+++ b/test/e2e/images.txt
@@ -23,3 +23,9 @@
 
 axllent/mailpit:latest
 ubuntu:22.04
+
+# Added 2026-08-29 from the first run of the list above, which is exactly what
+# the "Images this job actually used" step is for: the shards reported three
+# images from Docker Hub and the list held two. Nobody would have guessed this
+# one by reading the templates — it is not in any of them.
+alpine:3

--- a/test/e2e/images.txt
+++ b/test/e2e/images.txt
@@ -1,0 +1,25 @@
+# Images the end-to-end suite pulls from Docker Hub, warmed once per run and
+# loaded from GitHub's cache by every job that needs them.
+#
+# Why this file exists: Docker Hub allows 200 pulls an hour to an authenticated
+# free account, and a single pull request costs two runs of nine jobs. On
+# 2026-08-29 three pull requests in one morning spent the hour's budget and every
+# shard went red on `toomanyrequests` — wearing the face of a regression in the
+# change under review, which is the expensive part.
+#
+# One line per image, exact tags. Comments and blank lines are ignored.
+#
+# **Keep `:latest` out of here where a version tag exists.** A floating tag makes
+# compose ask the registry on every `up`, even when the image is already on the
+# daemon, and that question is itself counted against the limit. A pinned tag
+# that is present locally is not asked about at all — which is why the built
+# services report "Skipped - No image to be pulled" and mailpit does not.
+#
+# **This list is grown from evidence, not from reading the templates.** The
+# images come out of madock's config at render time, so which ones a given test
+# uses cannot be read off a file. Every job prints what its daemon ended up
+# holding, under "Images this job actually used"; anything appearing there and
+# missing here is a pull that is still being paid for.
+
+axllent/mailpit:latest
+ubuntu:22.04


### PR DESCRIPTION
The shards carry this guard already. `-run` with a name that matches nothing makes `go test` exit 0 having run nothing, and the job goes green.

On a shard that reads as "these tests passed". On the quarantine job it reads as **"the flake has stopped"** — the single conclusion that job exists to support, and the one nobody would go and check.

A SKIP counts as having run: it means the test was reached and the quarantine flag was not, which is its own defect and exactly the state the job was created to end.