### PR TITLE
Say which functions exist to be called from the other side

### DIFF
--- a/src/command/registry.go
+++ b/src/command/registry.go
@@ -119,19 +119,32 @@ func Register(def *Definition) {
 	}
 }
 
-// Use adds a global middleware applied to all commands
+// Use adds a global middleware applied to all commands.
+//
+// Extension point for madock-pro: the licence gate is registered here, which is
+// what makes a paid command refuse before it runs. Unreachable from this module
+// by design.
 func Use(m Middleware) {
 	globalMiddlewares = append(globalMiddlewares, m)
 }
 
-// AddBefore adds a before-hook to the command registered under the given alias
+// AddBefore adds a before-hook to the command registered under the given alias.
+//
+// Extension point for madock-pro, and eleven of its hooks arrive here. See
+// AddAfter for why this looks unreachable and is not.
 func AddBefore(alias string, hook Handler) {
 	if def, ok := registry[alias]; ok {
 		def.Before = append(def.Before, hook)
 	}
 }
 
-// AddAfter adds an after-hook to the command registered under the given alias
+// AddAfter adds an after-hook to the command registered under the given alias.
+//
+// Extension point for madock-pro. Nothing in this repository calls it, and that
+// is correct: pro registers 26 after-hooks through it — deploy, backup, cron,
+// ssl and the rest — from its own `init`. A reachability analysis of this module
+// alone reports it as unreachable, which is how the whole hook mechanism came to
+// be listed as dead code in an audit on 2026-08-31.
 func AddAfter(alias string, hook Handler) {
 	if def, ok := registry[alias]; ok {
 		def.After = append(def.After, hook)

--- a/src/controller/general/remote_sync/remote_sync.go
+++ b/src/controller/general/remote_sync/remote_sync.go
@@ -33,7 +33,12 @@ type SSHConfigProvider interface {
 
 var sshConfigProvider SSHConfigProvider
 
-// SetSSHConfigProvider sets a custom provider for creating SSH client configurations.
+// SetSSHConfigProvider installs the provider that builds SSH client
+// configurations.
+//
+// Extension point for madock-pro, whose provider is the one that reads
+// `ssh/key_path` and falls back to the agent. Unreachable from this module by
+// design.
 func SetSSHConfigProvider(p SSHConfigProvider) {
 	sshConfigProvider = p
 }

--- a/src/helper/configs/config.go
+++ b/src/helper/configs/config.go
@@ -20,6 +20,9 @@ import (
 var ConfigFilePermissions os.FileMode = 0644
 
 // SetConfigFilePermissions overrides the file mode for config XML files.
+//
+// Extension point for madock-pro, where a config holding enciphered secrets is
+// written tighter than 0644. Unreachable from this module by design.
 func SetConfigFilePermissions(perm os.FileMode) {
 	ConfigFilePermissions = perm
 }

--- a/src/helper/configs/projects.go
+++ b/src/helper/configs/projects.go
@@ -51,6 +51,10 @@ func SetDefaultOverride(key, value string) {
 }
 
 // GetDefaultConfigXML returns the raw embedded config_defaults.xml bytes.
+//
+// Extension point for madock-pro, which reads the shipped defaults to tell an
+// edition's own values apart from the ones a machine has changed. Unreachable
+// from this module by design.
 func GetDefaultConfigXML() []byte {
 	return defaultConfigXML
 }

--- a/src/helper/configs/secrets.go
+++ b/src/helper/configs/secrets.go
@@ -20,6 +20,10 @@ var SecretKeys = map[string]bool{
 }
 
 // RegisterSecretKey marks an additional config key as secret.
+//
+// Extension point for madock-pro, and seven keys arrive through it. Community
+// has no encryption, so it registers none — which is why this looks unreachable
+// here and is the whole mechanism there.
 func RegisterSecretKey(key string) {
 	SecretKeys[key] = true
 }
@@ -32,7 +36,12 @@ type SecretsProvider interface {
 
 var secretsProvider SecretsProvider
 
-// SetSecretsProvider sets a custom secrets provider for encrypting/decrypting config values.
+// SetSecretsProvider installs the provider that encrypts and decrypts config
+// values.
+//
+// Extension point for madock-pro. Nothing in this repository encrypts anything:
+// the keys registered above are plain text in community and enciphered in pro,
+// and this is the seam between those two answers.
 func SetSecretsProvider(p SecretsProvider) {
 	secretsProvider = p
 }

--- a/src/helper/docker/exec.go
+++ b/src/helper/docker/exec.go
@@ -29,7 +29,9 @@ func IsTTYAvailable() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
-// SetCommandInterceptor sets a custom interceptor for docker exec commands.
+// SetCommandInterceptor installs an interceptor for docker exec commands.
+//
+// Extension point for madock-pro. Unreachable from this module by design.
 func SetCommandInterceptor(i CommandInterceptor) {
 	commandInterceptor = i
 }

--- a/src/helper/docker/service.go
+++ b/src/helper/docker/service.go
@@ -50,6 +50,9 @@ func ComposeServices(projectName string) ([]string, error) {
 // step for a person, and why on 2026-08-19 three of four projects on one
 // machine were serving code from a release older than `current` — the symlink
 // had moved and the process had not been told.
+// Extension point for madock-pro: its post-deploy hook is the only caller, and
+// that hook is the answer to the paragraph above — the step a person used to
+// forget.
 func RestartServices(projectName string, services []string) error {
 	if len(services) == 0 {
 		return errors.New("no services named")

--- a/src/helper/dockertransform/secrets.go
+++ b/src/helper/dockertransform/secrets.go
@@ -11,7 +11,11 @@ type DockerTransformer interface {
 
 var transformer DockerTransformer
 
-// SetDockerTransformer sets a custom transformer for Docker files.
+// SetDockerTransformer installs the transformer applied to generated Docker
+// files.
+//
+// Extension point for madock-pro, which uses it to keep secrets out of the
+// files it renders. Unreachable from this module by design.
 func SetDockerTransformer(t DockerTransformer) {
 	transformer = t
 }

--- a/src/helper/embedded/extract.go
+++ b/src/helper/embedded/extract.go
@@ -16,10 +16,18 @@ import (
 var DockerFS fs.FS
 var ScriptsFS fs.FS
 
+// SetDockerFS installs the template tree an installation unpacks.
+//
+// Extension point for madock-pro, and the most load-bearing one there is: pro's
+// own `main` sets both of these before anything runs, which is how a pro
+// installation ends up with pro's templates rather than community's. Nothing in
+// this module calls either — the binary that does is the other one.
 func SetDockerFS(f fs.FS) {
 	DockerFS = f
 }
 
+// SetScriptsFS installs the script tree an installation unpacks. See
+// SetDockerFS: same seam, same caller, same reason it looks unreachable here.
 func SetScriptsFS(f fs.FS) {
 	ScriptsFS = f
 }

--- a/src/helper/hash/password.go
+++ b/src/helper/hash/password.go
@@ -19,7 +19,17 @@ type PasswordGenerator func(length int) (string, error)
 
 var passwordGenerator PasswordGenerator
 
-// SetPasswordGenerator sets a custom password generator.
+// SetPasswordGenerator installs the generator used for service passwords.
+//
+// Extension point for madock-pro, and the reason the weak defaults in
+// config.xml are a product boundary rather than an oversight: community ships
+// `root_password = password`, and pro replaces it — along with db2, rabbitmq,
+// redis, valkey, elasticsearch, opensearch and grafana — with crypto/rand values
+// on setup and rebuild. That is where a server's real passwords come from.
+//
+// An audit on 2026-08-31 read this as a finished security feature nobody had
+// wired up, because nothing in this module calls it. It is wired up on the other
+// side of the boundary.
 func SetPasswordGenerator(gen PasswordGenerator) {
 	passwordGenerator = gen
 }

--- a/src/helper/paths/paths.go
+++ b/src/helper/paths/paths.go
@@ -17,7 +17,11 @@ type PathValidator func(envName, value string) error
 
 var pathValidator PathValidator
 
-// SetPathValidator sets a custom validator for MADOCK_* env var overrides.
+// SetPathValidator installs the validator for MADOCK_* environment overrides.
+//
+// Extension point for madock-pro: its pathguard hook registers here, and that is
+// what stops a destructive command being pointed at a directory it should not
+// reach. Unreachable from this module by design.
 func SetPathValidator(v PathValidator) {
 	pathValidator = v
 }


### PR DESCRIPTION
A reachability analysis over this module alone reports 61 unreachable functions. **Fifteen of them are what madock-pro is built on**, and every one is genuinely unreachable from here, because being called from the other side of the boundary is the entire point.

Read without that context they are dead code with tidy comments. The audit that found them proposed deleting some — including the password generator that replaces this module's weak defaults with crypto/rand values on every server we run — and the only reason it did not was a question from the owner: *"maybe pro uses this?"*

So each says so now: what registers there, what it decides, and that being unreachable here is by design.

| | what sits on it |
|---|---|
| `command.AddAfter` / `AddBefore` | 26 and 11 hooks — deploy, backup, cron, ssl |
| `command.Use` | the licence gate, which is why a paid command refuses before it runs |
| `embedded.SetDockerFS` / `SetScriptsFS` | pro's own `main`, before anything runs: how a pro installation gets pro's templates |
| `hash.SetPasswordGenerator` | where a server's real passwords come from |
| `paths.SetPathValidator` | the guard on destructive commands |
| `configs.SetSecretsProvider` | plain text here, enciphered there |
| `configs.RegisterSecretKey` | seven keys |
| `docker.RestartServices` | the post-deploy step a person used to forget |
| plus | `SetConfigFilePermissions`, `GetDefaultConfigXML`, `SetCommandInterceptor`, `SetDockerTransformer`, `SetSSHConfigProvider` |

**Three of these were missed by the grep that produced the first list**, and found by a test written afterwards. That is the argument for the test rather than for the list — it lives in pro, because only pro knows what pro calls, and it lands once this is tagged.