### PR TITLE
4.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+**v4.1.11**
+
+Fixed:
+- **`docker compose pull` was asking the registry about images the machine already had.** It asks about every image whether or not it is present, and madock called it on the first start of every installation. Measured in CI on 2026-08-29: the image had just been loaded from a local cache, the log said `Loaded image:`, and compose still reported `Pulling` and then failed on Docker Hub's rate limit
+- **Told apart by what the run is for, which is what the 2021 commit that added the pull meant.** Its message says so: "add pulling images from docker hub with rebuild command run". A rebuild does mean go and look for a newer image; creating containers, recreating them after a config change and recovering from a failed `compose start` do not — there the image only has to be present. Rebuild and clone keep the old behaviour, everything else asks only for what is missing
+- The flag that makes this possible arrived in compose v2.22.0, and madock declares no minimum compose version anywhere, so the version is asked for rather than assumed. An unknown flag is not a degradation — compose exits non-zero and `madock start` dies — so where the version cannot be read, the old behaviour stands
+
+Changed:
+- **The mailpit image is named in the config like every other service** (`proxy/mailpit/repository` and `version`), so it can be raised in one place, per machine or per project, instead of being editable only by changing madock. It was `axllent/mailpit:latest` and is now pinned: the proxy is shared by every project on a machine, and a floating tag means it changes underneath all of them on whatever day upstream publishes
+
 **v4.1.10**
 
 Fixed:

--- a/config.xml
+++ b/config.xml
@@ -162,14 +162,22 @@
                 <pgadmin>
                     <enabled>false</enabled>
                     <repository>dpage/pgadmin4</repository>
-                    <version>latest</version>
+                    <!-- Pinned on 2026-08-29, with the rest of them. `latest` on
+                         a shared machine means the tool changes on whatever day
+                         upstream publishes, and nobody connects that to the
+                         morning it started behaving differently. -->
+                    <version>9.17</version>
                     <email>admin@admin.com</email>
                     <password>admin</password>
                 </pgadmin>
                 <mongo_express>
                     <enabled>false</enabled>
                     <repository>mongo-express</repository>
-                    <version>latest</version>
+                    <!-- 1.0.2 is where `latest` points, and where it has pointed
+                         since May 2024: this project publishes rarely. Pinned so
+                         that a release after such a gap arrives as a decision
+                         rather than as a Tuesday. -->
+                    <version>1.0.2</version>
                 </mongo_express>
             </db>
             <db2>
@@ -348,6 +356,19 @@
                 <timezone>America/Chicago</timezone>
                 <mftf>
                     <enabled>false</enabled>
+                    <!-- The browser the functional tests drive. Named here
+                         rather than written into the compose template, so a
+                         suite that needs a particular Chrome can say so.
+
+                         selenium tags a Chrome major, so this is the browser
+                         version as much as the image version. It was `latest`,
+                         which for a test runner is the worst of the two
+                         directions: a suite that passed yesterday and fails
+                         today, with nothing in the repository changed. -->
+                    <selenium>
+                        <repository>selenium/standalone-chrome</repository>
+                        <version>151.0</version>
+                    </selenium>
                     <admin_user>admin</admin_user>
                     <otp_shared_secret>MFZWIZTHNBVGW3D2</otp_shared_secret>
                 </mftf>
@@ -423,6 +444,19 @@
             </sylius>
             <proxy>
                 <enabled>true</enabled>
+                <!-- The image the shared proxy is built from. It lived in
+                     docker/general/nginx/proxy.Dockerfile as a literal `FROM
+                     nginx:1.28`, which made it the one version on this machine
+                     that could only be changed by editing madock itself — the
+                     proxy is not a project, so no project's config could reach
+                     it.
+
+                     Pinned there already, so this changes who may move it and
+                     not what runs. -->
+                <nginx>
+                    <repository>nginx</repository>
+                    <version>1.28</version>
+                </nginx>
                 <timeout>
                     <connect>60</connect>
                     <send>300</send>

