### PR TITLE
An internal tag is checked against const Version too

### DIFF
--- a/.github/scripts/check-release-version.sh
+++ b/.github/scripts/check-release-version.sh
@@ -30,6 +30,49 @@ version_file="src/version/version.go"
 
 fail() { printf '%s\n' "$*" >&2; exit 1; }
 
+# An internal tag is checked too, and only the second rule applies to it.
+#
+# `-norelease` publishes nothing, so the single-digit rule is not its business —
+# internal patch numbers run into the twenties on purpose. What still matters is
+# the agreement between the tag and `const Version`, and for an internal tag it
+# matters MORE than for a published one: madock-pro imports the module by tag,
+# so a tag cut from a tree whose constant has not moved produces a pro binary
+# that reports the older madock version — and `embedded.ExtractIfNeeded`
+# compares that same constant against `.embedded_version`, so the templates
+# beside the binary are never refreshed. A template change shipped in such a
+# release does not reach a single server, and nothing says so.
+#
+# Measured on 2026-09-08: v4.2.2-norelease was cut from a tree still declaring
+# 4.2.1. Four machines took the new binary and kept `.embedded_version` at
+# 4.2.1. Nothing was broken by it — that release changed no template — which is
+# exactly why it would have gone unnoticed until one did.
+case "$tag" in
+    *-norelease)
+        internal_tag="${tag%-norelease}"
+        case "$internal_tag" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) fail "refusing \"$tag\": \"$internal_tag\" is not a version number." ;;
+        esac
+
+        [ -f "$version_file" ] || fail "cannot read $version_file from $(pwd)"
+        declared=$(sed -n 's/^const Version = "\(.*\)"$/\1/p' "$version_file")
+        [ -n "$declared" ] || fail "no \`const Version\` found in $version_file"
+
+        if [ "v$declared" != "$internal_tag" ]; then
+            fail "the internal tag and the binary disagree about the version.
+
+  tag:            $tag
+  $version_file:  $declared
+
+madock-pro imports this module by tag, so a pro build made from it reports
+$declared. The same constant decides whether the templates unpacked beside a
+binary are refreshed, so a template change in this release would reach no
+server and say nothing. Bump $version_file and tag the commit that carries it."
+        fi
+        exit 0
+        ;;
+esac
+
 # Single digit per segment. Not a style preference: it is what every published
 # release has been, and it is what keeps the public numbering separate from the
 # internal one, where the patch runs into the twenties.

--- a/.github/workflows/internal-tag.yml
+++ b/.github/workflows/internal-tag.yml
@@ -1,0 +1,34 @@
+name: Internal tag
+
+# An internal tag publishes nothing, and until now it was checked by nothing
+# either: the Release workflow filters `-norelease` out on purpose, so the one
+# guard that compares the tag against `const Version` never ran for the tags
+# madock-pro actually imports.
+#
+# That is the wrong way round. A published release is downloaded by a person who
+# can see the number; an internal tag is consumed by a build, and when it
+# disagrees with the constant the disagreement is invisible — the pro binary
+# reports the older madock version, and `embedded.ExtractIfNeeded` compares that
+# same constant against `.embedded_version`, so the templates beside it are
+# never refreshed.
+#
+# Measured on 2026-09-08: v4.2.2-norelease was cut from a tree still declaring
+# 4.2.1, four machines took the binary, and every one of them kept
+# `.embedded_version` at 4.2.1.
+#
+# This builds nothing and publishes nothing. It fails the tag, loudly, when the
+# two numbers do not agree.
+
+on:
+  push:
+    tags:
+      - 'v*-norelease'
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: The tag and const Version must agree
+        run: sh .github/scripts/check-release-version.sh "${GITHUB_REF_NAME}"


### PR DESCRIPTION
The release workflow filters `-norelease` out on purpose, so the guard comparing the tag against `const Version` never ran for the tags **madock-pro actually imports**. That is the wrong way round: a published release is downloaded by a person who can read the number, while an internal tag is consumed by a build — and there the disagreement is invisible. The pro binary reports the older madock version, and `embedded.ExtractIfNeeded` compares that same constant against `.embedded_version`, so the templates unpacked beside the binary are never refreshed. A template change shipped in such a release reaches no server and says nothing.

Measured on 2026-09-08: `v4.2.2-norelease` was cut from a tree still declaring `4.2.1`. Four machines took the new binary and each kept `.embedded_version` at 4.2.1. Nothing broke, because that release changed no template — which is exactly why it would have stayed unnoticed until one did.

The single-digit rule stays out of the internal path: those numbers run into the twenties by design. Only the tag-versus-constant rule applies there.

Proved against the working tree, which declares 4.2.2:

- `v4.2.2-norelease` → exit 0
- `v4.2.1-norelease` → exit 1, both numbers printed
- `v4.2.12-norelease` → exit 1

A new workflow runs it on `v*-norelease` pushes. It builds nothing and publishes nothing.