### PR TITLE
4.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v4.1.17**
+
+Changed:
+-  says the marker phrase itself rather than pointing at its neighbour. A cross-reference is not what a search finds, and being findable is the whole purpose of the phrase
+
 **v4.1.16**
 
 Changed:

--- a/src/helper/embedded/extract.go
+++ b/src/helper/embedded/extract.go
@@ -26,8 +26,11 @@ func SetDockerFS(f fs.FS) {
 	DockerFS = f
 }
 
-// SetScriptsFS installs the script tree an installation unpacks. See
-// SetDockerFS: same seam, same caller, same reason it looks unreachable here.
+// SetScriptsFS installs the script tree an installation unpacks.
+//
+// Extension point for madock-pro: same seam as SetDockerFS, same caller, same
+// reason it is unreachable from here. Spelled out rather than cross-referenced,
+// because the phrase is what a search finds and a pointer to a neighbour is not.
 func SetScriptsFS(f fs.FS) {
 	ScriptsFS = f
 }

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.16"
+const Version = "4.1.17"


### PR DESCRIPTION
`SetScriptsFS` carried its reason as a pointer — *see SetDockerFS: same seam, same caller* — which reads fine and is invisible to the thing the phrase exists for. The marker is a string somebody greps for, and a cross-reference is not that string.

Found by the test in pro rather than by review: it went green on everything except this one, which is what a marker check is supposed to do to a marker written in prose.