### PR TITLE
Take the client address from a CDN header in the shared proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v4.2.2**
+
+Added:
+- **The shared proxy can take the client address from a CDN header** — `proxy/real_ip/enabled`, off by default, with `trusted` (the word `cloudflare`, or literal addresses and CIDRs), `header` (default `CF-Connecting-IP`) and `recursive`. Both per-client protections the proxy has are keyed on `$binary_remote_addr` — the rate limit zone and the connection limit zone — and so is the access log, so putting a CDN in front without this makes every visitor in the world look like one of a few dozen edge addresses: the rate limit throttles everyone together instead of anybody in particular, and the log stops answering which address did something
+- Off by default because it is the trust boundary, not a preference: on a directly reachable machine a trusted header lets the client choose the address the limiter counts. It is safe only once the origin refuses traffic that did not come through the CDN
+- A `trusted` entry that is not an address or CIDR is dropped and said so in the generated file. nginx refuses to start on a bad `set_real_ip_from`, and the shared proxy is one per machine — a typo in one project's config would otherwise take every project down at once. Enabled with nothing usable left, it trusts nobody and says that too, rather than reading as working
+- Cloudflare's ranges are shipped rather than fetched (`src/helper/configs/aruntime/nginx/realip.go`, taken from cloudflare.com/ips-v4 and ips-v6 on 2026-09-08): a proxy that asks a vendor at start is a proxy that does not start when the vendor is down
+
 **v4.2.1**
 
 Fixed:

--- a/config.xml
+++ b/config.xml
@@ -526,6 +526,47 @@
                     <enabled>true</enabled>
                     <per_ip>100</per_ip>
                 </conn_limit>
+                <!-- Where the client address comes from when something else
+                     terminated the connection — a CDN, or a load balancer in
+                     front of this machine.
+
+                     Both limits above are keyed on the client address, and so is
+                     the access log. Put Cloudflare in front of the proxy without
+                     this and that address becomes the CDN edge: a few dozen
+                     addresses standing in for the whole internet, so the rate
+                     limit throttles every visitor together and the log stops
+                     answering "who did this". Found the hard way on extmag.com,
+                     where the question "which address attacked us" had no answer
+                     because the log had rotated — adding a layer that removes the
+                     address permanently would have been worse.
+
+                     Off by default, and that is not caution: on a machine reached
+                     directly, trusting a header lets any client choose the
+                     address the limiter counts and the admin allow-lists believe.
+                     It is safe only once the origin refuses traffic that does not
+                     come from the CDN.
+
+                     `trusted` is a comma-separated list. The word `cloudflare`
+                     expands to the ranges shipped in
+                     src/helper/configs/aruntime/nginx/realip.go (fetched
+                     2026-09-08); anything else is taken as a literal address or
+                     CIDR, so a stack behind both a CDN and a company balancer can
+                     name both. An entry that is not an address is dropped and
+                     said so in the generated file — nginx refuses to start on a
+                     bad one, which would take every project on the machine down
+                     for a typo in one.
+
+                     `header` is CF-Connecting-IP for Cloudflare, which carries
+                     exactly one address and cannot be appended to. Use
+                     X-Forwarded-For only with `recursive` on, and only when every
+                     hop that could add to it is in `trusted` — otherwise a client
+                     that sends its own X-Forwarded-For picks its address. -->
+                <real_ip>
+                    <enabled>false</enabled>
+                    <trusted>cloudflare</trusted>
+                    <header>CF-Connecting-IP</header>
+                    <recursive>false</recursive>
+                </real_ip>
                 <!-- The largest request body the proxy will accept. It was 2G,
                      hard-coded in every server block, which is an upload nobody
                      makes through a browser and a cheap way to occupy disk and

