### PR TITLE
Print the compose version, because it decides behaviour and nothing shows it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Printed because it decides behaviour and is invisible everywhere else.
+      # `docker compose pull --policy` exists from compose v2.22.0, and madock
+      # asks for the version before using the flag rather than assuming it —
+      # an unknown flag is not a degradation, compose exits non-zero and
+      # `madock start` dies. So when a run shows the registry being asked about
+      # an image that was already loaded from this cache, the first question is
+      # which of the two happened: the flag was not passed, or it was and did
+      # not help. That question came up twice in two days with nothing in any
+      # log able to answer it.
+      #
+      # No test accompanies this. Asserting that a line appears in a log is a
+      # restatement of the line.
+      - name: Which compose this runner has
+        run: docker compose version
+
       - id: cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Twice in two days a run has shown the registry being asked about an image that had just been loaded from the cache: the log says `Loaded image: axllent/mailpit:v1.31.0` and then `mailcatcher Pulling`.

`docker compose pull --policy` exists from compose **v2.22.0**, and madock asks for the version before passing the flag rather than assuming it — an unknown flag is not a degradation, compose exits non-zero and `madock start` dies. So the observation has two possible causes and no log can tell them apart: the flag was not passed, or it was passed and did not help.

One line answers it permanently. A local reproduction was attempted first and failed for an unrelated reason: on the test VM the proxy stack has no mailcatcher at all, and why the template condition is false there is a separate unknown.

No test accompanies this — asserting that a line appears in a log restates the line.