### PR TITLE
A node preset may default, but it may not overrule

### DIFF
--- a/src/helper/configs/projects/bigcommerce.go
+++ b/src/helper/configs/projects/bigcommerce.go
@@ -14,10 +14,10 @@ func init() {
 // Bigcommerce presets map to different stack flavours:
 //   - catalyst : Node-only (Next.js storefront)
 //   - stencil  : Node-only (Stencil CLI for theme dev — proxies the
-//                live store, no DB needed locally)
+//     live store, no DB needed locally)
 //   - api-php  : PHP + MariaDB + Redis (raw bigcommerce/api SDK)
 //   - app-node : Node-only (Express + Next.js embedded app, OAuth
-//                session storage via SQLite/JSON file by default)
+//     session storage via SQLite/JSON file by default)
 //
 // The preset is stored in `bigcommerce/preset` so it survives config
 // rewrites and so install + setup controllers can branch on it.
@@ -94,8 +94,22 @@ func Bigcommerce(config *configs2.ConfigLines, defVersions versions.ToolsVersion
 	} else {
 		config.Set("php/enabled", "false")
 		config.Set("php/xdebug/enabled", "false")
-		config.Set("redis/enabled", "false")
-		config.Set("db/type", "")
+
+		// A node preset needs neither by default — Catalyst and Stencil are a
+		// storefront and a theme, and they talk to BigCommerce rather than to a
+		// database of their own. But defaulting and overruling are different
+		// things, and this branch used to do the second: whatever the project
+		// had asked for was replaced, in silence, while the php branch three
+		// lines above reads the same keys and says in a comment that it
+		// respects them.
+		//
+		// It stopped being theoretical when our own BigCommerce line was
+		// decided: Core is Node with Prisma and BullMQ, so it needs both a
+		// database and Redis, and this branch forbade exactly what that stack
+		// requires. The workaround was `platform custom` with the whole stack
+		// spelled out by hand, carrying a comment about this defect.
+		config.Set("redis/enabled", defaultTo(projectConf["redis/enabled"], "false"))
+		config.Set("db/type", projectConf["db/type"])
 	}
 
 	// Node stack.
@@ -129,4 +143,16 @@ func Bigcommerce(config *configs2.ConfigLines, defVersions versions.ToolsVersion
 	config.Set("grafana/auth/enabled", configs2.GetOption("grafana/auth/enabled", generalConf, projectConf))
 	config.Set("grafana/auth/user", configs2.GetOption("grafana/auth/user", generalConf, projectConf))
 	config.Set("grafana/auth/password", configs2.GetOption("grafana/auth/password", generalConf, projectConf))
+}
+
+// defaultTo is the project's answer when it gave one, and the fallback when it
+// did not. An empty string is "not asked for", which is what an absent key
+// looks like after the config is flattened — it is not the same as a project
+// asking for nothing.
+func defaultTo(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+
+	return value
 }

--- a/src/helper/configs/projects/projects_test.go
+++ b/src/helper/configs/projects/projects_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	configs2 "github.com/faradey/madock/v4/src/helper/configs"
-	magento2 "github.com/faradey/madock/v4/src/model/versions/magento2"
 	"github.com/faradey/madock/v4/src/model/versions"
+	magento2 "github.com/faradey/madock/v4/src/model/versions/magento2"
 )
 
 func TestMagento2ConfigSets(t *testing.T) {
@@ -25,18 +25,18 @@ func TestMagento2ConfigSets(t *testing.T) {
 		RabbitMQ:        "3.13",
 	}
 	generalConf := map[string]string{
-		"timezone":       "UTC",
-		"php/xdebug/ide_key": "PHPSTORM",
-		"php/xdebug/enabled": "false",
+		"timezone":            "UTC",
+		"php/xdebug/ide_key":  "PHPSTORM",
+		"php/xdebug/enabled":  "false",
 		"php/ioncube/enabled": "false",
-		"db/root_password":   "password",
-		"db/user":            "magento",
-		"db/password":        "magento",
-		"db/database":        "magento",
-		"redis/enabled":      "false",
-		"nodejs/enabled":     "false",
-		"nodejs/version":     "18.15.0",
-		"rabbitmq/enabled":   "false",
+		"db/root_password":    "password",
+		"db/user":             "magento",
+		"db/password":         "magento",
+		"db/database":         "magento",
+		"redis/enabled":       "false",
+		"nodejs/enabled":      "false",
+		"nodejs/version":      "18.15.0",
+		"rabbitmq/enabled":    "false",
 	}
 	projectConf := map[string]string{}
 
@@ -69,7 +69,7 @@ func TestMagento2WithElasticsearch(t *testing.T) {
 		RabbitMQ:        "3.9",
 	}
 	generalConf := map[string]string{
-		"timezone":        "UTC",
+		"timezone":            "UTC",
 		"php/xdebug/ide_key":  "PHPSTORM",
 		"php/xdebug/enabled":  "false",
 		"php/ioncube/enabled": "false",
@@ -107,7 +107,7 @@ func TestMagento2WithCustomDbRepo(t *testing.T) {
 		RabbitMQ:        "3.13",
 	}
 	generalConf := map[string]string{
-		"timezone":        "UTC",
+		"timezone":            "UTC",
 		"php/xdebug/ide_key":  "PHPSTORM",
 		"php/xdebug/enabled":  "false",
 		"php/ioncube/enabled": "false",
@@ -138,7 +138,7 @@ func TestShopifyConfigSets(t *testing.T) {
 		NodeJs:   "18.15.0",
 	}
 	generalConf := map[string]string{
-		"timezone":        "UTC",
+		"timezone":            "UTC",
 		"php/xdebug/ide_key":  "PHPSTORM",
 		"php/xdebug/enabled":  "false",
 		"php/ioncube/enabled": "false",
@@ -161,7 +161,7 @@ func TestCustomConfigSets(t *testing.T) {
 		Db:       "10.6",
 	}
 	generalConf := map[string]string{
-		"timezone":        "UTC",
+		"timezone":            "UTC",
 		"php/xdebug/ide_key":  "PHPSTORM",
 		"php/xdebug/enabled":  "false",
 		"php/ioncube/enabled": "false",
@@ -190,7 +190,7 @@ func TestShopwareConfigSets(t *testing.T) {
 		Db:       "10.6",
 	}
 	generalConf := map[string]string{
-		"timezone":        "UTC",
+		"timezone":            "UTC",
 		"php/xdebug/ide_key":  "PHPSTORM",
 		"php/xdebug/enabled":  "false",
 		"php/ioncube/enabled": "false",
@@ -219,7 +219,7 @@ func TestPrestaShopConfigSets(t *testing.T) {
 		Db:       "10.6",
 	}
 	generalConf := map[string]string{
-		"timezone":        "UTC",
+		"timezone":            "UTC",
 		"php/xdebug/ide_key":  "PHPSTORM",
 		"php/xdebug/enabled":  "false",
 		"php/ioncube/enabled": "false",
@@ -262,16 +262,16 @@ func TestMagento2_248_ConfigValues(t *testing.T) {
 	Magento2(config, defVersions, generalConf, projectConf)
 
 	expected := map[string]string{
-		"php/version":                "8.4",
-		"php/enabled":                "true",
-		"php/composer/version":       "2",
-		"db/version":                 "11.4",
-		"search/opensearch/enabled":  "true",
-		"search/opensearch/version":  "2.19.0",
+		"php/version":                  "8.4",
+		"php/enabled":                  "true",
+		"php/composer/version":         "2",
+		"db/version":                   "11.4",
+		"search/opensearch/enabled":    "true",
+		"search/opensearch/version":    "2.19.0",
 		"search/elasticsearch/enabled": "false",
-		"redis/version":              "8.0",
-		"rabbitmq/version":           "4.1",
-		"public_dir":                 "pub",
+		"redis/version":                "8.0",
+		"rabbitmq/version":             "4.1",
+		"public_dir":                   "pub",
 	}
 
 	for key, want := range expected {
@@ -323,13 +323,13 @@ func TestMagento2_248_ConfigSaveRoundTrip(t *testing.T) {
 	// Verify key values survive the round-trip (stored under scopes/default/)
 	checks := map[string]string{
 		"scopes/default/php/version":               "8.4",
-		"scopes/default/php/enabled":                "true",
-		"scopes/default/db/version":                 "11.4",
-		"scopes/default/search/opensearch/enabled":  "true",
-		"scopes/default/search/opensearch/version":  "2.19.0",
-		"scopes/default/redis/version":              "8.0",
-		"scopes/default/rabbitmq/version":           "4.1",
-		"scopes/default/public_dir":                 "pub",
+		"scopes/default/php/enabled":               "true",
+		"scopes/default/db/version":                "11.4",
+		"scopes/default/search/opensearch/enabled": "true",
+		"scopes/default/search/opensearch/version": "2.19.0",
+		"scopes/default/redis/version":             "8.0",
+		"scopes/default/rabbitmq/version":          "4.1",
+		"scopes/default/public_dir":                "pub",
 	}
 
 	for key, want := range checks {
@@ -364,4 +364,65 @@ func TestDbVersionFormatParsing(t *testing.T) {
 			t.Logf("Input %q: hasRepo=%v", tt.input, tt.expectRepo)
 		})
 	}
+}
+
+// A node preset defaults to no database and no Redis, and must not overrule a
+// project that asked for them.
+//
+// The two are different, and this branch used to do the second: whatever the
+// project had set was replaced in silence, while the php branch of the same
+// function reads the same keys and carries a comment saying it respects them.
+//
+// Found when our own BigCommerce line was decided — Core is Node with Prisma
+// and BullMQ, so it needs both, and the preset forbade exactly that. The
+// workaround was `platform custom` with the stack spelled out by hand.
+func TestBigcommerceNodePresetDoesNotOverruleTheProject(t *testing.T) {
+	defVersions := versions.ToolsVersions{
+		Platform:        "bigcommerce",
+		PlatformVersion: "catalyst",
+		NodeJs:          "22.20.0",
+	}
+	generalConf := map[string]string{"timezone": "UTC"}
+
+	t.Run("silent by default", func(t *testing.T) {
+		config := new(configs2.ConfigLines)
+
+		Bigcommerce(config, defVersions, generalConf, map[string]string{})
+
+		if got := config.Lines["redis/enabled"]; got != "false" {
+			t.Errorf("redis/enabled = %q, want false — a storefront needs none", got)
+		}
+		if got := config.Lines["db/type"]; got != "" {
+			t.Errorf("db/type = %q, want empty", got)
+		}
+	})
+
+	t.Run("what the project asked for survives", func(t *testing.T) {
+		config := new(configs2.ConfigLines)
+
+		Bigcommerce(config, defVersions, generalConf, map[string]string{
+			"redis/enabled": "true",
+			"db/type":       "mysql",
+		})
+
+		if got := config.Lines["redis/enabled"]; got != "true" {
+			t.Errorf("redis/enabled = %q, want true — the project asked for it", got)
+		}
+		if got := config.Lines["db/type"]; got != "mysql" {
+			t.Errorf("db/type = %q, want mysql — the project asked for it", got)
+		}
+	})
+
+	t.Run("an explicit no is still a no", func(t *testing.T) {
+		// The value equals the default, and that must not make it a special
+		// case: a project saying "false" and a project saying nothing are the
+		// same outcome for a reason, not by accident.
+		config := new(configs2.ConfigLines)
+
+		Bigcommerce(config, defVersions, generalConf, map[string]string{"redis/enabled": "false"})
+
+		if got := config.Lines["redis/enabled"]; got != "false" {
+			t.Errorf("redis/enabled = %q, want false", got)
+		}
+	})
 }


### PR DESCRIPTION
Three lines of the same `if/else` disagreed. The php branch reads `redis/enabled` from the project and says in a comment that it respects an explicit disable. The node branch replaced whatever the project had asked for, in silence, along with `db/type`.

Defaulting and overruling are different things. Catalyst and Stencil are a storefront and a theme and need neither, so `false` and `""` are the right defaults — but a project that wrote something there wrote it on purpose.

It stopped being theoretical when the BigCommerce line was decided: **Core is Node with Prisma and BullMQ**, so it needs both a database and Redis, and this branch forbade exactly what that stack requires. The workaround in that repository is `platform custom` with the stack spelled out by hand, carrying a comment about this defect.

Measured with the session that owns those repositories rather than assumed: all three schemas are `provider = "mysql"`, Redis is Core's alone via ioredis and BullMQ, and the two applications are consumers of Core's shared database. They asked for **no new preset** — their two shapes are not one preset's worth, since whichever has Next has no database and whichever has BullMQ has no Next.

The third test case is the one worth keeping: a project that explicitly says `false` and a project that says nothing produce the same result, and that has to be because the rule is the same, not because the code stopped looking.