### PR TITLE
Let a registry-only removal run under the destructive-commands ban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+**v4.1.19**
+
+Fixed:
+- **The ban on destructive commands refused the one removal that destroys nothing.** madock-pro ships `allow_destructive_commands` false on servers, and it covered `project:remove --registry-only` wholesale — so the three entries 4.1.18 taught `project:list` to name, sitting on a production host and pointing into live releases, still could not be removed. The machine that most needs the ban is the machine where such entries accumulate, and the only way out was to turn the ban off on production for the length of the cleanup
+- **The exemption is by state, not by flag.** An entry whose source is gone, whose link resolves to nothing, or whose path is inside another registered project owns nothing that could be lost — a port reservation and a block in the shared proxy, both on behalf of something that does not exist. A healthy project is refused as before: its record is its madock configuration, passwords and ports and stack, and nothing recreates it. `no-path` is refused too, being a legacy entry of a project that may well still exist
+- **And the exemption cannot destroy data even if an entry turns out to have some**: registry-only removal no longer passes `-v --rmi all`. Containers of that name go and come back from the configuration; volumes and images stay, findable by `prune` and the orphans command
+
 **v4.1.18**
 
 Fixed:

--- a/docs/config.md
+++ b/docs/config.md
@@ -125,6 +125,13 @@ project's data may run on this machine:
 
 - **`project:remove`** — the registry entry, the generated runtime, the ports,
   the volumes, the images, and a recursive delete of the project directory.
+- **`project:remove --registry-only`** is covered too, with one exception: an
+  entry that is not a project of its own — its source directory gone, its link
+  resolving to nothing, or its path inside another registered project — may be
+  removed while the setting is `false`. Such an entry owns nothing that could be
+  lost, and refusing kept three of them on a production host with no way to clean
+  up. Containers of that name go; volumes and images are left, so the exemption
+  cannot destroy data even if the entry turns out to have some.
 - **`prune --with-volumes`** — `docker compose down -v --rmi all`: the data
   volumes and the images. The database is gone and nothing brings it back.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -250,6 +250,10 @@ directory it is run in — and that is `os.Getwd()`, which keeps whatever symlin
 through, so `cd release/current` and `cd -P release/current` destroy different things. The
 confirmation now says which directory the delete will actually be given
 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`--registry-only` runs on an installation that forbids this command when the
+entry named is not a project of its own — source gone, link broken, or path inside another project.
+It leaves volumes and images alone, so the exemption cannot destroy data
+
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;An installation can forbid this command, and `prune --with-volumes` with it —
 see `allow_destructive_commands` in [config.md](config.md). madock-pro ships it forbidden
 

