### PR TITLE
Ask the proxy what it was doing when the handshake failed

### DIFF
--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -608,3 +608,31 @@ func requireFile(t *testing.T, path, what string) {
 		t.Errorf("%s: %v", what, err)
 	}
 }
+
+// describeProxy prints what the proxy was doing when a TLS handshake failed.
+//
+// The assertion in proxy_test and ssl_cache_test is the handshake, and a failed
+// handshake says one thing: nothing answered on 443. That is three different
+// situations — the proxy never started, it started and is not listening yet, or
+// it is up and refusing — and the message cannot tell them apart. Both tests
+// have failed that way on a runner, in different shards and on different
+// branches, and each time the only honest reading was "we do not know".
+//
+// So the failure asks. `status` says whether the container exists and is
+// running; `proxy:logs` is where nginx writes the reason it would not bind. It
+// runs after the test has already failed, so nothing here can turn a pass into
+// a failure — and it is deliberately not an assertion: what it prints is
+// evidence for a person, not a verdict.
+func describeProxy(t *testing.T, p *project) {
+	t.Helper()
+
+	for _, args := range [][]string{{"status"}, {"proxy:logs", "--tail=40"}} {
+		out, err := p.tryRun(2*time.Minute, args...)
+		label := strings.Join(args, " ")
+		if err != nil {
+			t.Logf("madock %s could not be asked: %v", label, err)
+			continue
+		}
+		t.Logf("madock %s:\n%s", label, strings.TrimSpace(out))
+	}
+}

--- a/test/e2e/proxy_lifecycle_test.go
+++ b/test/e2e/proxy_lifecycle_test.go
@@ -36,7 +36,7 @@ func TestProxyCommandsControlTheProxy(t *testing.T) {
 		"--hosts=e2eproxyctl.test",
 	)
 	p.run(20*time.Minute, "start")
-	requireCertificateFor(t, "e2eproxyctl.test")
+	requireCertificateFor(t, p, "e2eproxyctl.test")
 
 	// stop. Without this the rest of the test cannot fail: a proxy that was
 	// never taken down answers every later check whether or not the command
@@ -58,25 +58,25 @@ func TestProxyCommandsControlTheProxy(t *testing.T) {
 	// path from creating it: UpNginx decides between the two by asking compose
 	// whether the container is running, and a stopped container must not count.
 	p.run(5*time.Minute, "proxy:start")
-	requireCertificateFor(t, "e2eproxyctl.test")
+	requireCertificateFor(t, p, "e2eproxyctl.test")
 
 	// reload with the proxy up. It re-parses routing and certificates in place,
 	// so the project has to still be served afterwards — a reload that takes
 	// the site down is worse than one that does nothing.
 	p.run(3*time.Minute, "proxy:reload")
-	requireCertificateFor(t, "e2eproxyctl.test")
+	requireCertificateFor(t, p, "e2eproxyctl.test")
 
 	// restart is stop plus start in one command, and it is what the certificate
 	// test uses. Kept here for the sequence, not for the certificate.
 	p.run(5*time.Minute, "proxy:restart")
-	requireCertificateFor(t, "e2eproxyctl.test")
+	requireCertificateFor(t, p, "e2eproxyctl.test")
 
 	// rebuild throws the container away and builds it again. It is the heaviest
 	// of the four and the one most likely to come back without the routing it
 	// had: the configuration is regenerated from the project registry, not from
 	// whatever the old container was serving.
 	p.run(10*time.Minute, "proxy:rebuild")
-	requireCertificateFor(t, "e2eproxyctl.test")
+	requireCertificateFor(t, p, "e2eproxyctl.test")
 }
 
 // requireProxyUnreachable waits for port 443 to stop accepting connections.

--- a/test/e2e/proxy_neighbours_test.go
+++ b/test/e2e/proxy_neighbours_test.go
@@ -59,5 +59,5 @@ func TestRemovingAProjectTakesItOutOfTheProxy(t *testing.T) {
 	}
 
 	requireContains(t, afterRemove, "e2estays.test", "the neighbour's routing survived the removal")
