### PR TITLE
release: publish SHA256SUMS beside the binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,20 @@ jobs:
               go build -trimpath -ldflags="-s -w" -o "dist/${out}${ext}"
           done
 
+      # Answers "did I download what they published" for every platform at once,
+      # including the ones that will never be signed. It is not a signature: it
+      # proves the file matches this page, not who built it. Cheap enough that
+      # the absence was never a decision, only an omission.
+      #
+      # Written from inside dist/ so the file lists bare names — `shasum -c
+      # SHA256SUMS` then works wherever the user unpacked them — and generated
+      # before the checksum file exists, so it never tries to hash itself.
+      - name: Checksums
+        run: |
+          cd dist
+          shasum -a 256 * > SHA256SUMS
+          cat SHA256SUMS
+
       - name: Generate changelog
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ Each release ships a single self-contained binary on the [Releases page](https:/
 | Linux ARM | `madock-linux-arm64` |
 | Windows (via WSL2) | `madock-linux-amd64` |
 
+Every release also ships `SHA256SUMS`. To check the file you downloaded is the file that was published:
+
+```shell
+# from the directory holding the binary and SHA256SUMS
+shasum -a 256 --ignore-missing -c SHA256SUMS
+```
+
+It answers "is this the published file", not "who built it" — the second question needs a signature, which these binaries do not yet carry.
+
 > **Important:** the binary keeps its working data (`docker/`, `scripts/`, `projects/`, `aruntime/`) **next to itself** — these are auto-extracted on first run. Put the binary in a **dedicated, writable folder** (e.g. `~/.madock/`) and add it to your `PATH` via a symlink. Do **not** drop the real file straight into a system directory like `/opt/homebrew/bin` or `/usr/local/bin` — only the symlink goes there.
 
 <details>


### PR DESCRIPTION
First step of the signing plan, and the one that needs no keys.

A release page and a copy of it look identical: nothing published so far let anyone tell the file we built from a file somebody else put there. A checksum answers half of that — "is this the file that was published" — for every platform at once, including Linux and Windows, which will never carry an Apple signature.

## What changes

`SHA256SUMS` is generated after the build and uploaded with the binaries. Two details that decide whether it is usable:

- generated from **inside** `dist/`, so the list holds bare filenames and `shasum -c SHA256SUMS` works wherever the user unpacked them;
- generated **before** the file exists, so it never hashes itself.

The README gains the verification command with its limit stated plainly: this says nothing about **who** built the binary. That question needs a signature, and it is the next piece of work rather than something this quietly implies.

## What it does not do

It does not remove the `xattr -dr com.apple.quarantine` step from the macOS instructions. That step exists because the binaries are not notarised, and only notarisation removes it.
