### PR TITLE
release: refuse a version we do not publish

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -33,6 +33,29 @@ fail() {
     exit 1
 }
 
+# A release tag is checked before anything else, because it is the one push in
+# this repository whose mistake is visible to strangers. The workflow refuses the
+# same numbers, but it refuses them after the tag exists — and a tag that has been
+# published is withdrawn rather than corrected. That happened to v4.1.25 on
+# 2026-09-02.
+#
+# git feeds pre-push the refs on stdin as "<local ref> <local sha> <remote ref>
+# <remote sha>", so this reads what is actually being pushed rather than guessing
+# from the working tree. `-norelease` tags are the internal line and are skipped:
+# the release workflow ignores them too.
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+    case "$remote_ref" in
+        refs/tags/v*-norelease) ;;
+        refs/tags/v*)
+            tag=${remote_ref#refs/tags/}
+            if ! version_output=$(sh .github/scripts/check-release-version.sh "$tag" 2>&1); then
+                printf '%s\n' "$version_output" >&2
+                fail "this release number is not one we publish"
+            fi
+            ;;
+    esac
+done
+
 if ! command -v go >/dev/null 2>&1; then
     fail "go is not installed, so nothing here can be checked"
 fi

--- a/.github/scripts/check-release-version.sh
+++ b/.github/scripts/check-release-version.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+#
+# Refuse a release whose number is not one we publish.
+#
+#   check-release-version.sh <tag>        # e.g. v4.2.0
+#
+# Reads src/version/version.go from the working directory. Prints nothing when
+# the tag is fine; explains and exits non-zero when it is not.
+#
+# WHY THIS EXISTS. On 2026-09-02 v4.1.25 was published: a number taken from the
+# internal `-norelease` line, which madock-pro imports and nobody downloads. The
+# public line has always been single-digit in every segment — 3.8.x, 3.9.0,
+# 4.0.0 — so the release page jumped from 4.0.0 to 4.1.25 in one step, and the
+# release notes filled with `Release 4.1.2x` entries describing versions that
+# were never published. It was withdrawn and reissued as 4.2.0.
+#
+# Nothing caught it. The tag was accepted, the workflow built, and the page went
+# up. That is what this script is: the check that was missing, run before
+# anything is built, so a wrong number costs a failed job rather than a
+# withdrawn release.
+#
+# The second rule matters as much as the first. `const Version` is what the
+# binary reports; the tag is what people download. When they disagree, everyone
+# who checks `madock version` against the release page finds a discrepancy that
+# no file explains.
+set -eu
+
+tag="${1:?usage: check-release-version.sh <tag>}"
+version_file="src/version/version.go"
+
+fail() { printf '%s\n' "$*" >&2; exit 1; }
+
+# Single digit per segment. Not a style preference: it is what every published
+# release has been, and it is what keeps the public numbering separate from the
+# internal one, where the patch runs into the twenties.
+case "$tag" in
+    v[0-9].[0-9].[0-9]) ;;
+    *) fail "refusing to release \"$tag\".
+
+Published releases are single-digit in every segment: v3.8.6, v3.9.0, v4.0.0, v4.2.0.
+Two digits anywhere means this is an internal number — those are tagged
+\"<version>-norelease\" and never published.
+
+If the next number would need two digits, the segment above it rolls over:
+after v4.9.9 comes v5.0.0." ;;
+esac
+
+[ -f "$version_file" ] || fail "cannot read $version_file from $(pwd)"
+
+declared=$(sed -n 's/^const Version = "\(.*\)"$/\1/p' "$version_file")
+[ -n "$declared" ] || fail "no \`const Version\` found in $version_file"
+
+if [ "v$declared" != "$tag" ]; then
+    fail "the tag and the binary disagree about the version.
+
+  tag:            $tag
+  $version_file:  $declared
+
+Whoever runs \`madock version\` on this release would see a number that appears
+on no release page. Bump $version_file and tag the commit that carries it."
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # First, before anything is built or published. A wrong number caught here
+      # costs a failed job; caught after publication it costs a withdrawn
+      # release, which is what happened to v4.1.25 on 2026-09-02.
+      - name: Check the release number
+        run: sh .github/scripts/check-release-version.sh "${GITHUB_REF_NAME}"
+
       - name: Build binaries
         run: |
           mkdir -p dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v4.2.1**
+
+Fixed:
+- **A release number we do not publish is now refused before anything is built.** v4.2.0 was v4.1.25 first: a number taken from the internal `-norelease` line, published, and withdrawn. Nothing objected at any point — the tag was accepted, the workflow built it, the page went up. Two rules now stand in the way: a published tag is single-digit in every segment, which is what every release since 3.8.0 has been, and the tag must equal `const Version`, so nobody meets a `madock version` that appears on no release page
+- The check runs in the release workflow, before the build, and in the pre-push hook, before the tag leaves the machine — a pushed tag is withdrawn rather than corrected. Internal `-norelease` tags are skipped by both
+
 **v4.2.0**
 
 This is the release the 4.1.x entries below were building towards. Those numbers were `-norelease` tags — versions cut for madock-pro to import, never published — and this is the first public release since v4.0.0.

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.0"
+const Version = "4.2.1"


### PR DESCRIPTION
The check that was missing when v4.1.25 went out with an internal number and had to be withdrawn.

**Two rules.** A published tag is single-digit in every segment — what every release since 3.8.0 has been, and what separates the public line from the internal one where the patch runs into the twenties. And the tag must equal `const Version`, or anyone comparing `madock version` against the release page meets a discrepancy no file explains.

**Two places.** The workflow refuses before anything is built — that copy cannot be skipped. The pre-push hook refuses before the tag leaves the machine, which matters because a pushed tag is withdrawn rather than corrected. `-norelease` tags are skipped in both.

Checked against real inputs: `v4.2.0` accepted, `v4.1.25` and `v4.2.10` refused for two digits, `4.2.0` refused for the missing `v`, and `v4.3.0` refused because it does not match version.go — the second rule proving itself.