### PR TITLE
Tell a proxy.conf transformer whose blocks it is rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v4.1.20**
+
+Fixed:
+- **A proxy.conf transformer had no way to learn whose blocks it was rewriting, so it asked the working directory.** `proxytransform.Apply` hands over the finished file — every project's server blocks concatenated — and says nothing about the project, while the file is regenerated *on behalf of* a project the caller need not be standing in: during a removal it is regenerated for whichever project is left. Measured on a production installation on 2026-08-31, seven projects and forty service locations, all carrying a single obfuscation suffix, because one project's configuration had been applied to the whole file. The same run minted and persisted configuration for a home directory that was not a project at all, turning it into a registry entry that `project:list` then reported
+- **`ApplyProject(projectName, content)` is the answer**: a second chain, run over one project's blocks before they are concatenated, told which project they are. An empty name runs nothing rather than falling back to the current directory — that fallback is the defect, not a safety net. The whole-file chain is unchanged and independent, for transformers that genuinely operate on the assembled file
+
 **v4.1.19**
 
 Fixed:

--- a/src/helper/configs/aruntime/nginx/nginx.go
+++ b/src/helper/configs/aruntime/nginx/nginx.go
@@ -272,13 +272,18 @@ func makeProxy(projectName string) {
 						logger.Fatalln(err)
 					}
 
-					allFileData += "\n" + strReplaced
+					// Transformed here, where the project is known by name, and
+					// not written to the cache in that form: the cache holds the
+					// rendered block, the suffix is applied on the way into the
+					// file so a transformer can change its mind without a stale
+					// copy outliving it.
+					allFileData += "\n" + proxytransform.ApplyProject(name, strReplaced)
 				} else {
 					strReplaced, err := os.ReadFile(paths.CacheDir() + "/" + name + "-proxy.conf")
 					if err != nil {
 						logger.Fatalln(err)
 					}
-					allFileData += "\n" + string(strReplaced)
+					allFileData += "\n" + proxytransform.ApplyProject(name, string(strReplaced))
 				}
 			}
 		}

--- a/src/helper/configs/aruntime/proxytransform/transformer.go
+++ b/src/helper/configs/aruntime/proxytransform/transformer.go
@@ -12,6 +12,27 @@ type ProxyConfTransformer interface {
 	TransformProxyConf(content string) string
 }
 
+// ProjectProxyConfTransformer rewrites one project's server blocks and is told
+// which project they belong to.
+//
+// The interface above hands over the finished file and says nothing about whose
+// blocks are in it, so a transformer that needs to know had one place left to
+// ask: the working directory. That is not the same question. `proxy.conf` holds
+// every project at once and is regenerated on behalf of a project the caller
+// may not be standing in — during a removal it is regenerated on behalf of
+// whichever project is left — so the answer was whatever directory the command
+// ran in.
+//
+// Measured on a production installation on 2026-08-31: forty service locations
+// across seven projects, all carrying one suffix, because one project's
+// configuration had been applied to the whole file. The same run minted and
+// persisted configuration for a directory that was not a project at all — a
+// home directory the command happened to be started from — turning it into a
+// registry entry.
+type ProjectProxyConfTransformer interface {
+	TransformProjectProxyConf(projectName, content string) string
+}
+
 // transformers run in registration order, each seeing the previous one's
 // output.
 //
@@ -32,6 +53,38 @@ func AddProxyConfTransformer(t ProxyConfTransformer) {
 	}
 }
 
+var projectTransformers []ProjectProxyConfTransformer
+
+// AddProjectProxyConfTransformer appends a per-project transformer. Same
+// ordering rule as the whole-file chain, and the two are independent: a
+// per-project transformer sees one project's blocks before they are
+// concatenated, a whole-file one sees the assembled result.
+func AddProjectProxyConfTransformer(t ProjectProxyConfTransformer) {
+	if t != nil {
+		projectTransformers = append(projectTransformers, t)
+	}
+}
+
+// ApplyProject runs the per-project transformers over one project's blocks.
+//
+// An empty project name runs nothing: the whole point of this path is that the
+// caller knows whose blocks these are, and a transformer asked to rewrite
+// "somebody's" configuration is the defect being fixed, not a fallback.
+func ApplyProject(projectName, content string) string {
+	if projectName == "" {
+		return content
+	}
+
+	for _, t := range projectTransformers {
+		out := t.TransformProjectProxyConf(projectName, content)
+		if out != "" {
+			content = out
+		}
+	}
+
+	return content
+}
+
 // SetProxyConfTransformer replaces the whole chain with one transformer.
 // Kept for callers that mean "this and nothing else"; anything wanting to
 // coexist should use AddProxyConfTransformer.
@@ -41,6 +94,13 @@ func SetProxyConfTransformer(t ProxyConfTransformer) {
 		return
 	}
 	transformers = []ProxyConfTransformer{t}
+}
+
+// ResetTransformers clears both chains. For tests, which would otherwise leak
+// registrations into each other.
+func ResetTransformers() {
+	transformers = nil
+	projectTransformers = nil
 }
 
 // Apply runs the registered transformers in order. A transformer returning an

