### PR TITLE
nginx/enabled: which half of the ports claim is true

### DIFF
--- a/src/helper/configs/nginx.go
+++ b/src/helper/configs/nginx.go
@@ -13,6 +13,21 @@ package configs
 // it, because a project with no hosts gets loc.<name>.com invented for it — so
 // the block was renamed rather than removed, and the ports stayed reserved.
 //
+// **"The ports" is true of a project that ships with this off and false of one
+// switched off later, and the difference is not a bug.** The value is normally
+// committed in the project's own .madock/config.xml — extmag-core-shopify is
+// the case — and that file is read before the first render, so nothing ever
+// asks for a web port. `config:set nginx/enabled false` on a running project
+// arrives after `setup` has rendered and allocated, and nothing hands a number
+// back except `project:remove`. Both paths are measured in
+// test/e2e/nginx_optional_test.go.
+//
+// Releasing them on the switch was considered and rejected on 2026-09-08.
+// Ports run 17000–65535 and a removal already frees a project's whole set, so
+// the leak is at most two numbers per project that was switched off while
+// running — against the cost of numbers that move under a project people have
+// bookmarked, scripted or written into a firewall rule.
+//
 // A missing key is true, which is what an installation upgrading into this
 // change looks like before anything rewrites its project configurations.
 func NginxEnabled(conf map[string]string) bool {

--- a/test/e2e/nginx_optional_test.go
+++ b/test/e2e/nginx_optional_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -101,4 +102,71 @@ func TestNginxOffKeepsTheProjectOutOfTheSharedProxy(t *testing.T) {
 	// it here would pin a behaviour that does not exist; it is written up in
 	// MADOCK-E2E-PLAN.md instead, where it can be decided rather than enforced
 	// by a red test.
+}
+
+// TestAProjectShippedWithoutNginxNeverTakesTheWebPorts is the other order, and
+// it is the one real projects use.
+//
+// `nginx/enabled` is not usually typed at a machine: it is committed in the
+// project's own `.madock/config.xml`, which is how extmag-core-shopify ships —
+// Core accepts no request from anywhere, so a vhost would mean a certificate, a
+// block in the shared proxy and an open port for nothing. That file is read
+// before the first render, so the switch is off the first time anything asks
+// for a port.
+//
+// Which is what makes the claim in `configs.NginxEnabled` — "false leaves out
+// the container, the vhost, the block in the shared proxy, the name in the
+// certificate and the ports" — true of this path and false of the other. A
+// project set up with the web server on and switched off afterwards keeps the
+// numbers it already has: `setup` renders, and allocates, before there is a
+// project for `config:set` to write to, and nothing hands a number back except
+// `project:remove`. Measured both ways in the VM on 2026-09-08.
+func TestAProjectShippedWithoutNginxNeverTakesTheWebPorts(t *testing.T) {
+	install := newInstallation(t)
+	p := install.project("e2eshippedoff")
+
+	// Written before setup, exactly as a repository carries it.
+	madockDir := filepath.Join(p.runDir, ".madock")
+	if err := os.MkdirAll(madockDir, 0o755); err != nil {
+		t.Fatalf("creating %s: %v", madockDir, err)
+	}
+	// The platform and the language belong in this file as well, exactly as
+	// extmag-core-shopify carries them. A file holding only the nginx switch
+	// looks like it should work and does not: the project's own config wins
+	// over what `setup` was told, so app.Dockerfile rendered from a config with
+	// no platform and docker stopped with "failed to read dockerfile:
+	// app.Dockerfile". Measured, and it is the reason this fixture is not
+	// shorter.
+	writeString(t, filepath.Join(madockDir, "config.xml"), `<?xml version="1.0" encoding="UTF-8"?>
+<config>
+    <scopes>
+        <default>
+            <platform>custom</platform>
+            <language>none</language>
+            <nginx>
+                <enabled>false</enabled>
+            </nginx>
+        </default>
+    </scopes>
+</config>
+`)
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2eshippedoff.test",
+	)
+	p.run(20*time.Minute, "start")
+
+	compose := readFile(t, p.generated("docker-compose.yml"))
+	if strings.Contains(compose, "\n  nginx:") {
+		t.Fatalf("the project declares an nginx service, so its own config.xml was not read and nothing below means anything:\n%s", compose)
+	}
+
+	registry := readFile(t, filepath.Join(install.dir, "aruntime", "ports.conf"))
+	for _, key := range []string{p.name + "/nginx=", p.name + "/nginx_ssl="} {
+		if strings.Contains(registry, key) {
+			t.Errorf("%s is reserved for a project that ships without a web server:\n%s", key, registry)
+		}
+	}
 }


### PR DESCRIPTION
The comment on `configs.NginxEnabled` promised that switching the web server off leaves out "the container, the vhost, the block in the shared proxy, the name in the certificate and the ports". Measured both ways in the VM:

- **True on the path real projects take.** The value is committed in the project's own `.madock/config.xml` — `extmag-core-shopify` is the case — and that file is read before the first render, so nothing ever asks for a web port. New test: `TestAProjectShippedWithoutNginxNeverTakesTheWebPorts`.
- **False the other way round.** `config:set nginx/enabled false` arrives after `setup` has rendered and allocated, and only `project:remove` hands a number back.

Releasing the numbers on the switch was considered and rejected: ports run 17000–65535, a removal already frees a project's whole set, so the leak is at most two numbers per project switched off while running — against numbers that move under a project somebody has bookmarked, scripted, or written into a firewall rule. The comment now says which half is which, and both paths have a test.

One thing the fixture had to learn: a `.madock/config.xml` holding only the nginx switch renders `app.Dockerfile` from a config with no platform, and docker stops with `failed to read dockerfile: open app.Dockerfile`. The platform and language belong in that file too, exactly as Core carries them.

Green in the VM: 34s.