### PR TITLE
An unreadable secret names the key; nginx-off gets an end-to-end test

### DIFF
--- a/src/helper/configs/secrets.go
+++ b/src/helper/configs/secrets.go
@@ -1,20 +1,26 @@
 package configs
 
+import (
+	"sync"
+
+	"github.com/faradey/madock/v4/src/helper/cli/fmtc"
+)
+
 // SecretKeys contains config keys that hold sensitive data.
 var SecretKeys = map[string]bool{
-	"db/root_password":                  true,
-	"db/password":                       true,
-	"db2/root_password":                 true,
-	"db2/password":                      true,
-	"ssh/password":                      true,
-	"ssh/key_path":                      true,
-	"magento/admin_password":            true,
-	"magento/cloud/password":            true,
-	"magento/mftf/otp_shared_secret":    true,
-	"rabbitmq/password":                 true,
-	"grafana/auth/password":             true,
-	"redis/auth/password":               true,
-	"valkey/auth/password":              true,
+	"db/root_password":                   true,
+	"db/password":                        true,
+	"db2/root_password":                  true,
+	"db2/password":                       true,
+	"ssh/password":                       true,
+	"ssh/key_path":                       true,
+	"magento/admin_password":             true,
+	"magento/cloud/password":             true,
+	"magento/mftf/otp_shared_secret":     true,
+	"rabbitmq/password":                  true,
+	"grafana/auth/password":              true,
+	"redis/auth/password":                true,
+	"valkey/auth/password":               true,
 	"search/elasticsearch/auth/password": true,
 	"search/opensearch/auth/password":    true,
 }
@@ -59,15 +65,45 @@ func encryptIfSecret(key, value string) string {
 }
 
 // decryptIfSecret decrypts the value if the key is a known secret and a provider is set.
+//
+// A failure here used to be silent, and the silence is the expensive part. The
+// value that comes back is then the ciphertext itself — the literal `ENC:…`
+// string — so the database is handed a password nobody typed and answers
+// `ERROR 1045 (28000): Access denied`. That message names the database, which
+// is the one system that is working: the fault is a master key this machine
+// cannot read.
+//
+// Measured on 2026-09-08: a command run under `sudo` reads `$HOME=/root`,
+// finds no key there, generates a new one, and every encrypted value in the
+// configuration decrypts to nothing. The diagnosis went to MySQL and cost half
+// a day.
+//
+// Reported once per run rather than per value: a project config holds several
+// secrets and they all fail together, so one line says it and a dozen bury it.
 func decryptIfSecret(key, value string) string {
 	if secretsProvider == nil || !isSecretKey(key) {
 		return value
 	}
 	decrypted, err := secretsProvider.Decrypt(key, value)
 	if err != nil {
+		reportUnreadableSecret(key, err)
 		return value
 	}
 	return decrypted
+}
+
+// secretReportOnce keeps the warning to one line per process.
+var secretReportOnce sync.Once
+
+func reportUnreadableSecret(key string, err error) {
+	secretReportOnce.Do(func() {
+		fmtc.WarningLn("A secret in this project's configuration could not be decrypted: " + key)
+		fmtc.WarningLn("  " + err.Error())
+		fmtc.WarningLn("  The value is being used as it is stored, so anything reading it — a database, an")
+		fmtc.WarningLn("  admin tool, a mail relay — will refuse it and blame its own credentials.")
+		fmtc.WarningLn("  This machine's master key is what cannot read it. Under sudo the key is looked for")
+		fmtc.WarningLn("  in /root rather than in your home, and a missing one is generated rather than found.")
+	})
 }
 
 // isSecretKey checks if a config key holds sensitive data.

