### PR TITLE
Pin the seam's contract, and stop refusing to delete a tag

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -43,7 +43,16 @@ fail() {
 # <remote sha>", so this reads what is actually being pushed rather than guessing
 # from the working tree. `-norelease` tags are the internal line and are skipped:
 # the release workflow ignores them too.
-while read -r _local_ref _local_sha remote_ref _remote_sha; do
+# A deletion is not a release, and it used to be refused as one. Deleting a tag
+# pushes an all-zero local sha with the tag as the remote ref, so the check ran
+# against a number the tree no longer declares and refused the withdrawal —
+# measured on 2026-09-08 while removing v4.2.2 after its release was pulled.
+# The one thing a deletion cannot do is publish a wrong number.
+while read -r _local_ref local_sha remote_ref _remote_sha; do
+    case "$local_sha" in
+        *[!0]*) ;;
+        *) continue ;;
+    esac
     case "$remote_ref" in
         refs/tags/v*-norelease) ;;
         refs/tags/v*)

--- a/src/helper/configs/aruntime/nginx/extensions_test.go
+++ b/src/helper/configs/aruntime/nginx/extensions_test.go
@@ -1,0 +1,62 @@
+package nginx
+
+import (
+	"strings"
+	"testing"
+)
+
+// The seam's whole contract is where the text lands, so this is the test that
+// has to exist here rather than in the edition that registers an extension.
+//
+// The realip module — the one extension there is today — runs at nginx's
+// post-read phase, before limit_req and limit_conn are evaluated. That is a
+// property of nginx, not of file order, so the ordering pinned here is about
+// something else: the directives are written above the zones so that the reason
+// they exist stands next to what depends on them, and an edit that moves them
+// has to say why. An extension appended after the zones would still work and
+// would still be wrong to read.
+//
+// Proved by moving the call below the zones: this test goes red and nothing
+// else in the suite notices, which is exactly the blindness it is here for.
+func TestPreambleExtensionsComeBeforeTheLimitZones(t *testing.T) {
+	previous := preambleExtensions
+	t.Cleanup(func() { preambleExtensions = previous })
+
+	preambleExtensions = nil
+	RegisterPreambleExtension(func(map[string]string) string {
+		return "# extension marker\n"
+	})
+
+	preamble := proxyPreamble(map[string]string{
+		"proxy/rate_limit/enabled": "true",
+		"proxy/rate_limit/rate":    "50",
+		"proxy/conn_limit/enabled": "true",
+		"proxy/conn_limit/per_ip":  "100",
+	})
+
+	marker := strings.Index(preamble, "# extension marker")
+	rate := strings.Index(preamble, "limit_req_zone")
+	conn := strings.Index(preamble, "limit_conn_zone")
+
+	if marker == -1 || rate == -1 || conn == -1 {
+		t.Fatalf("expected the marker and both zones:\n%s", preamble)
+	}
+	if marker > rate || marker > conn {
+		t.Errorf("an extension must be rendered above both zones, got marker=%d rate=%d conn=%d:\n%s",
+			marker, rate, conn, preamble)
+	}
+}
+
+// Community registers nothing, and the generated file has to show it: an empty
+// extension list must add no whitespace, no comment, nothing. The golden
+// fixtures would catch a stray newline eventually; this says it directly.
+func TestNoExtensionsRenderNothing(t *testing.T) {
+	previous := preambleExtensions
+	t.Cleanup(func() { preambleExtensions = previous })
+
+	preambleExtensions = nil
+
+	if got := PreambleExtensions(map[string]string{}); got != "" {
+		t.Errorf("with no extensions registered the seam rendered %q", got)
+	}
+}


### PR DESCRIPTION
Two small things on top of the seam that landed in #140.

**Where a preamble extension lands is pinned.** The realip module runs at nginx's post-read phase, so what it rewrites reaches both limit zones regardless of file order — the ordering here is about reading: the directives sit above the zones so the reason they exist stands beside what depends on them. Proved by moving the call below the zones: the new test goes red (`marker=714` against `rate=218`, `conn=329`) and nothing else in the suite notices, golden fixtures included. A second test says the other half — with nothing registered the seam renders the empty string, not a stray newline.

**The pre-push hook refused to delete a tag.** A deletion pushes an all-zero local sha with the tag as the remote ref, so the release-number check ran against a number the tree no longer declares and refused the withdrawal — measured while removing `v4.2.2` after its release was pulled. A deletion is the one push that cannot publish a wrong number.