### PR TITLE
start: a leftover container is not a failed service

### DIFF
--- a/src/controller/general/start/start.go
+++ b/src/controller/general/start/start.go
@@ -2,6 +2,7 @@ package start
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/faradey/madock/v4/src/command"
@@ -52,7 +53,24 @@ func ExecuteWith(args *arg_struct.ControllerGeneralStart) {
 		// "up" returning zero only says the containers were created. Report a
 		// service whose main process is already gone instead of claiming
 		// success and leaving the reason in a log nobody has been told to read.
-		if dead := docker.NotRunning(projectName); len(dead) > 0 {
+		dead, orphans := docker.NotRunningAndOrphans(projectName)
+
+		// A leftover is not a failure and must not be reported as one. It is a
+		// container from a service the stack no longer declares — switching
+		// `nginx/enabled` off leaves one behind — and it keeps the compose
+		// project label, so `ps -a` goes on listing it after the service is
+		// gone. Said as "nginx — exited" it accuses a service that this project
+		// does not have, on every start, while `status` does not list it at all.
+		if len(orphans) > 0 {
+			names := make([]string, 0, len(orphans))
+			for _, service := range orphans {
+				names = append(names, service.Service)
+			}
+			fmtc.WarningIconLn("Left over from a service this project no longer has: " + strings.Join(names, ", "))
+			fmtc.ToDoLn("madock rebuild   # recreates the stack and clears them")
+		}
+
+		if len(dead) > 0 {
 			fmtc.WarningIconLn(fmt.Sprintf("Containers started in %s, but some are not running:", elapsed))
 			for _, service := range dead {
 				line := "  " + service.Service + " — " + service.State

--- a/src/helper/docker/docker.go
+++ b/src/helper/docker/docker.go
@@ -178,20 +178,85 @@ func HasContainers(projectName string) bool {
 // somebody read the log there was nothing to go on: start said success and
 // status, asked in between, honestly said running.
 func NotRunning(projectName string) []ServiceState {
+	dead, _ := NotRunningAndOrphans(projectName)
+	return dead
+}
+
+// NotRunningAndOrphans splits what `docker compose ps -a` returns into the two
+// things it mixes: services of this stack that are not running, and containers
+// left over from services the stack no longer declares.
+//
+// `ps -a` lists containers by compose project label, and a label outlives the
+// service. Turn a service off — `nginx/enabled=false` on a project with no web
+// surface, say — and its container stays behind, exited, wearing the label for
+// ever. Reported as "nginx — exited" it reads as a service that failed to
+// start, on every single start, while `status` (which reads the compose file)
+// does not list nginx at all. Two commands then disagree about a service that
+// does not exist, and the one raising the alarm is the one that is wrong.
+//
+// Found on a project with `nginx/enabled=false` and no web surface at all, so
+// the warning could never be anything but noise there.
+//
+// The classification needs to know what the stack declares. When that cannot be
+// established, everything is reported as before — a check that cannot tell must
+// not invent a new category, and the old behaviour is the safe one.
+func NotRunningAndOrphans(projectName string) (dead []ServiceState, orphans []ServiceState) {
 	entries, err := ServiceStates(projectName)
 	if err != nil {
 		// Nothing to report rather than a false alarm: a docker that cannot be
 		// asked is not evidence that a service died.
+		return nil, nil
+	}
+	return classifyStates(entries, DeclaredServices(projectName))
+}
+
+// classifyStates is the decision on its own: which stopped containers belong to
+// the stack and which are left over from a service it no longer has.
+//
+// declared == nil means "could not be established", and then nothing is called
+// an orphan.
+func classifyStates(entries []ServiceState, declared map[string]bool) (dead []ServiceState, orphans []ServiceState) {
+	for _, entry := range entries {
+		if entry.State == "running" || entry.State == "restarting" {
+			continue
+		}
+		if declared != nil && !declared[entry.Service] {
+			orphans = append(orphans, entry)
+			continue
+		}
+		dead = append(dead, entry)
+	}
+	return dead, orphans
+}
+
+// DeclaredServices returns the services this project's compose files define, or
+// nil when docker cannot be asked.
+//
+// It asks compose rather than reading the YAML: an override file may add a
+// service, and a service present only there would otherwise be mistaken for a
+// leftover — the exact error this function exists to prevent, made by the code
+// meant to catch it.
+func DeclaredServices(projectName string) map[string]bool {
+	pp := paths.NewProjectPaths(projectName)
+	composeFile := pp.DockerCompose()
+	if !paths.IsFileExist(composeFile) {
 		return nil
 	}
-
-	var dead []ServiceState
-	for _, entry := range entries {
-		if entry.State != "running" && entry.State != "restarting" {
-			dead = append(dead, entry)
+	out, err := exec.Command("docker", "compose", "-f", composeFile, "-f", pp.DockerComposeOverride(),
+		"config", "--services").Output()
+	if err != nil {
+		return nil
+	}
+	declared := make(map[string]bool)
+	for _, line := range strings.Split(string(out), "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			declared[name] = true
 		}
 	}
-	return dead
+	if len(declared) == 0 {
+		return nil
+	}
+	return declared
 }
 
 // parseComposePS reads `docker compose ps --format json` in both shapes it

--- a/src/helper/docker/orphan_states_test.go
+++ b/src/helper/docker/orphan_states_test.go
@@ -1,0 +1,117 @@
+package docker
+
+import "testing"
+
+// What is guarded here is a report, not a container: `docker compose ps -a`
+// lists by project label, and a label outlives the service it was put on. The
+// old code called every stopped container a service that failed to start, so a
+// project with `nginx/enabled=false` was told on every single start that its
+// nginx had exited — a service `status` does not list, because status reads the
+// compose file and the warning read docker.
+//
+// The second half matters as much: when the declared set cannot be established
+// nothing may be called a leftover. A check that cannot tell must fall back to
+// what it did before rather than invent a category.
+
+func states(pairs ...[2]string) []ServiceState {
+	out := make([]ServiceState, 0, len(pairs))
+	for _, p := range pairs {
+		out = append(out, ServiceState{Service: p[0], State: p[1]})
+	}
+	return out
+}
+
+func names(entries []ServiceState) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Service)
+	}
+	return out
+}
+
+func equal(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestStoppedContainerOfADeclaredServiceIsAFailure(t *testing.T) {
+	dead, orphans := classifyStates(
+		states([2]string{"db", "running"}, [2]string{"php", "exited"}),
+		map[string]bool{"db": true, "php": true},
+	)
+	if !equal(names(dead), []string{"php"}) {
+		t.Errorf("dead = %v, want [php]", names(dead))
+	}
+	if len(orphans) != 0 {
+		t.Errorf("nothing here is a leftover, got %v", names(orphans))
+	}
+}
+
+func TestStoppedContainerOfAGoneServiceIsALeftover(t *testing.T) {
+	dead, orphans := classifyStates(
+		states([2]string{"db", "running"}, [2]string{"nodejs", "running"}, [2]string{"nginx", "exited"}),
+		map[string]bool{"db": true, "nodejs": true},
+	)
+	if len(dead) != 0 {
+		t.Errorf("a service the stack does not declare cannot have failed to start: %v", names(dead))
+	}
+	if !equal(names(orphans), []string{"nginx"}) {
+		t.Errorf("orphans = %v, want [nginx]", names(orphans))
+	}
+}
+
+func TestBothAtOnceAreReportedSeparately(t *testing.T) {
+	dead, orphans := classifyStates(
+		states([2]string{"php", "exited"}, [2]string{"nginx", "exited"}),
+		map[string]bool{"php": true},
+	)
+	if !equal(names(dead), []string{"php"}) {
+		t.Errorf("dead = %v, want [php]", names(dead))
+	}
+	if !equal(names(orphans), []string{"nginx"}) {
+		t.Errorf("orphans = %v, want [nginx]", names(orphans))
+	}
+}
+
+// The fallback. nil means the question could not be answered — docker silent,
+// compose file unreadable — and then the report is exactly what it was before
+// this change.
+func TestUnknownDeclaredSetCallsNothingALeftover(t *testing.T) {
+	dead, orphans := classifyStates(
+		states([2]string{"nginx", "exited"}, [2]string{"php", "exited"}),
+		nil,
+	)
+	if !equal(names(dead), []string{"nginx", "php"}) {
+		t.Errorf("dead = %v, want both", names(dead))
+	}
+	if len(orphans) != 0 {
+		t.Errorf("nothing may be called a leftover without knowing the stack: %v", names(orphans))
+	}
+}
+
+func TestRestartingCountsAsAlive(t *testing.T) {
+	dead, orphans := classifyStates(
+		states([2]string{"php", "restarting"}),
+		map[string]bool{"php": true},
+	)
+	if len(dead) != 0 || len(orphans) != 0 {
+		t.Errorf("a restarting container is not a failure: dead=%v orphans=%v", names(dead), names(orphans))
+	}
+}
+
+func TestEverythingRunningReportsNothing(t *testing.T) {
+	dead, orphans := classifyStates(
+		states([2]string{"db", "running"}, [2]string{"php", "running"}),
+		map[string]bool{"db": true, "php": true},
+	)
+	if len(dead) != 0 || len(orphans) != 0 {
+		t.Errorf("a healthy project must produce no lines at all: dead=%v orphans=%v", names(dead), names(orphans))
+	}
+}


### PR DESCRIPTION
Reported from a project with `nginx/enabled=false` and no web surface: every `start`/`restart` warned `nginx — exited`, while `status` did not list nginx at all. The generated stack has no nginx service; the container is a leftover from when it did, still carrying the project label.

The start summary asked for the project's containers including stopped ones, so it saw the leftover and reported it as a service that had failed to start. Two commands disagreed about a service that does not exist, and the one raising the alarm was the wrong one.

## What changes

Leftovers are separated from failures and reported as what they are, with the cure:

    ⚠ Left over from a service this project no longer has: nginx
      madock rebuild   # recreates the stack and clears them

A genuinely dead service is reported exactly as before.

## Two details that decide whether the fix is safe

- the declared set is **asked of the stack generator**, not read out of the generated file. An override file may add a service, and a service present only there would otherwise be called a leftover — the very mistake this exists to catch;
- when the set cannot be established (the daemon does not answer, the file is unreadable) **nothing** is called a leftover and the output is what it was before. A check that cannot tell must not invent a category.

## Tests

`src/helper/docker/orphan_states_test.go` — six cases on the classification, including the fallback and `restarting` counting as alive.
