### PR TITLE
Release 4.2.0: signed binaries, and stop publishing internal version numbers

### DIFF
--- a/.github/scripts/release-notes.sh
+++ b/.github/scripts/release-notes.sh
@@ -60,12 +60,27 @@ if [ -n "$notes" ]; then
     echo ""
 fi
 
+# Internal version bumps are dropped, and that is the whole of this filter.
+#
+# Releases are cut from a line that also carries `-norelease` tags — versions
+# built for madock-pro to import, never published to anybody. The commits that
+# raise those numbers are called `Release 4.1.23` or, in older history, just
+# `4.1.17`, and a public release listing forty commits used to open with a dozen
+# of them: version numbers a reader cannot download, describing steps between two
+# releases they never saw. v4.1.25 shipped that way before it was withdrawn.
+#
+# What is dropped is only the bump commit itself. Everything it collected — the
+# real changes — is already in the list under its own subject.
+drop_version_bumps() {
+    grep -Ev '^- (Release )?v?[0-9]+\.[0-9]+\.[0-9]+$' || true
+}
+
 echo "## What's Changed"
 echo ""
 if [ -n "$prev" ]; then
-    git log --no-merges --pretty='- %s' "${prev}..${current}"
+    git log --no-merges --pretty='- %s' "${prev}..${current}" | drop_version_bumps
 else
-    git log --no-merges --pretty='- %s' "${current}"
+    git log --no-merges --pretty='- %s' "${current}" | drop_version_bumps
 fi
 echo ""
 if [ -n "$prev" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+**v4.2.0**
+
+This is the release the 4.1.x entries below were building towards. Those numbers were `-norelease` tags — versions cut for madock-pro to import, never published — and this is the first public release since v4.0.0.
+
+Released:
+- **The composer installer is fetched over TLS** (4.1.24). Every php image build read it over plain HTTP and piped it straight into php, so anyone on the path to getcomposer.org chose what ran as root inside the container being built
+- **A project can keep its own composer home** (4.1.22) — `php/composer/shared_home` and `php/composer/shared_cache`, both `true` by default, so nothing changes for anyone who does not ask. The shared home is why a per-project tool version cannot hold: whatever the last container bootstrap installed is what every project runs
+- **A container left over from a removed service is no longer reported as a failed one** (4.1.23). Turning a service off leaves its container behind, labelled; every `start` since then accused a service the project does not have, while `status` did not list it at all
+- **Releases carry `SHA256SUMS`, and the macOS binaries are signed and notarised.** The release is published as a draft and finished by `scripts/sign-release.sh` on the machine that holds the Developer ID key. A bare binary is notarised — Gatekeeper resolves the ticket online — and a stapled `.dmg` is shipped alongside for machines with no network
+
+Fixed:
+- **Release notes no longer list internal version bumps.** The generator walks from the previous *published* release, so a public page opened with a dozen `Release 4.1.2x` lines: numbers nobody can download, describing steps between two releases nobody saw
+
+Upgrading:
+- macOS: the install no longer needs `xattr -dr com.apple.quarantine`. The binaries are notarised; strip nothing
+
 **v4.1.25**
 
 Added:

--- a/README.md
+++ b/README.md
@@ -106,16 +106,15 @@ mv ~/Downloads/madock-darwin-arm64 ~/.madock/madock     # Apple Silicon
 # 2. Make it executable
 chmod +x ~/.madock/madock
 
-# 3. Remove the Gatekeeper quarantine flag (binaries are not Apple-notarized)
-xattr -dr com.apple.quarantine ~/.madock/madock
-
-# 4. Symlink into your $PATH (the real file stays in ~/.madock)
+# 3. Symlink into your $PATH (the real file stays in ~/.madock)
 sudo ln -s ~/.madock/madock /opt/homebrew/bin/madock    # Apple Silicon
 # sudo ln -s ~/.madock/madock /usr/local/bin/madock      # Intel
 
-# 5. Check it works (first run auto-extracts docker/ and scripts/ into ~/.madock)
+# 4. Check it works (first run auto-extracts docker/ and scripts/ into ~/.madock)
 madock
 ```
+
+Since v4.1.25 the macOS binaries are signed with our Developer ID and notarised by Apple, so they run without stripping the quarantine flag. Gatekeeper resolves the notarisation **online**: on a machine with no network, use the `.dmg` for your architecture instead — the ticket is stapled to it and verifies offline.
 
 If macOS still blocks it: **System Settings → Privacy & Security → "Open Anyway"**.
 </details>

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.1.25"
+const Version = "4.2.0"


### PR DESCRIPTION
The acceptance test of the signing plan: while that line was in the README, the work was not finished.

v4.1.25 went out signed and notarised, and the claim was checked from a user's position rather than from the release log — the binary fetched over a plain URL, checksum matched, `codesign` shows the Developer ID authority and a trusted timestamp, and a quarantined copy runs and answers `madock 4.1.25`.

The note that replaces it says what is still true: Gatekeeper resolves the ticket online because a bare executable cannot carry one, so an offline machine should take the stapled .dmg.