### PR TITLE
Six more images the config never mentioned

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -38,6 +38,15 @@
                      false leaves out the container, the vhost, the block in the
                      shared proxy, the name in the certificate and the ports. -->
                 <enabled>true</enabled>
+                <!-- The project's own web server, which is a different container
+                     from the shared proxy and had its version in a different
+                     place: a literal FROM in docker/snippets/dockerfile/nginx.
+                     Moving only the proxy's left this one behind, and the two
+                     read alike enough that it was reported as done.
+
+                     Same version as before, 1.28. -->
+                <repository>nginx</repository>
+                <version>1.28</version>
                 <port>
                     <unsecure>80</unsecure>
                     <secure>443</secure>
@@ -575,6 +584,38 @@
                 <enabled>false</enabled>
                 <repository>grafana/grafana</repository>
                 <version>11.1.5</version>
+                <!-- The rest of the stack, which used to be written into its
+                     compose snippets: five containers that this block did not
+                     mention at all, so a reader checking the config would have
+                     concluded grafana was one image.
+
+                     loki and promtail stay on 2.9.10, the version already
+                     running. Pinning is not upgrading — 3.x is a major move and
+                     belongs in a change that says so. The three exporters below
+                     carried no tag whatsoever, which is `latest` spelled
+                     invisibly; they are pinned at what `latest` resolved to on
+                     2026-08-29, so nothing changes today and the next move is a
+                     decision. -->
+                <loki>
+                    <repository>grafana/loki</repository>
+                    <version>2.9.10</version>
+                </loki>
+                <promtail>
+                    <repository>grafana/promtail</repository>
+                    <version>2.9.10</version>
+                </promtail>
+                <prometheus>
+                    <repository>prom/prometheus</repository>
+                    <version>v3.14.0</version>
+                </prometheus>
+                <mysqld_exporter>
+                    <repository>prom/mysqld-exporter</repository>
+                    <version>v0.20.0</version>
+                </mysqld_exporter>
+                <rabbitmq_exporter>
+                    <repository>kbudde/rabbitmq-exporter</repository>
+                    <version>1.0.0</version>
+                </rabbitmq_exporter>
                 <auth>
                     <enabled>false</enabled>
                     <user></user>

--- a/docker/snippets/docker-compose/grafana-loki.yml
+++ b/docker/snippets/docker-compose/grafana-loki.yml
@@ -1,7 +1,7 @@
 {{{- if .grafana.enabled}}}
   loki:
     init: true
-    image: grafana/loki:2.9.10
+    image: {{{.grafana.loki.repository}}}:{{{.grafana.loki.version}}}
     command: --config.file=/etc/loki/local-config.yaml
     user: root
     volumes:

--- a/docker/snippets/docker-compose/grafana-mysql-exporter.yml
+++ b/docker/snippets/docker-compose/grafana-mysql-exporter.yml
@@ -1,7 +1,7 @@
 {{{- if .grafana.enabled}}}
   dbexporter:
     init: true
-    image: prom/mysqld-exporter
+    image: {{{.grafana.mysqld_exporter.repository}}}:{{{.grafana.mysqld_exporter.version}}}
     volumes:
       - ./ctx/grafana/mysql-exporter.my.cnf:/.my.cnf
     networks:

--- a/docker/snippets/docker-compose/grafana-prometheus.yml
+++ b/docker/snippets/docker-compose/grafana-prometheus.yml
@@ -1,7 +1,7 @@
 {{{- if .grafana.enabled}}}
   prometheus:
     init: true
-    image: prom/prometheus
+    image: {{{.grafana.prometheus.repository}}}:{{{.grafana.prometheus.version}}}
     command: --config.file=/etc/prometheus/prometheus-config.yml
     volumes:
       - ./ctx/grafana/prometheus-config.yml:/etc/prometheus/prometheus-config.yml

--- a/docker/snippets/docker-compose/grafana-promtail-shopify.yml
+++ b/docker/snippets/docker-compose/grafana-promtail-shopify.yml
@@ -1,7 +1,7 @@
 {{{- if .grafana.enabled}}}
   promtail:
     init: true
-    image: grafana/promtail:2.9.10
+    image: {{{.grafana.promtail.repository}}}:{{{.grafana.promtail.version}}}
     volumes:
       - ./ctx/grafana/promtail-config.yml:/etc/promtail/config.yml
       - ./src/web/storage/logs:/var/log

--- a/docker/snippets/docker-compose/grafana-promtail.yml
+++ b/docker/snippets/docker-compose/grafana-promtail.yml
@@ -1,7 +1,7 @@
 {{{- if .grafana.enabled}}}
   promtail:
     init: true
