### PR TITLE
Say what a failed proxy reload means instead of printing its exit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v4.1.21**
+
+Fixed:
+- **A removal printed `exit status 1` one line above "Project was removed successfully".** That string is the whole of what an `exec.ExitError` carries — no command, no stderr — and it came from reloading the shared proxy, which fails when the proxy is not running. Nothing about the removal had failed: the registry entry, the runtime and the port reservations were gone and the generated configuration on disk was correct. The pair read as a destructive command that half worked, which is the worst thing this particular command can look like. Found while clearing two orphaned entries off a laptop whose proxy was simply down
+- **The failure now says which of the two it is.** Proxy not running: the removal succeeded and the configuration applies at the next `proxy:start`, no code quoted. Proxy running and refusing to reload: that is a real fault, so the error text is shown along with `proxy:logs` and `proxy:restart` — the only case where the underlying string is worth anything. `proxy:reload` has had a sentence like this for a while; this path had the bare code
+
 **v4.1.20**
 
 Fixed:

--- a/src/controller/general/project/remove/remove.go
+++ b/src/controller/general/project/remove/remove.go
@@ -265,6 +265,41 @@ func removeProject(projectName string) {
 // its containers, its registry entry, its generated runtime, its block in the
 // shared proxy and its port reservation. Everything except the project's own
 // directory, which is the caller's to decide about.
+// reloadFailureLines says what a failed proxy reload means, in place of the
+// error's own text.
+//
+// `docker compose exec nginx nginx -s reload` against a proxy that is not
+// running fails, and an exec.ExitError's Error() is the whole of `exit status
+// 1` — no command, no stderr, no hint. Removing a project printed exactly that
+// one line above "Project was removed successfully", which reads as a removal
+// that half failed and is nothing of the sort: the registry, the runtime and
+// the ports are gone, and the generated configuration on disk is correct and
+// waiting for the next start.
+//
+// Measured while cleaning two orphaned entries off a laptop where the proxy was
+// simply not up. The same refusal already has a good sentence in `proxy:reload`
+// — this path had the bare code instead.
+func reloadFailureLines(err error, proxyRunning bool) []string {
+	if err == nil {
+		return nil
+	}
+
+	if !proxyRunning {
+		return []string{
+			"The shared proxy is not running, so its configuration was not reloaded",
+			"The project is removed and the generated configuration is up to date — it applies on the next madock proxy:start",
+		}
+	}
+
+	// It is running and the reload still failed, which is a real fault and the
+	// only case where the underlying text is worth showing.
+	return []string{
+		"The shared proxy is running but did not reload its configuration: " + err.Error(),
+		"The project is removed; the proxy is still serving the previous configuration",
+		"Look at madock proxy:logs, then madock proxy:restart",
+	}
+}
+
 func removeRegistered(projectName string, reclaimSource, withVolumes bool) {
 	pp := paths.NewProjectPaths(projectName)
 
@@ -312,7 +347,9 @@ func removeRegistered(projectName string, reclaimSource, withVolumes bool) {
 	if len(remaining) > 0 {
 		nginx.MakeConf(remaining[0])
 		if err := docker.ReloadNginx(); err != nil {
-			logger.Println(err)
+			for _, line := range reloadFailureLines(err, docker.IsProxyRunning()) {
+				fmtc.WarningLn(line)
+			}
 		}
 	}
 

--- a/src/controller/general/project/remove/remove_test.go
+++ b/src/controller/general/project/remove/remove_test.go
@@ -1,6 +1,7 @@
 package remove
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,5 +191,40 @@ func TestRegistryOnlyAllowed_UnderTheBan(t *testing.T) {
 		if !registryOnlyAllowed(c.state, true) {
 			t.Errorf("state %q was refused on an installation that allows destructive commands", c.state)
 		}
+	}
+}
+
+// What a removal used to print when the proxy was not up: `exit status 1`, the
+// entire text an exec.ExitError carries, one line above "Project was removed
+// successfully". Nothing had failed about the removal — the registry, the
+// runtime and the ports were gone and the generated configuration was correct —
+// but the pair reads as a half-finished destructive command, which is the worst
+// thing for this particular command to look like.
+func TestReloadFailureLines(t *testing.T) {
+	err := errors.New("exit status 1")
+
+	if lines := reloadFailureLines(nil, false); lines != nil {
+		t.Errorf("no error should say nothing, got %v", lines)
+	}
+
+	down := strings.Join(reloadFailureLines(err, false), "\n")
+	if strings.Contains(down, "exit status") {
+		t.Errorf("a proxy that is not running is not a fault to quote a code for:\n%s", down)
+	}
+	if !strings.Contains(down, "not running") || !strings.Contains(down, "proxy:start") {
+		t.Errorf("the reader has to learn why and what applies the config:\n%s", down)
+	}
+	if !strings.Contains(down, "removed") {
+		t.Errorf("it must say the removal itself succeeded:\n%s", down)
+	}
+
+	// Running and still refusing is a real fault, and there the underlying text
+	// is the only clue anyone has.
+	up := strings.Join(reloadFailureLines(err, true), "\n")
+	if !strings.Contains(up, "exit status 1") {
+		t.Errorf("a running proxy that will not reload should carry the error text:\n%s", up)
+	}
+	if !strings.Contains(up, "proxy:logs") {
+		t.Errorf("and should say where to look:\n%s", up)
 	}
 }

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.20"
+const Version = "4.1.21"


### PR DESCRIPTION
Found by running the command this series has been fixing, on a laptop rather than a server.

Removing an orphaned registry entry printed:

```
 exit status 1
2026/08/31 17:03:57.505582 logger.go:87: exit status 1
Project was removed successfully
```

`exit status 1` is the entire text an `exec.ExitError` carries — no command, no stderr, no hint — and it came from `ReloadNginx()`, which runs `docker compose exec nginx nginx -s reload` and fails when the proxy is not up. **Nothing about the removal had failed**: the registry entry, the generated runtime and the port reservations were gone, and the proxy configuration on disk was correct and waiting to be applied. Verified after the fact — `project:list --stale` clean, eighteen port reservations released.

A bare code above the word "successfully" reads as a destructive command that half worked, which is the one impression `project:remove` must never give.

The two situations are now separated, because they call for opposite things:

- **proxy not running** — the removal succeeded, the configuration applies at the next `madock proxy:start`, and no code is quoted: there is no fault to diagnose
- **proxy running and refusing** — a real fault, so the underlying text stays, with `proxy:logs` and `proxy:restart` named

`proxy:reload` has carried a sentence like this for a while ("The proxy configuration was not reloaded: the proxy is not running"); this path had the raw code instead. Same defect class as the `status` bug in 3.8.50 — a code where a sentence belongs.

The decision is a pure function with the docker call factored out, so the test asserts the wording rather than mocking a container: no code quoted when the proxy is down, the error text kept when it is up.