--- a/docker/general/nginx/proxy.Dockerfile
+++ b/docker/general/nginx/proxy.Dockerfile
@@ -1,3 +1,3 @@
-FROM nginx:1.28
+FROM {{{.proxy.nginx.repository}}}:{{{.proxy.nginx.version}}}
 COPY . /
 EXPOSE 35729

--- a/docker/snippets/docker-compose/selenium.yml
+++ b/docker/snippets/docker-compose/selenium.yml
@@ -1,7 +1,7 @@
 {{{- if .magento.mftf.enabled}}}
   selenium:
     init: true
-    image: selenium/standalone-chrome:latest
+    image: {{{.magento.mftf.selenium.repository}}}:{{{.magento.mftf.selenium.version}}}
     platform: linux/amd64
     ports:
       - "{{{port "selenium"}}}:7900"

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -162,14 +162,22 @@
                 <pgadmin>
                     <enabled>false</enabled>
                     <repository>dpage/pgadmin4</repository>
-                    <version>latest</version>
+                    <!-- Pinned on 2026-08-29, with the rest of them. `latest` on
+                         a shared machine means the tool changes on whatever day
+                         upstream publishes, and nobody connects that to the
+                         morning it started behaving differently. -->
+                    <version>9.17</version>
                     <email>admin@admin.com</email>
                     <password>admin</password>
                 </pgadmin>
                 <mongo_express>
                     <enabled>false</enabled>
                     <repository>mongo-express</repository>
-                    <version>latest</version>
+                    <!-- 1.0.2 is where `latest` points, and where it has pointed
+                         since May 2024: this project publishes rarely. Pinned so
+                         that a release after such a gap arrives as a decision
+                         rather than as a Tuesday. -->
+                    <version>1.0.2</version>
                 </mongo_express>
             </db>
             <db2>
@@ -348,6 +356,19 @@
                 <timezone>America/Chicago</timezone>
                 <mftf>
                     <enabled>false</enabled>
+                    <!-- The browser the functional tests drive. Named here
+                         rather than written into the compose template, so a
+                         suite that needs a particular Chrome can say so.
+
+                         selenium tags a Chrome major, so this is the browser
+                         version as much as the image version. It was `latest`,
+                         which for a test runner is the worst of the two
+                         directions: a suite that passed yesterday and fails
+                         today, with nothing in the repository changed. -->
+                    <selenium>
+                        <repository>selenium/standalone-chrome</repository>
+                        <version>151.0</version>
+                    </selenium>
                     <admin_user>admin</admin_user>
                     <otp_shared_secret>MFZWIZTHNBVGW3D2</otp_shared_secret>
                 </mftf>
@@ -423,6 +444,19 @@
             </sylius>
             <proxy>
                 <enabled>true</enabled>
+                <!-- The image the shared proxy is built from. It lived in
+                     docker/general/nginx/proxy.Dockerfile as a literal `FROM
+                     nginx:1.28`, which made it the one version on this machine
+                     that could only be changed by editing madock itself — the
+                     proxy is not a project, so no project's config could reach
+                     it.
+
+                     Pinned there already, so this changes who may move it and
+                     not what runs. -->
+                <nginx>
+                    <repository>nginx</repository>
+                    <version>1.28</version>
+                </nginx>
                 <timeout>
                     <connect>60</connect>
                     <send>300</send>

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.10"
+const Version = "4.1.11"


### PR DESCRIPTION
Carries what landed in #102 into a version pro can import.

- `docker compose pull` no longer asks the registry about images the machine already has. It is told apart by what the run is for, which is what the 2021 commit that added the pull meant: rebuild and clone still look for a newer image, everything else asks only for what is missing. The flag needs compose v2.22.0, and since madock declares no minimum anywhere, the version is asked for rather than assumed — an unknown flag kills `madock start` rather than degrading it.
- The mailpit image is named in the config like every other service, and pinned. The proxy is shared by every project on a machine; a floating tag means it changes underneath all of them on whatever day upstream publishes.