### PR TITLE
composer: let a project keep a home of its own

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -77,6 +77,29 @@
                 <version>8.2</version>
                 <composer>
                     <version>2</version>
+                    <!-- Every project's composer home has always been one
+                         directory, ~/.composer, shared by the whole machine.
+                         That shares two things at once, and only one of them is
+                         wanted.
+
+                         shared_home shares the global INSTALL — composer.json
+                         and vendor/. Anything put there with
+                         `composer global require` from one project's container
+                         is the version every other project runs. Measured
+                         2026-09-01: moving one project's pinned Deployer from
+                         ^7 to ^8 moved all seven on the host, and the version
+                         reported inside a container whose own compose line read
+                         `deployer/deployer:^7` was 8.0.5.
+
+                         shared_cache shares the DOWNLOADS, which is the half
+                         worth having — 83 MB on that machine, fetched once.
+
+                         Both default to true: nothing changes for anyone who
+                         does not ask. shared_home=false with shared_cache=true
+                         gives a project its own tools at its own versions while
+                         downloads stay shared. -->
+                    <shared_home>true</shared_home>
+                    <shared_cache>true</shared_cache>
                 </composer>
                 <!-- The php-fpm pool. Until 4.0.3 none of this was settable and
                      the pool kept the distribution's own numbers, of which one

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -77,6 +77,29 @@
                 <version>8.2</version>
                 <composer>
                     <version>2</version>
+                    <!-- Every project's composer home has always been one
+                         directory, ~/.composer, shared by the whole machine.
+                         That shares two things at once, and only one of them is
+                         wanted.
+
+                         shared_home shares the global INSTALL — composer.json
+                         and vendor/. Anything put there with
+                         `composer global require` from one project's container
+                         is the version every other project runs. Measured
+                         2026-09-01: moving one project's pinned Deployer from
+                         ^7 to ^8 moved all seven on the host, and the version
+                         reported inside a container whose own compose line read
+                         `deployer/deployer:^7` was 8.0.5.
+
+                         shared_cache shares the DOWNLOADS, which is the half
+                         worth having — 83 MB on that machine, fetched once.
+
+                         Both default to true: nothing changes for anyone who
+                         does not ask. shared_home=false with shared_cache=true
+                         gives a project its own tools at its own versions while
+                         downloads stay shared. -->
+                    <shared_home>true</shared_home>
+                    <shared_cache>true</shared_cache>
                 </composer>
                 <!-- The php-fpm pool. Until 4.0.3 none of this was settable and
                      the pool kept the distribution's own numbers, of which one