--- a/src/helper/configs/aruntime/nginx/nginx.go
+++ b/src/helper/configs/aruntime/nginx/nginx.go
@@ -95,6 +95,45 @@ func proxyPreamble(generalConfig map[string]string) string {
 	// proxy service in compose — which needs no extra privilege.
 	preamble := "worker_processes 2;\nworker_rlimit_nofile 200000;\nevents {\n    worker_connections 4096;\nuse epoll;\n}\nhttp {\nserver_names_hash_bucket_size  128;\nserver_names_hash_max_size 1024;\n"
 
+	// The client address, when something else terminated the connection.
+	//
+	// This comes first on purpose. The realip module runs at the post-read phase,
+	// before limit_req and limit_conn are evaluated, so the two zones below and
+	// the access log all pick up the rewritten address — which is the entire
+	// reason to have it. Put a CDN in front of the proxy without this and every
+	// visitor in the world counts as one of a few dozen edge addresses: the rate
+	// limit stops protecting anything and starts throttling everyone together.
+	//
+	// Off by default. On a machine reached directly, trusting a header would let
+	// any client choose the address the limiter counts.
+	if generalConfig["proxy/real_ip/enabled"] == "true" {
+		trusted, rejected := TrustedRealIPRanges(generalConfig["proxy/real_ip/trusted"])
+
+		for _, entry := range rejected {
+			// Visible in the file rather than dropped in silence: a trusted
+			// range that was quietly discarded looks identical to one that
+			// works, and the difference is whether the client address is real.
+			preamble += "# real_ip: ignored '" + entry + "' — not an address or CIDR\n"
+		}
+
+		if len(trusted) == 0 {
+			preamble += "# real_ip: enabled with no usable trusted range, so nothing is trusted\n"
+		} else {
+			preamble += "# Real client address, taken from a header only for these upstreams\n"
+			for _, entry := range trusted {
+				preamble += "set_real_ip_from " + entry + ";\n"
+			}
+			header := generalConfig["proxy/real_ip/header"]
+			if header == "" {
+				header = "CF-Connecting-IP"
+			}
+			preamble += "real_ip_header " + header + ";\n"
+			if generalConfig["proxy/real_ip/recursive"] == "true" {
+				preamble += "real_ip_recursive on;\n"
+			}
+		}
+	}
+
 	// Global rate limiting zone (defined once for all projects)
 	//
 	// It was written to catch a request loop rather than an attacker, and the

--- a/src/helper/configs/aruntime/nginx/realip.go
+++ b/src/helper/configs/aruntime/nginx/realip.go
@@ -1,0 +1,111 @@
+package nginx
+
+import (
+	"net"
+	"strings"
+)
+
+// Trusted upstream addresses for the realip module.
+//
+// Why this exists at all: every per-address protection the shared proxy has is
+// keyed on `$binary_remote_addr` — the rate limit zone and the connection limit
+// zone both — and so is the access log. Put a CDN in front of the proxy and that
+// address stops being the client: it becomes the CDN's edge, of which there are a
+// few dozen. The limits then count every visitor in the world as the same handful
+// of addresses, which is worse than having no limit at all: one busy shop can
+// exhaust the burst for everybody, and a single attacker is indistinguishable
+// from the crowd behind the same edge. The log goes the same way — the field that
+// answers "who did this" starts answering "Cloudflare".
+//
+// The realip module rewrites `$remote_addr` from a header, but only for requests
+// that arrive from an address on this list. That restriction is the whole
+// security of it: without it any client could send `CF-Connecting-IP` and choose
+// the address the rate limiter counts, and the admin allow-lists trust.
+//
+// Ranges are shipped rather than fetched. A proxy that phones a vendor at start
+// is a proxy that does not start when the vendor is down, and these change on the
+// order of once a year. The cost is that they go stale silently, which is why the
+// date and the source are recorded here and why `trusted` also accepts explicit
+// CIDRs for anything else in front of the proxy.
+//
+// Fetched 2026-09-08 from https://www.cloudflare.com/ips-v4 and
+// https://www.cloudflare.com/ips-v6.
+var cloudflareRanges = []string{
+	"173.245.48.0/20",
+	"103.21.244.0/22",
+	"103.22.200.0/22",
+	"103.31.4.0/22",
+	"141.101.64.0/18",
+	"108.162.192.0/18",
+	"190.93.240.0/20",
+	"188.114.96.0/20",
+	"197.234.240.0/22",
+	"198.41.128.0/17",
+	"162.158.0.0/15",
+	"104.16.0.0/13",
+	"104.24.0.0/14",
+	"172.64.0.0/13",
+	"131.0.72.0/22",
+	"2400:cb00::/32",
+	"2606:4700::/32",
+	"2803:f800::/32",
+	"2405:b500::/32",
+	"2405:8100::/32",
+	"2a06:98c0::/29",
+	"2c0f:f248::/32",
+}
+
+// TrustedRealIPRanges turns the `proxy/real_ip/trusted` value into the list of
+// addresses nginx will accept a client address from.
+//
+// The value is a comma-separated list where the word `cloudflare` expands to the
+// shipped ranges and everything else is taken as a literal address or CIDR, so a
+// stack behind Cloudflare *and* a company load balancer can name both.
+//
+// An entry that is not a valid address or CIDR is dropped rather than passed
+// through. nginx would refuse to start on it, taking every project on the machine
+// down at once for a typo in one project's config — and a proxy that will not
+// start is the most expensive failure this file can cause. The second return
+// value names what was dropped so the caller can say so in the generated file
+// instead of leaving it invisible.
+func TrustedRealIPRanges(trusted string) (ranges []string, rejected []string) {
+	seen := make(map[string]bool)
+
+	add := func(candidate string) {
+		if candidate == "" || seen[candidate] {
+			return
+		}
+		seen[candidate] = true
+		ranges = append(ranges, candidate)
+	}
+
+	for _, part := range strings.Split(trusted, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		if strings.EqualFold(part, "cloudflare") {
+			for _, cidr := range cloudflareRanges {
+				add(cidr)
+			}
+			continue
+		}
+
+		if _, _, err := net.ParseCIDR(part); err == nil {
+			add(part)
+			continue
+		}
+
+		// A bare address is legal in set_real_ip_from, and is how a single
+		// upstream load balancer is named.
+		if net.ParseIP(part) != nil {
+			add(part)
+			continue
+		}
+
+		rejected = append(rejected, part)
+	}
+
+	return ranges, rejected
+}

--- a/src/helper/configs/aruntime/nginx/realip_test.go
+++ b/src/helper/configs/aruntime/nginx/realip_test.go
@@ -1,0 +1,175 @@
+package nginx
+
+import (
+	"strings"
+	"testing"
+)
+
+// Off by default is the security of the feature, not a preference: the realip
+// module rewrites the address every per-client limit is keyed on, so a proxy
+// that trusts a header on a directly reachable machine lets the client pick the
+// address the rate limiter counts.
+func TestRealIP_NothingWhenTurnedOff(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/real_ip/enabled": "false",
+		"proxy/real_ip/trusted": "cloudflare",
+	})
+
+	for _, directive := range []string{"set_real_ip_from", "real_ip_header", "real_ip_recursive"} {
+		if strings.Contains(preamble, directive) {
+			t.Errorf("%s is emitted even though real_ip is off:\n%s", directive, preamble)
+		}
+	}
+}
+
+// The keyword is the point: nobody should be pasting twenty-two CIDRs into a
+// project config, and a hand-copied list is a list that goes stale in one place
+// and not another.
+func TestRealIP_CloudflareKeywordExpands(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/real_ip/enabled": "true",
+		"proxy/real_ip/trusted": "cloudflare",
+		"proxy/real_ip/header":  "CF-Connecting-IP",
+	})
+
+	// one v4 range, one v6 range, and the header — enough to prove the
+	// expansion happened without pinning the vendor's whole list twice
+	for _, want := range []string{
+		"set_real_ip_from 173.245.48.0/20;",
+		"set_real_ip_from 2606:4700::/32;",
+		"real_ip_header CF-Connecting-IP;",
+	} {
+		if !strings.Contains(preamble, want) {
+			t.Errorf("missing %q:\n%s", want, preamble)
+		}
+	}
+
+	if strings.Contains(preamble, "real_ip_recursive") {
+		t.Errorf("recursive was not asked for but is on:\n%s", preamble)
+	}
+}
+
+// The rewritten address is what the limit zones count — the realip module runs
+// at post-read and limit_req at preaccess, so that holds regardless of where the
+// directives sit in the file. This pins the layout rather than the behaviour: the
+// block is written above the zones so the reason it exists is visible next to
+// what depends on it, and a later edit that moves it should have to say why.
+func TestRealIP_ComesBeforeTheLimitZones(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/real_ip/enabled":    "true",
+		"proxy/real_ip/trusted":    "cloudflare",
+		"proxy/rate_limit/enabled": "true",
+		"proxy/rate_limit/rate":    "50",
+		"proxy/conn_limit/enabled": "true",
+	})
+
+	realIP := strings.Index(preamble, "set_real_ip_from")
+	rate := strings.Index(preamble, "limit_req_zone")
+	conn := strings.Index(preamble, "limit_conn_zone")
+
+	if realIP == -1 || rate == -1 || conn == -1 {
+		t.Fatalf("expected all three blocks:\n%s", preamble)
+	}
+	if realIP > rate || realIP > conn {
+		t.Errorf("real_ip must precede both zones, got real_ip=%d rate=%d conn=%d:\n%s", realIP, rate, conn, preamble)
+	}
+}
+
+// A literal address or CIDR is how anything that is not Cloudflare gets named,
+// and mixing them with the keyword is the case of a stack behind both a CDN and
+// a company load balancer.
+func TestRealIP_ExplicitEntriesAndMixing(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/real_ip/enabled":   "true",
+		"proxy/real_ip/trusted":   "cloudflare, 10.0.0.0/8, 192.0.2.7",
+		"proxy/real_ip/header":    "X-Forwarded-For",
+		"proxy/real_ip/recursive": "true",
+	})
+
+	for _, want := range []string{
+		"set_real_ip_from 104.16.0.0/13;",
+		"set_real_ip_from 10.0.0.0/8;",
+		"set_real_ip_from 192.0.2.7;",
+		"real_ip_header X-Forwarded-For;",
+		"real_ip_recursive on;",
+	} {
+		if !strings.Contains(preamble, want) {
+			t.Errorf("missing %q:\n%s", want, preamble)
+		}
+	}
+}
+
+// nginx refuses to start on a bad set_real_ip_from, which on this machine means
+// every project goes down for a typo in one project's config. So a junk entry is
+// dropped — and said so in the file, because a silently discarded trusted range
+// looks exactly like one that works.
+func TestRealIP_JunkIsDroppedAndAnnounced(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/real_ip/enabled": "true",
+		"proxy/real_ip/trusted": "10.0.0.0/8, not-an-address, 300.1.2.3",
+	})
+
+	if strings.Contains(preamble, "not-an-address") && !strings.Contains(preamble, "# real_ip: ignored 'not-an-address'") {
+		t.Errorf("junk reached a directive instead of a comment:\n%s", preamble)
+	}
+	for _, want := range []string{
+		"# real_ip: ignored 'not-an-address' — not an address or CIDR",
+		"# real_ip: ignored '300.1.2.3' — not an address or CIDR",
+		"set_real_ip_from 10.0.0.0/8;",
+	} {
+		if !strings.Contains(preamble, want) {
+			t.Errorf("missing %q:\n%s", want, preamble)
+		}
+	}
+}
+
+// Turned on with nothing usable trusted, the module would silently trust
+// nobody — which is the safe outcome, and worth a line in the file so it does
+// not read as "real_ip is working".
+func TestRealIP_EnabledWithNoUsableRange(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/real_ip/enabled": "true",
+		"proxy/real_ip/trusted": "nonsense",
+	})
+
+	if !strings.Contains(preamble, "# real_ip: enabled with no usable trusted range") {
+		t.Errorf("the empty case is not announced:\n%s", preamble)
+	}
+	if strings.Contains(preamble, "real_ip_header") {
+		t.Errorf("a header is trusted with no upstream to trust it from:\n%s", preamble)
+	}
+}
+
+// The default header is Cloudflare's, because that is what `trusted=cloudflare`
+// pairs with, and an empty header setting would otherwise emit
+// `real_ip_header ;` — a file nginx will not start on.
+func TestRealIP_HeaderDefaultsRatherThanEmpty(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/real_ip/enabled": "true",
+		"proxy/real_ip/trusted": "cloudflare",
+	})
+
+	if !strings.Contains(preamble, "real_ip_header CF-Connecting-IP;") {
+		t.Errorf("expected the Cloudflare header by default:\n%s", preamble)
+	}
+	if strings.Contains(preamble, "real_ip_header ;") {
+		t.Errorf("emitted a directive with no value:\n%s", preamble)
+	}
+}
+
+func TestTrustedRealIPRanges_DeduplicatesAndReportsJunk(t *testing.T) {
+	ranges, rejected := TrustedRealIPRanges("cloudflare, 104.16.0.0/13, 104.16.0.0/13, bad")
+
+	seen := 0
+	for _, entry := range ranges {
+		if entry == "104.16.0.0/13" {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Errorf("expected 104.16.0.0/13 once, got %d: %v", seen, ranges)
+	}
+	if len(rejected) != 1 || rejected[0] != "bad" {
+		t.Errorf("expected only 'bad' rejected, got %v", rejected)
+	}
+}

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -526,6 +526,47 @@
                     <enabled>true</enabled>
                     <per_ip>100</per_ip>
                 </conn_limit>
+                <!-- Where the client address comes from when something else
+                     terminated the connection — a CDN, or a load balancer in
+                     front of this machine.
+
+                     Both limits above are keyed on the client address, and so is
+                     the access log. Put Cloudflare in front of the proxy without
+                     this and that address becomes the CDN edge: a few dozen
+                     addresses standing in for the whole internet, so the rate
+                     limit throttles every visitor together and the log stops
+                     answering "who did this". Found the hard way on extmag.com,
+                     where the question "which address attacked us" had no answer
+                     because the log had rotated — adding a layer that removes the
+                     address permanently would have been worse.
+
+                     Off by default, and that is not caution: on a machine reached
+                     directly, trusting a header lets any client choose the
+                     address the limiter counts and the admin allow-lists believe.
+                     It is safe only once the origin refuses traffic that does not
+                     come from the CDN.
+
+                     `trusted` is a comma-separated list. The word `cloudflare`
+                     expands to the ranges shipped in
+                     src/helper/configs/aruntime/nginx/realip.go (fetched
+                     2026-09-08); anything else is taken as a literal address or
+                     CIDR, so a stack behind both a CDN and a company balancer can
+                     name both. An entry that is not an address is dropped and
+                     said so in the generated file — nginx refuses to start on a
+                     bad one, which would take every project on the machine down
+                     for a typo in one.
+
+                     `header` is CF-Connecting-IP for Cloudflare, which carries
+                     exactly one address and cannot be appended to. Use
+                     X-Forwarded-For only with `recursive` on, and only when every
+                     hop that could add to it is in `trusted` — otherwise a client
+                     that sends its own X-Forwarded-For picks its address. -->
+                <real_ip>
+                    <enabled>false</enabled>
+                    <trusted>cloudflare</trusted>
+                    <header>CF-Connecting-IP</header>
+                    <recursive>false</recursive>
+                </real_ip>
                 <!-- The largest request body the proxy will accept. It was 2G,
                      hard-coded in every server block, which is an upload nobody
                      makes through a browser and a cheap way to occupy disk and

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.1"
+const Version = "4.2.2"


### PR DESCRIPTION
`proxy/real_ip/enabled`, off by default, with `trusted` / `header` / `recursive`.

Every per-client protection the shared proxy has is keyed on `$binary_remote_addr` — the rate limit zone and the connection limit zone both — and so is the access log. Put a CDN in front of the proxy without this and that address stops being the client: it becomes the CDN edge, a few dozen addresses standing in for the whole internet. The rate limit then throttles every visitor together rather than any attacker in particular, and the log stops answering which address did something.

Off by default is the trust boundary, not caution: on a directly reachable machine a trusted header lets the client choose the address the limiter counts. Safe only once the origin refuses traffic that did not arrive through the CDN.

A `trusted` entry that is not an address or CIDR is dropped and the generated file names it — nginx refuses to start on a bad `set_real_ip_from`, and the shared proxy is one per machine, so a typo in one project's config would otherwise take every project down together. Enabled with nothing usable left, it trusts nobody and says so.

Cloudflare's ranges are shipped rather than fetched, with the date and source recorded beside them: a proxy that asks a vendor at start does not start when the vendor is down.

Tests were proved by breaking the code — changing the `cloudflare` keyword failed five of them, moving the block below the limit zones failed the one that pins the layout.