-	requireCertificateFor(t, "e2estays.test")
+	requireCertificateFor(t, staying, "e2estays.test")
 }

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -40,16 +40,16 @@ func TestProxyRoutesEveryProjectOverHTTPS(t *testing.T) {
 	// regeneration is written from the project being started rather than from
 	// every project, the first one disappears from the proxy — which is exactly
 	// how it once behaved.
-	requireCertificateFor(t, "e2eproxya.test")
-	requireCertificateFor(t, "e2eproxyb.test")
+	requireCertificateFor(t, first, "e2eproxya.test")
+	requireCertificateFor(t, first, "e2eproxyb.test")
 
 	// proxy:restart is the operation that took HTTPS down before. It has no
 	// project argument, so nothing about it says which projects it is allowed
 	// to forget.
 	second.run(5*time.Minute, "proxy:restart")
 
-	requireCertificateFor(t, "e2eproxya.test")
-	requireCertificateFor(t, "e2eproxyb.test")
+	requireCertificateFor(t, first, "e2eproxya.test")
+	requireCertificateFor(t, first, "e2eproxyb.test")
 }
 
 // requireCertificateFor opens a TLS connection to the proxy asking for the given
@@ -59,7 +59,7 @@ func TestProxyRoutesEveryProjectOverHTTPS(t *testing.T) {
 // container serving nothing, so the HTTP response would be a 502 and would say
 // nothing about routing — whereas the certificate is chosen by server name, and
 // getting the right one back means the proxy knows the project.
-func requireCertificateFor(t *testing.T, host string) {
+func requireCertificateFor(t *testing.T, p *project, host string) {
 	t.Helper()
 
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
@@ -102,6 +102,9 @@ func requireCertificateFor(t *testing.T, host string) {
 
 		if time.Now().After(deadline) {
 			t.Errorf("%s: could not complete a TLS handshake with the proxy: %v", host, lastErr)
+			// Nothing answered on 443, and that is three situations wearing one
+			// message. Ask before giving up.
+			describeProxy(t, p)
 			return
 		}
 		time.Sleep(2 * time.Second)
@@ -121,12 +124,12 @@ func TestChangedHostGetsItsOwnCertificate(t *testing.T) {
 		"--hosts=e2ehost-before.test",
 	)
 	p.run(20*time.Minute, "start")
-	requireCertificateFor(t, "e2ehost-before.test")
+	requireCertificateFor(t, p, "e2ehost-before.test")
 
 	// Hosts live one per store code, so the key is a path rather than `hosts`.
 	// `--hosts=` on setup writes the base one.
 	p.run(2*time.Minute, "config:set", "-n", "nginx/hosts/base/name", "-v", "e2ehost-after.test")
 	p.run(10*time.Minute, "restart")
 
-	requireCertificateFor(t, "e2ehost-after.test")
+	requireCertificateFor(t, p, "e2ehost-after.test")
 }

--- a/test/e2e/ssl_cache_test.go
+++ b/test/e2e/ssl_cache_test.go
@@ -39,7 +39,7 @@ func TestSslRebuildIssuesANewCertificate(t *testing.T) {
 
 	ctx := filepath.Join(p.execDir, "aruntime", "ctx")
 	caBefore := fileDigest(t, filepath.Join(ctx, "madockCA.pem"))
-	servedBefore := servedCertificateDigest(t, "e2essl.test")
+	servedBefore := servedCertificateDigest(t, p, "e2essl.test")
 	if servedBefore == "" {
 		t.Fatal("the proxy served no certificate before the rebuild")
 	}
@@ -54,7 +54,7 @@ func TestSslRebuildIssuesANewCertificate(t *testing.T) {
 	// asserted: nginx holds the certificate it loaded, so whether a rebuild
 	// alone is enough depends on madock reloading it, and that is a decision
 	// this test should report rather than encode.
-	if immediate := servedCertificateDigest(t, "e2essl.test"); immediate == servedBefore {
+	if immediate := servedCertificateDigest(t, p, "e2essl.test"); immediate == servedBefore {
 		t.Logf("ssl:rebuild replaced the files but the running proxy still serves the old certificate; a reload is required")
 	}
 
@@ -64,13 +64,13 @@ func TestSslRebuildIssuesANewCertificate(t *testing.T) {
 	// the old workers are still answering with the certificate they loaded.
 	// Reading once immediately after the command measures that moment and calls
 	// it a defect.
-	if !certificateChangedWithin(t, "e2essl.test", servedBefore, time.Minute) {
+	if !certificateChangedWithin(t, p, "e2essl.test", servedBefore, time.Minute) {
 		t.Errorf("a minute after ssl:rebuild and proxy:reload the proxy still serves the old certificate (%s)", servedBefore)
 	}
 
 	// And it still has to be a certificate for this project. A rebuild that
 	// produced something valid for nothing would satisfy every check above.
-	requireCertificateFor(t, "e2essl.test")
+	requireCertificateFor(t, p, "e2essl.test")
 }
 
 // TestConfigCacheCleanRemovesTheCacheAndNothingElse covers `config:cache:clean`,
@@ -116,7 +116,7 @@ func TestConfigCacheCleanRemovesTheCacheAndNothingElse(t *testing.T) {
 	// And the environment still comes back. The markers that were deleted are
 	// exactly the ones the proxy path reads.
 	p.run(10*time.Minute, "restart")
-	requireCertificateFor(t, "e2econfcache.test")
+	requireCertificateFor(t, p, "e2econfcache.test")
 	requireContains(t, p.run(3*time.Minute, "status"), "db running", "the database after a cache clean and restart")
 }
 
@@ -136,7 +136,7 @@ func fileDigest(t *testing.T, path string) string {
 
 // servedCertificateDigest returns the sha256 of the certificate the proxy
 // offers for a host, or "" if it offers none.
-func servedCertificateDigest(t *testing.T, host string) string {
+func servedCertificateDigest(t *testing.T, p *project, host string) string {
 	t.Helper()
 
 	dialer := &net.Dialer{Timeout: 10 * time.Second}
@@ -160,6 +160,7 @@ func servedCertificateDigest(t *testing.T, host string) string {
 			_ = conn.Close()
 		}
 		if time.Now().After(deadline) {
+			describeProxy(t, p)
 			t.Fatalf("%s: could not complete a TLS handshake with the proxy: %v", host, err)
 		}
 		time.Sleep(2 * time.Second)
@@ -168,12 +169,12 @@ func servedCertificateDigest(t *testing.T, host string) string {
 
 // certificateChangedWithin waits for the proxy to start offering a certificate
 // other than the one given.
-func certificateChangedWithin(t *testing.T, host, previous string, within time.Duration) bool {
+func certificateChangedWithin(t *testing.T, p *project, host, previous string, within time.Duration) bool {
 	t.Helper()
 
 	deadline := time.Now().Add(within)
 	for {
-		if current := servedCertificateDigest(t, host); current != "" && current != previous {
+		if current := servedCertificateDigest(t, p, host); current != "" && current != previous {
 			return true
 		}
 		if time.Now().After(deadline) {


### PR DESCRIPTION
Two tests assert a TLS handshake against the proxy, and both have failed on a runner with the same sentence: nothing answered on `127.0.0.1:443`. That is **three situations wearing one message** — the proxy never started, it started and is not listening yet, or it is up and refusing.

It has happened twice in two days, in different shards and on different branches, and each time cost a wrong first guess: the change under review looked like the cause because nothing else was on offer.

    2026-08-29, master   ssl_cache_test.go:42   TestSslRebuildIssuesANewCertificate
    2026-08-30, staging  proxy_test.go:51       TestProxyRoutesEveryProjectOverHTTPS

So the failure asks. `status` says whether the container exists and is running; `proxy:logs` is where nginx writes the reason it would not bind. Both run **after** the test has already failed, so neither can turn a pass into a failure, and neither is an assertion — what they print is evidence for a person, not a verdict.

This does not fix the flake. It makes the next occurrence able to say which of the three it was, which is what MADOCK-BACKLOG item 45 asks for before anything is changed: raising the timeout without knowing would be wrong if the proxy is not coming up at all, because the same thing then happens on a customer's machine where nobody re-runs anything.

The flag was `--lines` in the first draft and is `--tail`. A wrong flag fails the way the thing it diagnoses fails — quietly, leaving one line saying the command could not be asked. Checked against a real machine rather than against the help text.