### PR TITLE
Go 1.27, and cron that survives a reboot

### DIFF
--- a/docker/snippets/dockerfile/php/footer
+++ b/docker/snippets/dockerfile/php/footer
@@ -7,8 +7,53 @@ EXPOSE 9001 9003 35729 5173 9998 9999
 
 {{{template "snippets/dockerfile/common/umask" .}}}
 
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
+
 {{{- if .permissions.umask.permissive}}}
 CMD ["bash", "-c", "exec php-fpm{{{.php.version}}}"]
 {{{- else}}}
-CMD "php-fpm{{{.php.version}}}"
+CMD ["php-fpm{{{.php.version}}}"]
 {{{- end}}}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/faradey/madock/v4
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/alexflint/go-arg v1.4.3

--- a/src/helper/configs/aruntime/project/php_entrypoint_test.go
+++ b/src/helper/configs/aruntime/project/php_entrypoint_test.go
@@ -1,0 +1,141 @@
+package project
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/faradey/madock/v4/src/helper/testenv"
+)
+
+// These run the php image's entrypoint against a fake crontab, because the
+// question it answers is behavioural and a rendering test cannot reach it.
+//
+// What it exists for: nothing in an application image starts cron — the CMD is
+// php-fpm — so the daemon lived only as long as the container it was started
+// in. Anything that recreates that container takes cron with it and leaves the
+// crontab behind: the jobs are there, nothing reads them, nothing fails, and
+// every HTTP check stays green. madock re-arms after `service:restart`, and that
+// cannot cover a host reboot, where Docker brings the containers back on its own
+// and madock is not running at all. Measured on a production machine on
+// 2026-08-30: containers up, applications answering, cron down in both projects
+// that had it.
+//
+// The three cases below are the whole contract, and the middle one is the reason
+// this is a test rather than a line of shell nobody checks: a Debian crontab is
+// never empty — it carries an explanatory header — so "the file has content"
+// would start cron for a project that has no jobs at all, and the daemon would
+// then be running everywhere, including where cron:disable was used.
+func TestPhpEntrypointStartsCronOnlyWhenThereAreJobs(t *testing.T) {
+	t.Run("jobs installed: cron is started, then the command runs", func(t *testing.T) {
+		out := runPhpEntrypoint(t, "0 * * * * /usr/bin/php /var/www/html/bin/magento cron:run\n")
+
+		if !strings.Contains(out, "service cron start") {
+			t.Errorf("cron was not started while jobs were installed:\n%s", out)
+		}
+		if !strings.Contains(out, "COMMAND RAN") {
+			t.Errorf("the entrypoint did not exec the command it was given:\n%s", out)
+		}
+	})
+
+	t.Run("only Debian's header: cron stays down", func(t *testing.T) {
+		// Exactly what `crontab -l` prints for a user who has never had a job.
+		out := runPhpEntrypoint(t, "# Edit this file to introduce tasks to be run by cron.\n#\n# m h  dom mon dow   command\n")
+
+		if strings.Contains(out, "service cron start") {
+			t.Errorf("cron was started for a crontab holding nothing but comments:\n%s", out)
+		}
+		if !strings.Contains(out, "COMMAND RAN") {
+			t.Errorf("the entrypoint did not exec the command it was given:\n%s", out)
+		}
+	})
+
+	t.Run("no crontab at all: the command still runs", func(t *testing.T) {
+		// `crontab -l` exits 1 and prints to stderr here. The application must
+		// not be held hostage by that: a container refusing to serve because its
+		// scheduler is unhappy is worse than the silence being fixed.
+		out := runPhpEntrypoint(t, "")
+
+		if strings.Contains(out, "service cron start") {
+			t.Errorf("cron was started with no crontab present:\n%s", out)
+		}
+		if !strings.Contains(out, "COMMAND RAN") {
+			t.Errorf("a missing crontab stopped the application from starting:\n%s", out)
+		}
+	})
+}
+
+// runPhpEntrypoint renders the php Dockerfile, takes the entrypoint out of it
+// and runs it with `crontab` and `service` replaced by scripts that report what
+// they were asked to do.
+//
+// The entrypoint is read out of the rendered file rather than copied here: a
+// copy would keep passing after the real one changed, which is the failure this
+// whole file is about.
+func runPhpEntrypoint(t *testing.T, crontabBody string) string {
+	t.Helper()
+
+	projectName := "phpentry"
+	installation := testenv.SetupWith(t, projectName, "phpentry.test", map[string]string{
+		"platform":    "magento2",
+		"php/enabled": "true",
+	})
+
+	MakeConf(projectName)
+
+	rendered := testenv.Collect(t, filepath.Join(installation.ExecDir, "aruntime", "projects", projectName), installation)
+
+	var dockerfile string
+	for name, body := range rendered {
+		if strings.HasSuffix(name, "ctx/php.Dockerfile") {
+			dockerfile = body
+		}
+	}
+	if dockerfile == "" {
+		t.Fatal("MakeConf produced no php.Dockerfile")
+	}
+
+	// entrypointBody cuts at the marker, and the marker sits mid-line — the
+	// `RUN cat > … <<'MADOCK_EOF' && chmod +x …` tail comes with it. Dropping
+	// everything up to the first newline is what leaves a script sh can read.
+	body := entrypointBody(t, dockerfile)
+	if _, rest, found := strings.Cut(body, "\n"); found {
+		body = rest
+	}
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "madock-entrypoint")
+	writeExecutable(t, scriptPath, body)
+
+	bin := filepath.Join(dir, "bin")
+
+	// `crontab -u <user> -l` prints the body for any user, or fails when there
+	// is none — the empty case is a missing crontab, not an empty one.
+	if crontabBody == "" {
+		writeExecutable(t, filepath.Join(bin, "crontab"), "#!/bin/sh\necho 'no crontab for user' >&2\nexit 1\n")
+	} else {
+		writeExecutable(t, filepath.Join(bin, "crontab"), "#!/bin/sh\ncat <<'CRONTAB_EOF'\n"+crontabBody+"CRONTAB_EOF\n")
+	}
+
+	// Records to a file rather than to a stream. The entrypoint sends this
+	// command's output to /dev/null deliberately — a scheduler that complains
+	// must not appear in the application's log — so stdout and stderr are both
+	// unavailable to the test, and the first version of this stub silently
+	// reported nothing.
+	marker := filepath.Join(dir, "service.calls")
+	writeExecutable(t, filepath.Join(bin, "service"), "#!/bin/sh\necho \"service $*\" >> "+marker+"\n")
+
+	cmd := exec.Command("sh", scriptPath, "sh", "-c", "echo COMMAND RAN")
+	cmd.Env = append(os.Environ(), "PATH="+bin+":"+os.Getenv("PATH"))
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("the entrypoint failed: %v\n%s", err, out)
+	}
+
+	calls, _ := os.ReadFile(marker)
+
+	return string(out) + string(calls)
+}

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/ctx/php.Dockerfile
@@ -199,4 +199,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/ctx/php.Dockerfile
@@ -199,4 +199,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/ctx/php.Dockerfile
@@ -197,4 +197,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/ctx/php.Dockerfile
@@ -210,4 +210,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php/ctx/php.Dockerfile
@@ -199,4 +199,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/ctx/php.Dockerfile
@@ -199,4 +199,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/ctx/php.Dockerfile
@@ -199,4 +199,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/ctx/php.Dockerfile
@@ -199,4 +199,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/ctx/php.Dockerfile
@@ -195,4 +195,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-shopify/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-shopify/ctx/php.Dockerfile
@@ -206,5 +206,50 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]
 

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/ctx/php.Dockerfile
@@ -197,6 +197,51 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]
 
 # Shopware init-chown entrypoint: fixes root-owned runtime dirs on container

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-sylius/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-sylius/ctx/php.Dockerfile
@@ -195,5 +195,50 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]
 