--- a/src/controller/general/project/remove/remove.go
+++ b/src/controller/general/project/remove/remove.go
@@ -51,7 +51,11 @@ func Execute() {
 
 	// Before anything is read, decided or printed: this command deletes a
 	// project's data, and an installation may forbid that.
-	if !configs.AllowsDestructiveCommands() {
+	//
+	// --registry-only answers this for itself, once it knows which entry was
+	// named. It has to: what such a removal costs is a property of the entry,
+	// not of the command, and that cannot be known here.
+	if !args.RegistryOnly && !configs.AllowsDestructiveCommands() {
 		for _, line := range configs.DestructiveRefusal("project:remove") {
 			fmtc.ErrorLn(line)
 		}
@@ -247,7 +251,7 @@ func removeProject(projectName string) {
 	}
 	fmtc.WarningLn("  containers, images and volumes of the project")
 
-	removeRegistered(projectName, true)
+	removeRegistered(projectName, true, true)
 
 	// The project's own directory, and only when standing in it. Split out so
 	// that removing an entry by name — where the source is gone and the caller
@@ -261,7 +265,7 @@ func removeProject(projectName string) {
 // its containers, its registry entry, its generated runtime, its block in the
 // shared proxy and its port reservation. Everything except the project's own
 // directory, which is the caller's to decide about.
-func removeRegistered(projectName string, reclaimSource bool) {
+func removeRegistered(projectName string, reclaimSource, withVolumes bool) {
 	pp := paths.NewProjectPaths(projectName)
 
 	// Before the containers go: anything they wrote as root has to be handed
@@ -277,7 +281,10 @@ func removeRegistered(projectName string, reclaimSource bool) {
 		docker.ReclaimProjectFiles(projectName)
 	}
 
-	docker.Down(projectName, true)
+	// withVolumes false is what makes a registry-only removal safe to allow on an
+	// installation that forbids destructive commands: containers are not data and
+	// come back from the configuration, volumes and images are and do not.
+	docker.Down(projectName, withVolumes)
 
 	if err := os.RemoveAll(paths.GetExecDirPath() + "/projects/" + projectName + "/"); err != nil {
 		logger.Fatal(err)
@@ -396,8 +403,9 @@ func removeNamed(projectName string, force bool) {
 
 	// No reclaim: the source directory is gone, so there is nothing to hand back
 	// — and the caller is standing somewhere unrelated, which is the one place
-	// the fallback would chown.
-	removeRegistered(projectName, false)
+	// the fallback would chown. Volumes do go: this branch runs only for an entry
+	// whose source is gone, and it is gated on the installation allowing it.
+	removeRegistered(projectName, false, true)
 }
 
 // removeRegistryOnly drops what the installation holds for a name and nothing else.
@@ -412,6 +420,39 @@ func removeNamed(projectName string, force bool) {
 //
 // So the source is not merely left alone here, it is unreachable from this path:
 // nothing below takes a directory, and removeRegistered has never deleted one.
+// registryOnlyAllowed decides whether a registry-only removal may run on an
+// installation that forbids destructive commands.
+//
+// The ban exists to stop a project's data being destroyed, and for a healthy
+// project this removal still does that: the entry it deletes is the project's
+// madock configuration — database passwords, ports, the stack — and nothing
+// recreates it. So the ban holds there.
+//
+// It does not hold for an entry that is not a project of its own. A record whose
+// source directory is gone, whose link resolves to nothing, or whose path lives
+// inside another project owns nothing that could be lost: what it holds is a
+// port reservation and a block in the shared proxy, both on behalf of something
+// that does not exist. Refusing there protected nothing and left three such
+// entries on a production host with no way to remove them — the machine that
+// most needs the ban is the machine where they accumulate.
+//
+// Paired with withVolumes=false in this path, so what runs under the exemption
+// cannot delete data even if an entry turns out to have some.
+func registryOnlyAllowed(state string, destructiveAllowed bool) bool {
+	if destructiveAllowed {
+		return true
+	}
+
+	switch state {
+	case configs.ProjectMissingSource, configs.ProjectBrokenLink, configs.ProjectNestedPath:
+		return true
+	}
+
+	// ProjectOk, and ProjectNoPath — a legacy entry of a project that may well
+	// still exist, which is not something to guess about under a ban.
+	return false
+}
+
 func removeRegistryOnly(projectName string, force bool) {
 	// Taken from --name only. The working directory is what invented these
 	// entries in the first place, and a command whose entire promise is "the
@@ -434,6 +475,19 @@ func removeRegistryOnly(projectName string, force bool) {
 	if entry == nil {
 		fmtc.ErrorLn("No project named '" + projectName + "' is registered in this installation")
 		fmtc.ToDoLn("madock project:list")
+		os.Exit(1)
+	}
+
+	if !registryOnlyAllowed(entry.State, configs.AllowsDestructiveCommands()) {
+		for _, line := range configs.DestructiveRefusal("project:remove --registry-only") {
+			fmtc.ErrorLn(line)
+		}
+		fmtc.ErrorLn("")
+		fmtc.ErrorLn("'" + projectName + "' is a project in its own right, and its record is its madock")
+		fmtc.ErrorLn("configuration — passwords, ports, the stack. Nothing recreates that.")
+		fmtc.ToDoLn("Entries that are not a project of their own are removable here without changing")
+		fmtc.ToDoLn("that setting — source gone, link broken, or path inside another project:")
+		fmtc.ToDoLn("  madock project:list --stale")
 		os.Exit(1)
 	}
 
@@ -464,7 +518,12 @@ func removeRegistryOnly(projectName string, force bool) {
 		}
 	}
 
-	removeRegistered(projectName, false)
+	// Neither the source nor the project's data: containers go, volumes and images
+	// stay. An orphaned volume is recoverable and findable — `prune` and the
+	// orphans command exist for exactly that — while a volume deleted under an
+	// installation that forbids destructive commands is the thing the setting was
+	// put there to prevent.
+	removeRegistered(projectName, false, false)
 }
 
 // definition returns this command's registration, for tests that assert on it.

--- a/src/controller/general/project/remove/remove_test.go
+++ b/src/controller/general/project/remove/remove_test.go
@@ -164,3 +164,31 @@ func TestRemovalTargetLines_PlainDirectoryStaysOneLine(t *testing.T) {
 		t.Fatalf("expected a single line naming the directory, got %#v", lines)
 	}
 }
+
+// The ban on destructive commands is what madock-pro ships on servers, and it
+// refused the one removal that cannot destroy anything — which is how three
+// registry entries pointing into live releases stayed on a production host with
+// no way to remove them.
+func TestRegistryOnlyAllowed_UnderTheBan(t *testing.T) {
+	cases := []struct {
+		state string
+		want  bool
+		why   string
+	}{
+		{configs.ProjectNestedPath, true, "the path is inside another project, so the entry owns nothing"},
+		{configs.ProjectMissingSource, true, "the source directory is gone"},
+		{configs.ProjectBrokenLink, true, "the entry resolves to nothing at all"},
+		{configs.ProjectOk, false, "a healthy project: its record is its madock configuration"},
+		{configs.ProjectNoPath, false, "legacy entry of a project that may still exist — not a thing to guess about"},
+	}
+
+	for _, c := range cases {
+		if got := registryOnlyAllowed(c.state, false); got != c.want {
+			t.Errorf("state %q under the ban = %v, want %v — %s", c.state, got, c.want, c.why)
+		}
+		// With the ban lifted every state is the caller's business.
+		if !registryOnlyAllowed(c.state, true) {
+			t.Errorf("state %q was refused on an installation that allows destructive commands", c.state)
+		}
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.18"
+const Version = "4.1.19"


### PR DESCRIPTION
Follow-up to #120, found by running it on the machine it was written for.

madock-pro ships `allow_destructive_commands` false on servers, and the gate at the top of `project:remove` covered `--registry-only` along with everything else. So on production the three entries #120 taught `project:list` to name — `current`, `current-2`, `current-3`, each pointing into a live release — still could not be removed:

```
'project:remove' deletes a project's data, and this installation does not allow that.
```

The only way through was to turn the ban off on production for the length of a cleanup, which is worse than the entries.

**The exemption is by the state of the entry**, decided after the registry is read rather than by a flag the caller passes:

| state | under the ban | why |
|---|---|---|
| `nested-path`, `missing-source`, `broken-link` | allowed | the entry owns a port reservation and a proxy block on behalf of something that does not exist |
| `ok` | refused, as before | the record *is* the project's madock configuration — passwords, ports, stack — and nothing recreates it |
| `no-path` | refused | legacy entry of a project that may well still exist; not a thing to guess about under a ban |

**And the exemption cannot destroy data even if an entry turns out to have some.** Registry-only removal no longer passes `-v --rmi all` to `docker compose down`: containers of that name go and come back from the configuration, volumes and images stay where `prune` and the orphans command can find them.

Measured on the production host before writing this: the entry is `/opt/madock/projects/current/` — a `config.xml` and a generated `docker/` — with no runtime directory, no port reservation, and no containers under the `madock_current` compose label. The release symlinks it points at (`ops-console → releases/37`, `shiplab-shopify → releases/33`, `core-shopify → releases/34`) are untouched by this path: the only `RemoveAll` that takes a source directory lives in the in-place branch, which `--registry-only` returns before reaching.

4.1.18 is installed on that host and its `project:list` names all three with their owning project, which is what made the gate the last thing standing.