--- a/src/helper/docker/composer_home.go
+++ b/src/helper/docker/composer_home.go
@@ -1,0 +1,133 @@
+package docker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Where a project's composer home comes from.
+//
+// madock has always pointed every project's `aruntime/projects/<name>/composer`
+// at one directory — `~/.composer` — and it does so on every start: if it finds
+// a real directory at that path it replaces it with the symlink. One cache and
+// one set of globally installed packages for the whole machine.
+//
+// That is a deliberate trade and mostly a good one — the download cache is the
+// bulk of it, 83 MB on the machine this was written on. What it also shares is
+// the **global install**: `~/.composer/composer.json` and `vendor/`. Anything
+// installed with `composer global require` in one project's container is the
+// version every other project runs, whatever their own configuration says.
+//
+// Measured on 2026-09-01, and the reason these keys exist: madock-pro pins the
+// Deployer version per project (`deploy/deployer_version`, written into each
+// project's compose file). Moving ONE project from `^7` to `^8` moved all seven
+// on that host — `dep --version` inside a container whose own compose line said
+// `deployer/deployer:^7` answered `Deployer 8.0.5`. The pin is not wrong in the
+// file; it simply cannot hold, because the install it pins is shared. One of
+// those projects carried a recipe that only parses under v7, so its next deploy
+// would have failed with nothing in its own configuration to explain why.
+//
+// So the sharing is now two decisions instead of one:
+//
+//	php/composer/shared_home   the global install — vendor/ and composer.json
+//	php/composer/shared_cache  the download cache
+//
+// Both default to true, which is exactly the behaviour described above: nothing
+// changes for anybody who does not ask. `shared_home=false` with
+// `shared_cache=true` is the combination worth having — each project gets its
+// own tools at its own versions, and downloads are still fetched once.
+
+// prepareProjectComposerDir puts the project's composer directory into the
+// shape the two settings ask for, and reports what it did in a line the caller
+// can print (empty when nothing needed doing).
+//
+// It never touches the global directory itself: what changes is only the entry
+// at projectDir — a symlink to the global home, or a real directory of the
+// project's own.
+func prepareProjectComposerDir(projectDir, globalDir string, sharedHome, sharedCache bool) (string, error) {
+	if sharedHome {
+		return linkToGlobal(projectDir, globalDir)
+	}
+	return isolateFromGlobal(projectDir, globalDir, sharedCache)
+}
+
+// linkToGlobal is the long-standing behaviour: the project directory IS the
+// global one, reached through a symlink.
+func linkToGlobal(projectDir, globalDir string) (string, error) {
+	fi, err := os.Lstat(projectDir)
+	if err != nil {
+		return "", os.Symlink(globalDir, projectDir)
+	}
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		return "", nil
+	}
+
+	// A real directory here is drift — normally it is the empty one madock
+	// itself has just created. When it is not empty, somebody or something put
+	// packages there, and they are about to go. Deleting them is still the
+	// right move (the invariant is that this path is a link), but doing it in
+	// silence is how "it reinstalled itself again" becomes a mystery.
+	notice := ""
+	if entries, readErr := os.ReadDir(projectDir); readErr == nil && len(entries) > 0 {
+		notice = fmt.Sprintf(
+			"composer: %s held %d entr(y/ies) of its own and has been replaced by the shared home at %s.\n"+
+				"  Set php/composer/shared_home=false to keep a composer home per project.",
+			projectDir, len(entries), globalDir)
+	}
+	if err := os.RemoveAll(projectDir); err != nil {
+		return "", err
+	}
+	return notice, os.Symlink(globalDir, projectDir)
+}
+
+// isolateFromGlobal gives the project a composer home of its own, optionally
+// keeping the download cache shared.
+//
+// Removing the symlink removes the link, never its target — os.Remove on a
+// symlink does not follow it. The global home, and every other project pointing
+// at it, are untouched.
+func isolateFromGlobal(projectDir, globalDir string, sharedCache bool) (string, error) {
+	notice := ""
+	fi, err := os.Lstat(projectDir)
+	switch {
+	case err != nil:
+		if mkErr := os.MkdirAll(projectDir, 0o777); mkErr != nil {
+			return "", mkErr
+		}
+	case fi.Mode()&os.ModeSymlink == os.ModeSymlink:
+		if rmErr := os.Remove(projectDir); rmErr != nil {
+			return "", rmErr
+		}
+		if mkErr := os.MkdirAll(projectDir, 0o777); mkErr != nil {
+			return "", mkErr
+		}
+		// Worth saying out loud: the project starts with an empty composer home,
+		// so whatever was installed globally — `dep` above all — is installed
+		// again on the next container start, at this project's own version.
+		notice = fmt.Sprintf(
+			"composer: %s no longer points at the shared home. Globally installed tools\n"+
+				"  will be reinstalled here, at the versions this project asks for.", projectDir)
+	}
+
+	cache := filepath.Join(projectDir, "cache")
+	if !sharedCache {
+		return notice, nil
+	}
+	// The half worth keeping shared. A link one level down, so the project owns
+	// composer.json and vendor/ while downloads are still fetched once per
+	// machine.
+	if cfi, cerr := os.Lstat(cache); cerr == nil {
+		if cfi.Mode()&os.ModeSymlink == os.ModeSymlink {
+			return notice, nil
+		}
+		// A real cache directory of its own: leave it. It is a cache, it costs
+		// disk and nothing else, and deleting somebody's files to save space is
+		// not this function's decision to make.
+		return notice, nil
+	}
+	if err := os.MkdirAll(projectDir, 0o777); err != nil {
+		return notice, err
+	}
+	return notice, os.Symlink(filepath.Join(globalDir, "cache"), cache)
+}