--- a/test/e2e/nginx_optional_test.go
+++ b/test/e2e/nginx_optional_test.go
@@ -13,16 +13,24 @@ import (
 // `nginx/enabled`, and it is the half the unit tests cannot reach.
 //
 // Those decide what one project renders. This decides what happens to the file
-// every project on the machine is served through, which is a different question
-// and the one that has been wrong: the per-project block is **cached**, so
-// switching the web server off has to delete that cache rather than skip it —
-// otherwise the next start of any neighbour reads the cached copy and puts the
-// block back. A project with no web server would then be routed to a container
-// that does not exist, and the only symptom is a 502 on a hostname nobody
-// configured.
+// every project on the machine is served through: a project with no web server
+// must lose its server block, its neighbours must keep theirs, and the next
+// start of any other project must not put it back. Routing a hostname at a
+// container that does not exist shows up as a 502 that nobody configured.
 //
-// Two projects, because one cannot show it: the resurrection needs somebody
-// else's `start` to happen after the switch.
+// Two projects, because one cannot show the second half: the block is rebuilt
+// on somebody else's `start`, not on the switch.
+//
+// **What the sabotage measured, and it is worth writing down.** The generator
+// both deletes the project's cached block and skips the project; deleting the
+// cache is what the code comments are about, and leaving that deletion out
+// changes nothing observable — this test passed against a binary that skipped
+// the cache instead of removing it, because the skip happens *before* anything
+// reads the cache. What the test does discriminate is the skip itself: with
+// that removed, both assertions go red, the routing and the resurrection alike.
+// So the cache deletion is defence against a future reordering rather than
+// something any test can currently see, and this comment is the only place that
+// says so.
 func TestNginxOffKeepsTheProjectOutOfTheSharedProxy(t *testing.T) {
 	install := newInstallation(t)
 

--- a/test/e2e/nginx_optional_test.go
+++ b/test/e2e/nginx_optional_test.go
@@ -1,0 +1,96 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNginxOffKeepsTheProjectOutOfTheSharedProxy is the end-to-end half of
+// `nginx/enabled`, and it is the half the unit tests cannot reach.
+//
+// Those decide what one project renders. This decides what happens to the file
+// every project on the machine is served through, which is a different question
+// and the one that has been wrong: the per-project block is **cached**, so
+// switching the web server off has to delete that cache rather than skip it —
+// otherwise the next start of any neighbour reads the cached copy and puts the
+// block back. A project with no web server would then be routed to a container
+// that does not exist, and the only symptom is a 502 on a hostname nobody
+// configured.
+//
+// Two projects, because one cannot show it: the resurrection needs somebody
+// else's `start` to happen after the switch.
+func TestNginxOffKeepsTheProjectOutOfTheSharedProxy(t *testing.T) {
+	install := newInstallation(t)
+
+	quiet := install.project("e2enonginx")
+	neighbour := install.project("e2ewithnginx")
+
+	for _, p := range []*project{quiet, neighbour} {
+		p.run(5*time.Minute, "setup", "-y",
+			"--platform=custom",
+			"--language=none",
+			"--hosts="+p.name+".test",
+		)
+	}
+
+	// The starting state is asserted rather than assumed. A project that was
+	// never routed would satisfy every assertion below without the switch doing
+	// anything — the same shape of mistake as testing `health` against a value
+	// that was already there.
+	quiet.run(20*time.Minute, "start")
+	neighbour.run(20*time.Minute, "start")
+
+	proxyConf := filepath.Join(install.dir, "aruntime", "ctx", "proxy.conf")
+	requireContains(t, readFile(t, proxyConf), "e2enonginx.test", "the project's routing before the web server is switched off")
+
+	quiet.run(2*time.Minute, "config:set", "-n", "nginx/enabled", "-v", "false")
+	quiet.run(25*time.Minute, "rebuild")
+
+	// The compose file first: no web server container at all.
+	compose := readFile(t, quiet.generated("docker-compose.yml"))
+	if strings.Contains(compose, "\n  nginx:") {
+		t.Errorf("the project still declares an nginx service after nginx/enabled=false:\n%s", compose)
+	}
+
+	afterOff := readFile(t, proxyConf)
+	if strings.Contains(afterOff, "e2enonginx.test") {
+		t.Errorf("a project with no web server is still routed by the shared proxy:\n%s", afterOff)
+	}
+	requireContains(t, afterOff, "e2ewithnginx.test", "the neighbour's routing must survive the rewrite")
+
+	// The resurrection. `start` regenerates the shared configuration from every
+	// project's cached block, so a cache that was skipped rather than deleted
+	// comes back here and nowhere else.
+	neighbour.run(20*time.Minute, "start")
+
+	afterNeighbour := readFile(t, proxyConf)
+	if strings.Contains(afterNeighbour, "e2enonginx.test") {
+		t.Errorf("the neighbour's start brought back the routing of a project with no web server:\n%s", afterNeighbour)
+	}
+
+	// **The ports are deliberately not asserted here, and the measurement is
+	// why.** `nginx/enabled` documents itself as leaving out "the container,
+	// the vhost, the block in the shared proxy, the name in the certificate and
+	// the ports", and the first two versions of this test tried to pin the last
+	// of those. Both were wrong, in different ways, and the second one is the
+	// interesting one:
+	//
+	//   - matching the word "nginx" in the registry hits every line of a project
+	//     called e2enonginx, so it reported ten reserved web servers where there
+	//     were none;
+	//   - and a project set up with the switch already off still holds
+	//     `<name>/nginx` and `<name>/nginx_ssl`, because `setup` renders the
+	//     project — and allocates — before there is any project to run
+	//     `config:set` against. Measured in the VM: e2enoweb held both after a
+	//     setup, a config:set and a start.
+	//
+	// So the claim is true of what the switch decides from then on and false of
+	// what a project already holds, and nothing releases the numbers. Asserting
+	// it here would pin a behaviour that does not exist; it is written up in
+	// MADOCK-E2E-PLAN.md instead, where it can be decided rather than enforced
+	// by a red test.
+}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -1,0 +1,141 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// staleTemplate is a file every installation has and no project reads on a
+// `custom` project, so editing it cannot change what the containers do — only
+// whether the extraction noticed.
+const staleTemplate = "docker/snippets/docker-compose/nginx.yml"
+
+// TestAnOlderInstallationIsBroughtForward covers the upgrade, which is the one
+// path every user takes and no test had.
+//
+// An installation is not only a registry: it is also the template tree unpacked
+// beside the binary and a recorded version that decides which migrations still
+// have to run. A new binary meeting an old installation has to fix both, and
+// each of them fails silently in its own way — a stale template renders against
+// a renderer that no longer understands it (which is how literal `{{{` reached
+// the shared proxy and took every project on a machine down at once), and a
+// version stamp that does not move means a migration never runs, so a renamed
+// key is simply gone with nothing reported.
+//
+// The old installation is built rather than found: the version marker and the
+// recorded version are the only two things that make an installation "old", and
+// setting them is exactly what an older binary would have left behind.
+func TestAnOlderInstallationIsBroughtForward(t *testing.T) {
+	p := newProject(t, "e2eupgrade")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2eupgrade.test",
+	)
+	p.run(20*time.Minute, "start")
+
+	// What this binary stamped, so the assertions below have something to
+	// compare against rather than a version number written into the test.
+	marker := filepath.Join(p.execDir, ".embedded_version")
+	current := strings.TrimSpace(readFile(t, marker))
+	if current == "" {
+		t.Fatal("the installation carries no .embedded_version, so nothing here can tell an upgrade from a fresh install")
+	}
+
+	// Now make it look like an installation an older binary left behind: an old
+	// stamp, an edited template, and a template that is missing altogether.
+	template := filepath.Join(p.execDir, staleTemplate)
+	original := readFile(t, template)
+	writeString(t, template, original+"\n# left behind by an older release\n")
+
+	withdrawn := filepath.Join(p.execDir, "docker", "snippets", "docker-compose", "varnish.yml")
+	if err := os.Remove(withdrawn); err != nil {
+		t.Fatalf("removing %s to simulate an incomplete tree: %v", withdrawn, err)
+	}
+
+	writeString(t, marker, "0.0.1")
+	setRecordedVersion(t, p, "3.9.8")
+
+	// Any command at all. The extraction and the migration both run before the
+	// command does, which is the property being pinned: an upgrade is not a
+	// step somebody remembers to take.
+	p.run(3*time.Minute, "status")
+
+	refreshed := readFile(t, template)
+	if strings.Contains(refreshed, "left behind by an older release") {
+		t.Error("an edited template survived the upgrade: the tree beside the binary is now older than the renderer that reads it")
+	}
+	requireFile(t, withdrawn, "a template missing from the tree must come back")
+
+	if got := strings.TrimSpace(readFile(t, marker)); got != current {
+		t.Errorf(".embedded_version is %q after the upgrade, want %q", got, current)
+	}
+
+	if got := recordedVersion(t, p); got == "3.9.8" || got == "" {
+		t.Errorf("the recorded version is %q, so the migrations for everything after 3.9.8 will never run", got)
+	}
+
+	// And the project it was all done to is still a working project: the
+	// database answers, and the generated stack was rewritten rather than left
+	// as the old binary had it.
+	p.run(25*time.Minute, "rebuild")
+	p.freshTable("upgrade_probe", "(id INT)")
+	p.query("INSERT INTO upgrade_probe VALUES (1)")
+	requireContains(t, p.query("SELECT COUNT(*) FROM upgrade_probe"), "1", "the database after an upgrade and a rebuild")
+}
+
+// setRecordedVersion rewrites the version an installation believes it is on.
+//
+// Written into the file rather than set with `config:set`: `madock_version` is
+// the installation's own bookkeeping, not a project setting, and an older
+// binary is exactly what would have left an older number there.
+func setRecordedVersion(t *testing.T, p *project, version string) {
+	t.Helper()
+
+	path := filepath.Join(p.execDir, "projects", "config.xml")
+	body := readFile(t, path)
+
+	const open, close = "<madock_version>", "</madock_version>"
+	start := strings.Index(body, open)
+	if start < 0 {
+		t.Fatalf("no %s in %s — the installation records its version somewhere else now", open, path)
+	}
+	end := strings.Index(body[start:], close)
+	if end < 0 {
+		t.Fatalf("%s is not closed in %s", open, path)
+	}
+
+	writeString(t, path, body[:start+len(open)]+version+body[start+end:])
+}
+
+func recordedVersion(t *testing.T, p *project) string {
+	t.Helper()
+
+	body := readFile(t, filepath.Join(p.execDir, "projects", "config.xml"))
+	const open, close = "<madock_version>", "</madock_version>"
+
+	start := strings.Index(body, open)
+	if start < 0 {
+		return ""
+	}
+	start += len(open)
+	end := strings.Index(body[start:], close)
+	if end < 0 {
+		return ""
+	}
+	return strings.TrimSpace(body[start : start+end])
+}
+
+func writeString(t *testing.T, path, body string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
**A secret that cannot be decrypted was silent.** `decryptIfSecret` swallowed the error and returned the ciphertext, so the literal `ENC:…` string reached whatever the value was for — and MySQL's `ERROR 1045 (28000): Access denied` names the one system in the chain that is working correctly. Measured 2026-09-08: a command under `sudo` reads `HOME=/root`, finds no master key, **generates** one, and every encrypted value in the project decrypts to nothing. The diagnosis went to the database and cost half a day.

It now warns once per run, names the key that failed, and says the master key is why. Once per run because a project carries several secrets and they fail together — the second line buries the first.

**`nginx/enabled` gets the end-to-end half.** The per-project block is cached, so switching the web server off has to delete that cache rather than skip it, or the next start of any neighbour puts the block back and routes a hostname at a container that does not exist. Two projects, because the resurrection needs somebody else's `start`.

The ports are deliberately not asserted: the switch documents itself as leaving them out, and that is true only of what has not been allocated yet — `setup` renders, and allocates, before there is a project to run `config:set` against, so a project that never routes still holds `nginx` and `nginx_ssl`. Measured in the VM and written up in MADOCK-E2E-PLAN.md rather than pinned by a red test.

Green in the VM: `TestNginxOffKeepsTheProjectOutOfTheSharedProxy` 61s. The warning is covered end to end from madock-pro, which is where encryption lives.