### PR TITLE
Two helpers that six platforms each carried, and had each changed

### DIFF
--- a/src/controller/bigcommerce/setup/setup.go
+++ b/src/controller/bigcommerce/setup/setup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/faradey/madock/v4/src/controller/general/install"
 	"github.com/faradey/madock/v4/src/controller/general/rebuild"
@@ -179,7 +178,7 @@ func Execute(projectName string, projectConf map[string]string, continueSetup bo
 // dependency on git / composer / npm.
 func DownloadBigcommerce(projectName, presetCode string) {
 	target := paths.GetRunDirPath()
-	if !isDirEmpty(target) {
+	if !paths.IsDirEmpty(target) {
 		fmtc.WarningLn("Skipping download — project directory is not empty: " + target)
 		return
 	}
@@ -245,37 +244,13 @@ func runInContainer(projectConf map[string]string, projectName, serviceHint, use
 	}
 }
 
-func isDirEmpty(path string) bool {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return true
-	}
-	for _, e := range entries {
-		if e.Name() == ".madock" || e.Name() == "." || e.Name() == ".." {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
+// findPresetByName is the shared lookup with this platform's own table.
+//
+// The table stays here because it is data — which words this platform
+// accepts — while the matching is the same everywhere and used to be six
+// copies that had drifted into three behaviours.
 func findPresetByName(name string) *preset.Preset {
-	name = strings.ToLower(name)
 	presets := preset.GetBigcommercePresets()
-
-	for _, p := range presets {
-		if strings.ToLower(p.Name) == name ||
-			strings.ToLower(p.Versions.PlatformVersion) == name {
-			return &p
-		}
-	}
-	for _, p := range presets {
-		lowerName := strings.ToLower(p.Name)
-		lowerVer := strings.ToLower(p.Versions.PlatformVersion)
-		if strings.Contains(lowerName, name) || strings.Contains(lowerVer, name) {
-			return &p
-		}
-	}
 	aliases := map[string]string{
 		"next":       "catalyst",
 		"storefront": "catalyst",
@@ -285,12 +260,6 @@ func findPresetByName(name string) *preset.Preset {
 		"app":        "app-node",
 		"node":       "app-node",
 	}
-	if alias, ok := aliases[name]; ok {
-		for _, p := range presets {
-			if p.Versions.PlatformVersion == alias {
-				return &p
-			}
-		}
-	}
-	return nil
+
+	return preset.Find(presets, aliases, name)
 }

--- a/src/controller/medusa/setup/setup.go
+++ b/src/controller/medusa/setup/setup.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/faradey/madock/v4/src/controller/general/install"
 	"github.com/faradey/madock/v4/src/controller/general/rebuild"
@@ -170,7 +168,7 @@ func Execute(projectName string, projectConf map[string]string, continueSetup bo
 // Runs inside the nodejs container so the host has no git dependency.
 func DownloadMedusa(projectName string) {
 	target := paths.GetRunDirPath()
-	if !isDirEmpty(target) {
+	if !paths.IsDirEmpty(target) {
 		fmtc.WarningLn("Skipping download — project directory is not empty: " + target)
 		return
 	}
@@ -202,7 +200,7 @@ func DownloadMedusa(projectName string) {
 	// and by docker as root before that. Skipping on existence alone meant the
 	// storefront was never cloned on a clean project, which shows up much later
 	// as a site that has a backend and no shop.
-	if !isDirEmpty(storefrontTarget) {
+	if !paths.IsDirEmpty(storefrontTarget) {
 		fmtc.WarningLn("Skipping storefront download — " + storefrontTarget + " already has content.")
 		return
 	}
@@ -244,43 +242,15 @@ func runMedusaInContainer(projectConf map[string]string, projectName, serviceHin
 // Empty directories are skipped rather than the one name, because that is the
 // property that matters: an empty directory is not a project, whoever created
 // it.
-func isDirEmpty(path string) bool {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return true
-	}
-	for _, e := range entries {
-		if e.Name() == ".madock" || e.Name() == "." || e.Name() == ".." {
-			continue
-		}
-		if e.IsDir() && isDirEmpty(filepath.Join(path, e.Name())) {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
 // findPresetByName resolves --preset value to a Medusa preset.
 // Accepts exact names, fragments, and aliases like "latest", "stable", "legacy", "v2", "v1".
+// findPresetByName is the shared lookup with this platform's own table.
+//
+// The table stays here because it is data — which words this platform
+// accepts — while the matching is the same everywhere and used to be six
+// copies that had drifted into three behaviours.
 func findPresetByName(name string) *preset.Preset {
-	name = strings.ToLower(name)
 	presets := preset.GetMedusaPresets()
-
-	for _, p := range presets {
-		if strings.ToLower(p.Name) == name {
-			return &p
-		}
-	}
-
-	for _, p := range presets {
-		lowerName := strings.ToLower(p.Name)
-		if strings.Contains(lowerName, name) ||
-			strings.Contains(p.Versions.PlatformVersion, name) {
-			return &p
-		}
-	}
-
 	aliases := map[string]string{
 		"latest": "2.x",
 		"stable": "2.0",
@@ -290,12 +260,6 @@ func findPresetByName(name string) *preset.Preset {
 		"2":      "2.x",
 		"1":      "1.x",
 	}
-	if alias, ok := aliases[name]; ok {
-		for _, p := range presets {
-			if strings.Contains(p.Name, alias) {
-				return &p
-			}
-		}
-	}
-	return nil
+
+	return preset.Find(presets, aliases, name)
 }

--- a/src/controller/saleor/setup/setup.go
+++ b/src/controller/saleor/setup/setup.go
@@ -149,7 +149,7 @@ func Execute(projectName string, projectConf map[string]string, continueSetup bo
 // when the version is empty or doesn't look like a Saleor release tag.
 func DownloadSaleor(projectName, platformVersion string) {
 	target := paths.GetRunDirPath()
-	if !isDirEmpty(target) {
+	if !paths.IsDirEmpty(target) {
 		fmtc.WarningLn("Skipping download — project directory is not empty: " + target)
 		return
 	}
@@ -200,47 +200,18 @@ func branchFromVersion(v string) string {
 
 // isDirEmpty returns true when path doesn't exist or holds no entries
 // besides dotfiles madock itself may have created (.madock/).
-func isDirEmpty(path string) bool {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return true
-	}
-	for _, e := range entries {
-		if e.Name() == ".madock" || e.Name() == "." || e.Name() == ".." {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
+// findPresetByName is the shared lookup with this platform's own table.
+//
+// The table stays here because it is data — which words this platform
+// accepts — while the matching is the same everywhere and used to be six
+// copies that had drifted into three behaviours.
 func findPresetByName(name string) *preset.Preset {
-	name = strings.ToLower(name)
 	presets := preset.GetSaleorPresets()
-
-	for _, p := range presets {
-		if strings.ToLower(p.Name) == name {
-			return &p
-		}
-	}
-	for _, p := range presets {
-		lowerName := strings.ToLower(p.Name)
-		if strings.Contains(lowerName, name) ||
-			strings.Contains(p.Versions.PlatformVersion, name) {
-			return &p
-		}
-	}
 	aliases := map[string]string{
 		"latest": "3.23",
 		"stable": "3.20",
 		"3":      "3.23",
 	}
-	if alias, ok := aliases[name]; ok {
-		for _, p := range presets {
-			if strings.Contains(p.Name, alias) {
-				return &p
-			}
-		}
-	}
-	return nil
+
+	return preset.Find(presets, aliases, name)
 }

--- a/src/controller/shopify/setup/setup.go
+++ b/src/controller/shopify/setup/setup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/faradey/madock/v4/src/controller/general/install"
 	"github.com/faradey/madock/v4/src/controller/general/rebuild"
@@ -205,7 +204,7 @@ func Execute(projectName string, projectConf map[string]string, continueSetup bo
 // No host-side dependency on node / composer / git.
 func DownloadShopify(projectName, presetCode string) {
 	target := paths.GetRunDirPath()
-	if !isDirEmpty(target) {
+	if !paths.IsDirEmpty(target) {
 		fmtc.WarningLn("Skipping download — project directory is not empty: " + target)
 		return
 	}
@@ -271,37 +270,13 @@ func runShopifyInContainer(projectConf map[string]string, projectName, serviceHi
 	}
 }
 
-func isDirEmpty(path string) bool {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return true
-	}
-	for _, e := range entries {
-		if e.Name() == ".madock" || e.Name() == "." || e.Name() == ".." {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
+// findPresetByName is the shared lookup with this platform's own table.
+//
+// The table stays here because it is data — which words this platform
+// accepts — while the matching is the same everywhere and used to be six
+// copies that had drifted into three behaviours.
 func findPresetByName(name string) *preset.Preset {
-	name = strings.ToLower(name)
 	presets := preset.GetShopifyPresets()
-
-	for _, p := range presets {
-		if strings.ToLower(p.Name) == name ||
-			strings.ToLower(p.Versions.PlatformVersion) == name {
-			return &p
-		}
-	}
-	for _, p := range presets {
-		lowerName := strings.ToLower(p.Name)
-		lowerVer := strings.ToLower(p.Versions.PlatformVersion)
-		if strings.Contains(lowerName, name) || strings.Contains(lowerVer, name) {
-			return &p
-		}
-	}
 	aliases := map[string]string{
 		"node":       "hydrogen",
 		"storefront": "hydrogen",
@@ -311,12 +286,6 @@ func findPresetByName(name string) *preset.Preset {
 		"api":        "api-php",
 		"laravel":    "laravel-shopify",
 	}
-	if alias, ok := aliases[name]; ok {
-		for _, p := range presets {
-			if p.Versions.PlatformVersion == alias {
-				return &p
-			}
-		}
-	}
-	return nil
+
+	return preset.Find(presets, aliases, name)
 }

--- a/src/controller/spree/setup/setup.go
+++ b/src/controller/spree/setup/setup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/faradey/madock/v4/src/controller/general/install"
 	"github.com/faradey/madock/v4/src/controller/general/rebuild"
@@ -147,7 +146,7 @@ func Execute(projectName string, projectConf map[string]string, continueSetup bo
 // storefront (nodejs) container when storefront is enabled.
 func DownloadSpree(projectName string) {
 	target := paths.GetRunDirPath()
-	if !isDirEmpty(target) {
+	if !paths.IsDirEmpty(target) {
 		fmtc.WarningLn("Skipping download — project directory is not empty: " + target)
 		return
 	}
@@ -204,48 +203,19 @@ func runSpreeInContainer(projectConf map[string]string, projectName, serviceHint
 
 // isDirEmpty returns true when path doesn't exist or holds no entries
 // besides dotfiles madock itself may have created (.madock/).
-func isDirEmpty(path string) bool {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return true
-	}
-	for _, e := range entries {
-		if e.Name() == ".madock" || e.Name() == "." || e.Name() == ".." {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
+// findPresetByName is the shared lookup with this platform's own table.
+//
+// The table stays here because it is data — which words this platform
+// accepts — while the matching is the same everywhere and used to be six
+// copies that had drifted into three behaviours.
 func findPresetByName(name string) *preset.Preset {
-	name = strings.ToLower(name)
 	presets := preset.GetSpreePresets()
-
-	for _, p := range presets {
-		if strings.ToLower(p.Name) == name {
-			return &p
-		}
-	}
-	for _, p := range presets {
-		lowerName := strings.ToLower(p.Name)
-		if strings.Contains(lowerName, name) ||
-			strings.Contains(p.Versions.PlatformVersion, name) {
-			return &p
-		}
-	}
 	aliases := map[string]string{
 		"latest": "5",
 		"stable": "4.10",
 		"5":      "5",
 		"4":      "4.10",
 	}
-	if alias, ok := aliases[name]; ok {
-		for _, p := range presets {
-			if strings.Contains(p.Name, alias) {
-				return &p
-			}
-		}
-	}
-	return nil
+
+	return preset.Find(presets, aliases, name)
 }

--- a/src/controller/sylius/setup/setup.go
+++ b/src/controller/sylius/setup/setup.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/faradey/madock/v4/src/controller/general/install"
 	"github.com/faradey/madock/v4/src/controller/general/rebuild"
@@ -168,7 +167,7 @@ func Execute(projectName string, projectConf map[string]string, continueSetup bo
 // frontend pipeline.
 func DownloadSylius(projectName string) {
 	target := paths.GetRunDirPath()
-	if !isDirEmpty(target) {
+	if !paths.IsDirEmpty(target) {
 		fmtc.WarningLn("Skipping download — project directory is not empty: " + target)
 		return
 	}
@@ -199,48 +198,19 @@ func DownloadSylius(projectName string) {
 
 // isDirEmpty returns true when path doesn't exist or holds no entries
 // besides dotfiles madock itself may have created (.madock/).
-func isDirEmpty(path string) bool {
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return true
-	}
-	for _, e := range entries {
-		if e.Name() == ".madock" || e.Name() == "." || e.Name() == ".." {
-			continue
-		}
-		return false
-	}
-	return true
-}
-
+// findPresetByName is the shared lookup with this platform's own table.
+//
+// The table stays here because it is data — which words this platform
+// accepts — while the matching is the same everywhere and used to be six
+// copies that had drifted into three behaviours.
 func findPresetByName(name string) *preset.Preset {
-	name = strings.ToLower(name)
 	presets := preset.GetSyliusPresets()
-
-	for _, p := range presets {
-		if strings.ToLower(p.Name) == name {
-			return &p
-		}
-	}
-	for _, p := range presets {
-		lowerName := strings.ToLower(p.Name)
-		if strings.Contains(lowerName, name) ||
-			strings.Contains(p.Versions.PlatformVersion, name) {
-			return &p
-		}
-	}
 	aliases := map[string]string{
 		"latest": "2",
 		"stable": "1.13",
 		"2":      "2",
 		"1":      "1.13",
 	}
-	if alias, ok := aliases[name]; ok {
-		for _, p := range presets {
-			if strings.Contains(p.Name, alias) {
-				return &p
-			}
-		}
-	}
-	return nil
+
+	return preset.Find(presets, aliases, name)
 }

--- a/src/helper/paths/dir.go
+++ b/src/helper/paths/dir.go
@@ -1,0 +1,48 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// IsDirEmpty reports whether a directory holds anything worth refusing to
+// install over.
+//
+// It guards `setup` against writing a platform into a directory somebody is
+// already using, so what counts as "empty" is a judgement rather than a fact.
+// Two things are deliberately not counted:
+//
+//   - `.madock`, because it is ours. A directory holding only madock's own
+//     configuration is one where setup was started and not finished, and
+//     refusing there would leave the person unable to continue without deleting
+//     a file they did not create.
+//   - directories that are themselves empty, all the way down. An empty tree
+//     holds nothing to lose, and it is what a half-finished clone or an
+//     interrupted extraction leaves behind.
+//
+// The second rule existed in exactly one of the six copies this replaces —
+// medusa's — and nowhere else. Nothing announced the difference: five platforms
+// simply refused to set up in a directory the sixth accepted.
+//
+// An unreadable directory answers "empty", which is the permissive direction and
+// is what every copy already did. Refusing on a read error would block setup on
+// a permissions problem the message would not explain.
+func IsDirEmpty(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return true
+	}
+
+	for _, entry := range entries {
+		if entry.Name() == ".madock" || entry.Name() == "." || entry.Name() == ".." {
+			continue
+		}
+		if entry.IsDir() && IsDirEmpty(filepath.Join(path, entry.Name())) {
+			continue
+		}
+
+		return false
+	}
+
+	return true
+}

--- a/src/helper/paths/dir_test.go
+++ b/src/helper/paths/dir_test.go
@@ -1,0 +1,114 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The middle case is the one that differed between platforms, and the reason
+// this function moved: a directory holding only empty directories was "empty"
+// on Medusa and "occupied" on the other five, so `setup` refused on five
+// platforms and proceeded on the sixth, over the same directory.
+func TestIsDirEmpty(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func(t *testing.T, dir string)
+		want  bool
+		why   string
+	}{
+		{
+			name:  "nothing in it",
+			build: func(*testing.T, string) {},
+			want:  true,
+			why:   "the ordinary case",
+		},
+		{
+			name: "only madock's own directory",
+			build: func(t *testing.T, dir string) {
+				mkdir(t, filepath.Join(dir, ".madock"))
+				write(t, filepath.Join(dir, ".madock", "config.xml"), "<config/>")
+			},
+			want: true,
+			why:  "setup started and did not finish; refusing here strands the person",
+		},
+		{
+			name: "empty directories, several deep",
+			build: func(t *testing.T, dir string) {
+				mkdir(t, filepath.Join(dir, "src", "app", "components"))
+				mkdir(t, filepath.Join(dir, "public"))
+			},
+			want: true,
+			why:  "an empty tree holds nothing to lose — true on Medusa and false everywhere else",
+		},
+		{
+			name: "one file, however deep",
+			build: func(t *testing.T, dir string) {
+				mkdir(t, filepath.Join(dir, "src", "app"))
+				write(t, filepath.Join(dir, "src", "app", "page.tsx"), "export default null")
+			},
+			want: false,
+			why:  "this is the whole point: somebody's work must not be installed over",
+		},
+		{
+			name: "a file at the top",
+			build: func(t *testing.T, dir string) {
+				write(t, filepath.Join(dir, "README.md"), "mine")
+			},
+			want: false,
+			why:  "the obvious case, and the only one all six copies agreed on",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			c.build(t, dir)
+
+			if got := IsDirEmpty(dir); got != c.want {
+				t.Errorf("IsDirEmpty = %v, want %v — %s", got, c.want, c.why)
+			}
+		})
+	}
+}
+
+// A directory that cannot be read answers "empty".
+//
+// The permissive direction, and what every copy already did: refusing would stop
+// setup on a permissions problem, with a message about the directory not being
+// empty that names nothing the person can act on.
+func TestIsDirEmptyAnswersEmptyWhenItCannotLook(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads unreadable directories, so this cannot be staged")
+	}
+
+	dir := t.TempDir()
+	locked := filepath.Join(dir, "locked")
+	mkdir(t, locked)
+	write(t, filepath.Join(locked, "file"), "content")
+
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if !IsDirEmpty(locked) {
+		t.Error("an unreadable directory was reported as occupied")
+	}
+}
+
+func mkdir(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/src/helper/preset/find.go
+++ b/src/helper/preset/find.go
@@ -1,0 +1,72 @@
+package preset
+
+import "strings"
+
+// Find resolves what a person typed after `--preset` to one of the presets a
+// platform offers.
+//
+// It exists because six platforms each carried their own copy of this, and the
+// copies had drifted into three different behaviours — silently, because none of
+// them fails, they simply fail to match:
+//
+//   - saleor, sylius and spree matched the preset's **name** only, so
+//     `--preset=3.23` found nothing while `--preset=catalyst` did;
+//   - bigcommerce and shopify also matched the **version**, and lowercased it
+//     before comparing;
+//   - the alias tables pointed at different things. saleor's `"latest": "3.23"`
+//     is a version looked up by substring against the preset's *name*, while
+//     bigcommerce's `"next": "catalyst"` is a version compared to
+//     `Versions.PlatformVersion` exactly.
+//
+// So this is the union of all three rather than a choice between them: every
+// mapping that resolved before still resolves, and the two behaviours that were
+// missing from four platforms are now everywhere. Being more permissive is the
+// safe direction — the failure this replaces is "the preset you named does not
+// exist", and nothing here can select a preset the platform did not offer.
+//
+// The order is deliberate and is the one all six copies already had: an exact
+// match beats a substring, and both beat an alias. Without it `--preset=2` on a
+// platform offering `2` and `2.5` would depend on map iteration order.
+func Find(presets []Preset, aliases map[string]string, name string) *Preset {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return nil
+	}
+
+	for i := range presets {
+		if strings.ToLower(presets[i].Name) == name ||
+			strings.ToLower(presets[i].Versions.PlatformVersion) == name {
+			return &presets[i]
+		}
+	}
+
+	for i := range presets {
+		lowerName := strings.ToLower(presets[i].Name)
+		lowerVersion := strings.ToLower(presets[i].Versions.PlatformVersion)
+		if strings.Contains(lowerName, name) || strings.Contains(lowerVersion, name) {
+			return &presets[i]
+		}
+	}
+
+	alias, ok := aliases[name]
+	if !ok {
+		return nil
+	}
+
+	// An alias names either a version or a name, because the two conventions
+	// both exist in the tables this replaces. Version first: it is the exact
+	// comparison, and the substring on names is what a wrong guess would land on.
+	lowerAlias := strings.ToLower(alias)
+	for i := range presets {
+		if strings.ToLower(presets[i].Versions.PlatformVersion) == lowerAlias {
+			return &presets[i]
+		}
+	}
+	for i := range presets {
+		if strings.Contains(strings.ToLower(presets[i].Name), lowerAlias) {
+			return &presets[i]
+		}
+	}
+
+	return nil
+}

--- a/src/helper/preset/find_test.go
+++ b/src/helper/preset/find_test.go
@@ -1,0 +1,103 @@
+package preset
+
+import (
+	"testing"
+
+	"github.com/faradey/madock/v4/src/model/versions"
+)
+
+// The cases here are the differences between the six copies this replaces, not
+// invented ones. Each of the first three was a real behaviour that existed on
+// two platforms and not on the other four, and none of them failed loudly: an
+// unmatched preset is reported as "not found", so a platform simply refused a
+// name its neighbour accepted.
+func TestFindResolvesEveryConventionTheCopiesHad(t *testing.T) {
+	presets := []Preset{
+		{Name: "Catalyst storefront", Versions: versions.ToolsVersions{PlatformVersion: "catalyst"}},
+		{Name: "Stencil theme", Versions: versions.ToolsVersions{PlatformVersion: "stencil"}},
+		{Name: "Saleor 3.23", Versions: versions.ToolsVersions{PlatformVersion: "3.23"}},
+		{Name: "Saleor 3.20", Versions: versions.ToolsVersions{PlatformVersion: "3.20"}},
+	}
+	aliases := map[string]string{
+		"latest": "3.23",     // a version, the saleor convention
+		"next":   "catalyst", // a version, the bigcommerce convention
+		"theme":  "Stencil",  // a name, matched by substring
+	}
+
+	cases := []struct {
+		name string
+		want string
+		why  string
+	}{
+		{"catalyst", "Catalyst storefront", "exact match on the version — four platforms could not do this"},
+		{"Catalyst storefront", "Catalyst storefront", "exact match on the name, which every copy had"},
+		{"CATALYST", "Catalyst storefront", "case is not the user's problem"},
+		{"3.23", "Saleor 3.23", "a version typed directly, which is the commonest way to ask"},
+		{"stenc", "Stencil theme", "substring on the name"},
+		{"3.2", "Saleor 3.23", "substring on the version, and the first offered wins"},
+		{"latest", "Saleor 3.23", "alias pointing at a version"},
+		{"next", "Catalyst storefront", "alias pointing at a version, the other table's convention"},
+		{"theme", "Stencil theme", "alias pointing at a name, resolved by substring"},
+	}
+
+	for _, c := range cases {
+		got := Find(presets, aliases, c.name)
+		if got == nil {
+			t.Errorf("Find(%q) found nothing — %s", c.name, c.why)
+			continue
+		}
+		if got.Name != c.want {
+			t.Errorf("Find(%q) = %q, want %q — %s", c.name, got.Name, c.want, c.why)
+		}
+	}
+}
+
+// What must not resolve. A preset selected by accident is worse than one not
+// found: the run continues, and it continues with the wrong versions.
+func TestFindRefusesWhatItCannotResolve(t *testing.T) {
+	presets := []Preset{
+		{Name: "Catalyst storefront", Versions: versions.ToolsVersions{PlatformVersion: "catalyst"}},
+	}
+	aliases := map[string]string{"next": "nothing-offers-this"}
+
+	for _, name := range []string{"", "   ", "hydrogen", "next"} {
+		if got := Find(presets, aliases, name); got != nil {
+			t.Errorf("Find(%q) = %q, want nothing", name, got.Name)
+		}
+	}
+}
+
+// Exact beats substring, and both beat an alias.
+//
+// Not a stylistic preference: with `2` and `2.5` both offered, a substring rule
+// applied first would answer whichever the slice happened to hold first, and the
+// person asking for `2` would get 2.5 on a good day. All six copies had this
+// order already; it is written down here so a rewrite cannot lose it quietly.
+func TestFindPrefersTheExactAnswer(t *testing.T) {
+	presets := []Preset{
+		{Name: "Two point five", Versions: versions.ToolsVersions{PlatformVersion: "2.5"}},
+		{Name: "Two", Versions: versions.ToolsVersions{PlatformVersion: "2"}},
+	}
+	aliases := map[string]string{"2": "2.5"}
+
+	got := Find(presets, aliases, "2")
+	if got == nil || got.Name != "Two" {
+		t.Errorf("Find(2) = %v, want the preset whose version is exactly 2", got)
+	}
+}
+
+// The returned pointer addresses the caller's slice, not a loop copy.
+//
+// Every copy this replaces wrote `for _, p := range presets { return &p }`,
+// which was a bug in Go before 1.22 and is merely fragile now. A caller that
+// changes what it is handed should see it in what it got back.
+func TestFindReturnsThePresetItWasGiven(t *testing.T) {
+	presets := []Preset{
+		{Name: "Catalyst", Versions: versions.ToolsVersions{PlatformVersion: "catalyst"}},
+	}
+
+	got := Find(presets, nil, "catalyst")
+	if got != &presets[0] {
+		t.Error("Find returned a copy rather than the element of the slice it was given")
+	}
+}


### PR DESCRIPTION
First finding of the code audit, and it is not about the line count.

`isDirEmpty` and `findPresetByName` existed **six times over**, once per platform that offers presets, and the copies had drifted. Nothing said so: neither function fails, they only fail to match, so a platform quietly refused what its neighbour accepted.

Found by fingerprinting every copy rather than by reading two:

| | |
|---|---|
| `isDirEmpty` | five identical, **medusa's alone** skips empty subdirectories |
| `findPresetByName` | six texts, **two behaviours** once the alias tables are set aside as data |
| alias tables | **two conventions** — a version matched against the name by substring, or against `Versions.PlatformVersion` exactly |

Behavioural consequences, both silent:

- `--preset=3.23` found nothing on saleor, sylius, spree and medusa, and worked on bigcommerce and shopify.
- A directory holding only empty directories was "empty" on Medusa and "occupied" on the other five, so `setup` refused on five platforms and proceeded on the sixth over the same directory.

The shared lookup is the **union** of all three rather than a choice: every mapping that resolved before still resolves, and the two behaviours four platforms lacked are now everywhere. More permissive is the safe direction — the failure being replaced is "the preset you named does not exist", and nothing can select a preset the platform did not offer.

The alias tables stay with their platforms: they are the words each platform accepts, which is data. The matching is not.

**236 lines removed, 49 added**, plus two shared files with tests. The tests are the differences themselves, including the ordering all six copies already had — exact beats substring beats alias, without which `--preset=2` on a platform offering `2` and `2.5` answers by slice order.