--- a/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/ctx/php.Dockerfile
@@ -198,4 +198,49 @@ RUN printf 'umask 0002\n' > /etc/madock-umask.sh \
     && touch /etc/bash.bashrc \
     && printf '\numask 0002\n' >> /etc/bash.bashrc \
     && chmod 644 /etc/madock-umask.sh /etc/profile.d/madock-umask.sh
+
+# Start cron when the container has jobs and nothing else would.
+#
+# Nothing in an application image starts cron: this one's CMD is php-fpm. The
+# daemon existed only because `start`, `rebuild` or `cron:enable` ran a command
+# inside a container that was already up — so anything that restarts the
+# container takes the daemon with it and **leaves the crontab**. The jobs are
+# still there, nothing reads them, nothing fails, and every HTTP check stays
+# green.
+#
+# madock already re-arms it after `service:restart`, which is where a deploy lost
+# it. That cannot cover the case this exists for: when the host reboots, Docker
+# brings the containers back by its restart policy and **madock is not running at
+# all**. Measured on 2026-08-30, on a production machine rebooted for a plan
+# change — containers up, applications answering, cron down in both projects that
+# had it, found only because `cron:status` was taught to ask the right question
+# three days earlier.
+#
+# The signal is the crontab rather than the config, deliberately. A config value
+# is baked in when the image is built, so enabling cron and rebooting without a
+# rebuild would bring back the same silence. Jobs in the crontab mean jobs that
+# are meant to run — `cron:disable` removes them, so a project told to stop has
+# none — and that is true at the moment the container starts, not at the moment
+# it was built.
+#
+# Failure to start cron never blocks the application: a container that refuses to
+# serve because its scheduler is unhappy is a worse outcome than the one being
+# fixed.
+RUN cat > /usr/local/bin/madock-entrypoint <<'MADOCK_EOF' && chmod +x /usr/local/bin/madock-entrypoint
+#!/bin/sh
+has_jobs() {
+    # A line that is neither blank nor a comment. Debian keeps the explanatory
+    # header in every crontab, so "the file is not empty" would start cron for a
+    # project that has no jobs at all.
+    crontab -u "$1" -l 2>/dev/null | grep -qE '^[^#[:space:]]'
+}
+
+if has_jobs www-data || has_jobs root; then
+    service cron start >/dev/null 2>&1 || true
+fi
+
+exec "$@"
+MADOCK_EOF
+
+ENTRYPOINT ["/usr/local/bin/madock-entrypoint"]
 CMD ["bash", "-c", "exec php-fpm8.4"]


### PR DESCRIPTION
Go supports a line until two newer ones exist, so **1.25 died on 2026-08-19** — the day 1.27 shipped, not the day 1.28 will. Both this module and madock-pro sat on it for eleven days.

The check meant to notice answered "clean": its calendar ended a release early, and an empty end-of-life date reads as supported. Fixed on that side separately; this is the half that lives here.

Verified against `endoflife.date/api/go.json`:

    1.27  released 2026-08-19  eol=false
    1.26  released 2026-02-10  eol=false
    1.25  released 2025-08-12  eol=2026-08-19
    1.24  released 2025-02-11  eol=2026-02-10

Nothing needs installing. `GOTOOLCHAIN=auto` fetches what the file requires and CI reads the same file through `go-version-file`, so release builds and test runs move together.

**No test accompanies this, deliberately.** Asserting that go.mod says 1.27 restates the file. The test worth having — that the build is not quietly older than the file claims — was written and then deleted: Go already refuses, both for an explicit older toolchain and for `GOTOOLCHAIN=local`, so it could never fail. The suite running green on 1.27 is the verification.