--- a/src/helper/configs/aruntime/proxytransform/transformer_test.go
+++ b/src/helper/configs/aruntime/proxytransform/transformer_test.go
@@ -105,3 +105,75 @@ func TestApplyEmptyReturnFallsBackToInput(t *testing.T) {
 		t.Errorf("empty transform return should preserve input, got %q", got)
 	}
 }
+
+// recorder is a per-project transformer that remembers what it was told.
+type recorder struct {
+	seen []string
+}
+
+func (r *recorder) TransformProjectProxyConf(projectName, content string) string {
+	r.seen = append(r.seen, projectName)
+	return content + "\n# " + projectName
+}
+
+// The whole point of the per-project chain: the transformer is told whose
+// blocks these are. Asking the working directory instead is what put one
+// project's service-route suffix on all seven projects of a production
+// installation.
+func TestApplyProject_NamesTheProject(t *testing.T) {
+	ResetTransformers()
+	t.Cleanup(ResetTransformers)
+
+	rec := &recorder{}
+	AddProjectProxyConfTransformer(rec)
+
+	if out := ApplyProject("shiplab-shopify", "server {}"); out != "server {}\n# shiplab-shopify" {
+		t.Errorf("output = %q, want the project's own rewrite", out)
+	}
+	if out := ApplyProject("ops-console", "server {}"); out != "server {}\n# ops-console" {
+		t.Errorf("second project got %q — each block is rewritten for its own project", out)
+	}
+	if len(rec.seen) != 2 || rec.seen[0] != "shiplab-shopify" || rec.seen[1] != "ops-console" {
+		t.Errorf("transformer saw %v, want both project names in order", rec.seen)
+	}
+}
+
+// An empty name runs nothing. A transformer asked to rewrite somebody's
+// configuration without being told whose is the defect this exists to remove,
+// so there is no fallback to the current directory here or anywhere else.
+func TestApplyProject_EmptyNameRewritesNothing(t *testing.T) {
+	ResetTransformers()
+	t.Cleanup(ResetTransformers)
+
+	rec := &recorder{}
+	AddProjectProxyConfTransformer(rec)
+
+	if out := ApplyProject("", "server {}"); out != "server {}" {
+		t.Errorf("output = %q, want the content untouched", out)
+	}
+	if len(rec.seen) != 0 {
+		t.Errorf("transformer was called with %v — an unnamed project must not reach it", rec.seen)
+	}
+}
+
+// The two chains are independent: registering one must not silence the other.
+func TestBothChainsRun(t *testing.T) {
+	ResetTransformers()
+	t.Cleanup(ResetTransformers)
+
+	rec := &recorder{}
+	AddProjectProxyConfTransformer(rec)
+	AddProxyConfTransformer(suffixAppender{"# whole"})
+
+	block := ApplyProject("core-shopify", "server {}")
+	if got := Apply(block); got != "server {}\n# core-shopify\n# whole" {
+		t.Errorf("got %q, want both rewrites applied in order", got)
+	}
+}
+
+// suffixAppender is a whole-file transformer for the test above.
+type suffixAppender struct{ line string }
+
+func (s suffixAppender) TransformProxyConf(content string) string {
+	return content + "\n" + s.line
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.19"
+const Version = "4.1.20"


### PR DESCRIPTION
Found while cleaning up after #120/#121 on the production host, and it is the same shape as the entries those removed: something asked the working directory a question the working directory cannot answer.

`proxytransform.Apply` hands a transformer the assembled `proxy.conf` — every project's server blocks concatenated — and names no project. A transformer that needs to know whose blocks these are had one place left to ask, `configs.GetProjectName()`, which reads the *working directory*. But `proxy.conf` is regenerated **on behalf of** a project the caller need not be standing in: `project:remove` regenerates it for whichever project remains, from wherever the command was run.

**Measured on production, 2026-08-31**, where madock-pro's service-route obfuscation is that transformer:

```
20 location /grafana-c86daf/
10 location /kibana-c86daf/
10 location /phpmyadmin-c86daf/
```

Seven projects, forty locations, one suffix — although the feature is documented as per-project and derives from `sha256(projectName + salt)`. One project's configuration had been applied to the whole file.

The second half is worse than the wrong suffix. Running the command from a home directory made the transformer mint and persist a salt **for the home directory's name**, creating `/opt/madock/projects/vrudiuk/config.xml` — a registry entry for something that is not a project, which `project:list` then reported. `SetParam` resolves `MadockLevelConfigCode` to `GetProjectName()`, so the write landed wherever the caller was standing.

`ApplyProject(projectName, content)` is a second chain, run over one project's blocks before they are concatenated, with the name in hand. Both branches of the assembly loop go through it — the rendered one and the cached one — and the cache keeps the untransformed block, so a transformer changing its mind cannot be outlived by a stale copy.

**An empty name runs nothing.** No fallback to the current directory: that fallback is the defect, and leaving one in would make this fix a preference rather than a repair.

The whole-file chain is untouched and independent — `hooks/ssl` genuinely operates on the finished file. madock-pro's suffixer moves to the new chain in its own release; until then it keeps working exactly as before.