--- a/src/helper/docker/composer_home_test.go
+++ b/src/helper/docker/composer_home_test.go
@@ -1,0 +1,197 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The cases here are about what is left on disk, not about a boolean, because
+// the failure this guards is a layout: a project that believes it pins its own
+// tool versions while running somebody else's.
+//
+// The one that must never regress is `isolate keeps the global home`: the
+// project entry is a symlink, and removing a symlink must remove the link and
+// not walk into it. Getting that wrong deletes the machine's composer home —
+// every project's packages at once — while the code reads as if it tidied one
+// project.
+
+func lstatMode(t *testing.T, path string) os.FileMode {
+	t.Helper()
+	fi, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", path, err)
+	}
+	return fi.Mode()
+}
+
+func newGlobalHome(t *testing.T) string {
+	t.Helper()
+	global := filepath.Join(t.TempDir(), "global-composer")
+	if err := os.MkdirAll(filepath.Join(global, "cache"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+	// The two things the global home holds, so a test can tell them apart.
+	if err := os.WriteFile(filepath.Join(global, "composer.json"), []byte(`{"require":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(global, "cache", "package.zip"), []byte("cached"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return global
+}
+
+func TestSharedHomeLinksToTheGlobalDirectory(t *testing.T) {
+	global := newGlobalHome(t)
+	project := filepath.Join(t.TempDir(), "composer")
+
+	notice, err := prepareProjectComposerDir(project, global, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notice != "" {
+		t.Errorf("a first link is routine and should say nothing, got %q", notice)
+	}
+	if lstatMode(t, project)&os.ModeSymlink == 0 {
+		t.Fatal("the project entry is not a symlink")
+	}
+	target, _ := os.Readlink(project)
+	if target != global {
+		t.Errorf("link points at %q, want %q", target, global)
+	}
+}
+
+func TestSharedHomeIsIdempotent(t *testing.T) {
+	global := newGlobalHome(t)
+	project := filepath.Join(t.TempDir(), "composer")
+
+	if _, err := prepareProjectComposerDir(project, global, true, true); err != nil {
+		t.Fatal(err)
+	}
+	notice, err := prepareProjectComposerDir(project, global, true, true)
+	if err != nil {
+		t.Fatalf("second run failed: %v", err)
+	}
+	if notice != "" {
+		t.Errorf("nothing changed, so nothing should be said: %q", notice)
+	}
+}
+
+// A real directory here is drift and is replaced — that is the long-standing
+// invariant. What is new is that it stops being silent when something was in
+// it, because "it reinstalled itself again" is otherwise unexplainable.
+func TestSharedHomeSaysWhenItReplacesSomethingNonEmpty(t *testing.T) {
+	global := newGlobalHome(t)
+	project := filepath.Join(t.TempDir(), "composer")
+	if err := os.MkdirAll(filepath.Join(project, "vendor"), 0o777); err != nil {
+		t.Fatal(err)
+	}
+
+	notice, err := prepareProjectComposerDir(project, global, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notice == "" {
+		t.Error("a non-empty directory was deleted without a word")
+	}
+	if !strings.Contains(notice, "shared_home=false") {
+		t.Errorf("the notice does not say how to keep a per-project home: %q", notice)
+	}
+	if lstatMode(t, project)&os.ModeSymlink == 0 {
+		t.Error("the entry should be a symlink after replacement")
+	}
+}
+
+func TestIsolateReplacesTheLinkWithARealDirectory(t *testing.T) {
+	global := newGlobalHome(t)
+	project := filepath.Join(t.TempDir(), "composer")
+	if _, err := prepareProjectComposerDir(project, global, true, true); err != nil {
+		t.Fatal(err)
+	}
+
+	notice, err := prepareProjectComposerDir(project, global, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if notice == "" {
+		t.Error("switching to a private home reinstalls global tools — that has to be said")
+	}
+	if lstatMode(t, project)&os.ModeSymlink != 0 {
+		t.Fatal("the project entry is still a symlink")
+	}
+	if fi, statErr := os.Stat(project); statErr != nil || !fi.IsDir() {
+		t.Fatalf("expected a real directory at %s", project)
+	}
+}
+
+// The whole point of the cheap half: downloads stay shared.
+func TestIsolateKeepsTheCacheShared(t *testing.T) {
+	global := newGlobalHome(t)
+	project := filepath.Join(t.TempDir(), "composer")
+
+	if _, err := prepareProjectComposerDir(project, global, false, true); err != nil {
+		t.Fatal(err)
+	}
+	cache := filepath.Join(project, "cache")
+	if lstatMode(t, cache)&os.ModeSymlink == 0 {
+		t.Fatal("the cache is not shared")
+	}
+	body, err := os.ReadFile(filepath.Join(cache, "package.zip"))
+	if err != nil || string(body) != "cached" {
+		t.Errorf("the shared cache is not reachable through the link: %v %q", err, body)
+	}
+}
+
+func TestIsolateWithPrivateCacheLinksNothing(t *testing.T) {
+	global := newGlobalHome(t)
+	project := filepath.Join(t.TempDir(), "composer")
+
+	if _, err := prepareProjectComposerDir(project, global, false, false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(filepath.Join(project, "cache")); !os.IsNotExist(err) {
+		t.Error("a private cache should be left for composer to create, not linked")
+	}
+}
+
+// The one that would be catastrophic and is invisible in a diff: os.Remove on a
+// symlink must remove the link. If it ever followed the link, the machine's
+// composer home — every project's packages — would go with it.
+func TestIsolateKeepsTheGlobalHomeIntact(t *testing.T) {
+	global := newGlobalHome(t)
+	project := filepath.Join(t.TempDir(), "composer")
+	if _, err := prepareProjectComposerDir(project, global, true, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := prepareProjectComposerDir(project, global, false, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(global, "composer.json")); err != nil {
+		t.Fatalf("the global composer.json is gone: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(global, "cache", "package.zip")); err != nil {
+		t.Fatalf("the global cache is gone: %v", err)
+	}
+}
+
+// Going back is a supported move — it is how somebody undoes the experiment.
+func TestIsolateThenShareAgain(t *testing.T) {
+	global := newGlobalHome(t)
+	project := filepath.Join(t.TempDir(), "composer")
+
+	if _, err := prepareProjectComposerDir(project, global, false, true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareProjectComposerDir(project, global, true, true); err != nil {
+		t.Fatal(err)
+	}
+	if lstatMode(t, project)&os.ModeSymlink == 0 {
+		t.Fatal("the project did not go back to the shared home")
+	}
+	if _, err := os.Stat(filepath.Join(global, "composer.json")); err != nil {
+		t.Fatalf("the global home did not survive the round trip: %v", err)
+	}
+}

--- a/src/helper/docker/docker.go
+++ b/src/helper/docker/docker.go
@@ -445,25 +445,25 @@ func upProjectWithBuild(projectName string, withChown bool, refresh bool) {
 	}
 
 	pp := paths.NewProjectPaths(projectName)
-	src := paths.MakeDirsByPath(pp.ComposerDir())
 
-	if fi, err := os.Lstat(src); err == nil {
-		if fi.Mode()&os.ModeSymlink != os.ModeSymlink {
-			err = os.RemoveAll(src)
-			if err == nil {
-				err = os.Symlink(composerGlobalDir+"/.composer", src)
-				if err != nil {
-					logger.Fatal(err)
-				}
-			} else {
-				fmt.Println(err)
-			}
-		}
-	} else {
-		err = os.Symlink(composerGlobalDir+"/.composer", src)
-		if err != nil {
-			logger.Fatal(err)
-		}
+	// Whether this project shares the machine's composer home, or keeps one of
+	// its own. Shared is the default and the behaviour madock has always had —
+	// see composer_home.go for what each half of the sharing costs.
+	//
+	// MakeDirsByPath is deliberately NOT called here any more: it created a
+	// real directory that the next few lines then deleted, which made the code
+	// read as though it were removing something a user had put there.
+	projectConf := configs2.GetProjectConfig(projectName)
+	sharedHome := !strings.EqualFold(projectConf["php/composer/shared_home"], "false")
+	sharedCache := !strings.EqualFold(projectConf["php/composer/shared_cache"], "false")
+
+	notice, composerErr := prepareProjectComposerDir(
+		pp.ComposerDir(), composerGlobalDir+"/.composer", sharedHome, sharedCache)
+	if composerErr != nil {
+		logger.Fatal(composerErr)
+	}
+	if notice != "" {
+		fmt.Println(notice)
 	}
 
 	sshDir := pp.SSHDir()
@@ -510,8 +510,6 @@ func upProjectWithBuild(projectName string, withChown bool, refresh bool) {
 	if err != nil {
 		logger.Fatal(err)
 	}
-
-	projectConf := configs2.GetProjectConfig(projectName)
 
 	if val, ok := projectConf["cron/enabled"]; ok && val == "true" {
 		CronExecute(projectName, true, false)


### PR DESCRIPTION
Every project's composer home has always been one shared directory. That shares the download cache — worth having — and the global install, which is not: anything installed with `composer global require` from one project's container is the version every other project runs.

**Measured on a production host.** madock-pro pins the Deployer version per project and writes it into each compose file. Moving one project from `^7` to `^8` moved all seven: the version reported inside a container whose own compose line read `deployer/deployer:^7` was 8.0.5. One of those projects carried a deploy recipe that only parses under v7, so its next deploy would have failed with nothing in its own configuration to explain why.

## What this adds

`php/composer/shared_home` and `php/composer/shared_cache`, both `true` by default — the behaviour madock has always had. `shared_home=false` with `shared_cache=true` is the combination worth having: a project gets its own tools at its own versions, downloads are still fetched once.

## Two fixes on the way past

- the project composer directory was created and then deleted a line later, which made the code read as though it were removing something a user had put there;
- replacing a **non-empty** directory now says so. It is still replaced — the invariant is that the path is a link — but silence is how "it reinstalled itself again" becomes unexplainable.

## Tests

`src/helper/docker/composer_home_test.go`, 8 cases over real temp directories. The one that matters most: removing the symlink must remove the link and not walk into it — following it would delete the machine's composer home, every project's packages at once, while the code reads as if it tidied one project.