-    image: grafana/promtail:2.9.10
+    image: {{{.grafana.promtail.repository}}}:{{{.grafana.promtail.version}}}
     volumes:
       - ./ctx/grafana/promtail-config.yml:/etc/promtail/config.yml
       - ./src/var/log:/var/log

--- a/docker/snippets/docker-compose/grafana-rabbitmq-exporter.yml
+++ b/docker/snippets/docker-compose/grafana-rabbitmq-exporter.yml
@@ -1,7 +1,7 @@
 {{{- if and .grafana.enabled .rabbitmq.enabled}}}
   rabbitmqexporter:
     init: true
-    image: kbudde/rabbitmq-exporter
+    image: {{{.grafana.rabbitmq_exporter.repository}}}:{{{.grafana.rabbitmq_exporter.version}}}
     environment:
       RABBIT_URL: http://rabbitmq:15672
       RABBIT_USER: {{{.rabbitmq.user}}}

--- a/docker/snippets/dockerfile/nginx/nginx
+++ b/docker/snippets/dockerfile/nginx/nginx
@@ -1,4 +1,4 @@
-FROM nginx:1.28
+FROM {{{.nginx.repository}}}:{{{.nginx.version}}}
 
 RUN rm -f /var/log/faillog && rm -f /var/log/lastlog
 

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -38,6 +38,15 @@
                      false leaves out the container, the vhost, the block in the
                      shared proxy, the name in the certificate and the ports. -->
                 <enabled>true</enabled>
+                <!-- The project's own web server, which is a different container
+                     from the shared proxy and had its version in a different
+                     place: a literal FROM in docker/snippets/dockerfile/nginx.
+                     Moving only the proxy's left this one behind, and the two
+                     read alike enough that it was reported as done.
+
+                     Same version as before, 1.28. -->
+                <repository>nginx</repository>
+                <version>1.28</version>
                 <port>
                     <unsecure>80</unsecure>
                     <secure>443</secure>
@@ -575,6 +584,38 @@
                 <enabled>false</enabled>
                 <repository>grafana/grafana</repository>
                 <version>11.1.5</version>
+                <!-- The rest of the stack, which used to be written into its
+                     compose snippets: five containers that this block did not
+                     mention at all, so a reader checking the config would have
+                     concluded grafana was one image.
+
+                     loki and promtail stay on 2.9.10, the version already
+                     running. Pinning is not upgrading — 3.x is a major move and
+                     belongs in a change that says so. The three exporters below
+                     carried no tag whatsoever, which is `latest` spelled
+                     invisibly; they are pinned at what `latest` resolved to on
+                     2026-08-29, so nothing changes today and the next move is a
+                     decision. -->
+                <loki>
+                    <repository>grafana/loki</repository>
+                    <version>2.9.10</version>
+                </loki>
+                <promtail>
+                    <repository>grafana/promtail</repository>
+                    <version>2.9.10</version>
+                </promtail>
+                <prometheus>
+                    <repository>prom/prometheus</repository>
+                    <version>v3.14.0</version>
+                </prometheus>
+                <mysqld_exporter>
+                    <repository>prom/mysqld-exporter</repository>
+                    <version>v0.20.0</version>
+                </mysqld_exporter>
+                <rabbitmq_exporter>
+                    <repository>kbudde/rabbitmq-exporter</repository>
+                    <version>1.0.0</version>
+                </rabbitmq_exporter>
                 <auth>
                     <enabled>false</enabled>
                     <user></user>


### PR DESCRIPTION
Follow-up to #103, which claimed no image versions were left in templates. That claim was wrong, and the grep behind it looked for four names I already knew instead of for the shape of the thing.

The grafana block named one image; its stack is six containers. loki, promtail (twice), prometheus, the mysqld exporter and the rabbitmq exporter lived in their compose snippets. **Three of them carried no tag at all** — `latest` spelled invisibly, and worse than writing it, because nothing in the file suggests a version was ever decided.

The project's own nginx was a literal `FROM` in its Dockerfile. It is a different container from the shared proxy, whose version moved in #103, and the two read alike enough that moving one was reported as moving both.

**Pinned at what runs, not at what is newest.** loki and promtail stay on 2.9.10 — 3.x is a major move and belongs in a change that says so. The three untagged ones are pinned at whatever `latest` resolved to today, so nothing changes and the next move becomes a decision.

Found by the freshness image checker on its first pass, which is what it is for. The grep that finds them is `grep -rn "image:|^FROM" docker/ | grep -v '{{{'` and it now comes back empty.