### PR TITLE
A host can name the website code it is served as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+**v4.2.4**
+
+Added:
+- **A host can name the website code it is served as — `nginx/hosts/<key>/code`.** The key has always been the code, and on Magento that is not a naming convention: it is handed to the application as `MAGE_RUN_CODE` through the vhost's `map $http_host $MAGE_RUN_CODE`. So a host added under `www` asked Magento for a website called "www" and got `NoSuchEntityException` — measured on extmag.com, where every request to www.extmag.com answered 500 from 2026-09-06
+- **Removing such a host is worse than leaving it**, which is why a code and not a deletion. `server_name` is built from the same list, so the name would fall out of the project's block and land on the shared proxy's default — answered with another project's certificate
+- Absent, the code is still the key. Nothing written by an earlier version changes meaning
+
+Fixed:
+- **A key under `hosts/` that is not a name is no longer read as a host.** The loop accepted anything below `hosts/`, which was harmless while `name` was the only leaf and would have turned each new `code` into a phantom host — named after the code, coded after the host, and put into `server_name`
+
 **v4.2.3**
 
 Changed:

--- a/config.xml
+++ b/config.xml
@@ -52,10 +52,29 @@
                     <secure>443</secure>
                     <internal>80</internal>
                 </port>
+                <!-- Each host is a key, a name, and optionally the website code it
+                     is served as.
+
+                     The key is the code by default, and on Magento that is not a
+                     convention: it reaches the application as MAGE_RUN_CODE. A
+                     host added under a key that names no website answers 500 to
+                     every request — measured on extmag.com, where `www` asked
+                     Magento for a website called "www" and got
+                     NoSuchEntityException.
+
+                     `code` is how two hosts share one website: www served as
+                     base. Removing the host instead is worse, because server_name
+                     is built from this same list — the name would fall out of the
+                     project's block and land on the shared proxy's default, with
+                     somebody else's certificate. -->
                 <!--<hosts>
                     <base>
                         <name>example.com</name>
                     </base>
+                    <www>
+                        <name>www.example.com</name>
+                        <code>base</code>
+                    </www>
                 </hosts>-->
                 <ssl>
                     <enabled>true</enabled>

--- a/src/helper/configs/config.go
+++ b/src/helper/configs/config.go
@@ -277,14 +277,46 @@ func IsOption(name string) bool {
 	return false
 }
 
+// GetHosts lists the project's hosts, each with the website code it is served
+// as.
+//
+// **The key is the code, and that is not a naming convention — it reaches
+// Magento.** `nginx/hosts/<key>/name` becomes an entry in the vhost's
+// `map $http_host $MAGE_RUN_CODE`, so the key is handed to the application as
+// the website code. A host added as `www` therefore asks Magento for a website
+// called "www"; on extmag.com that was NoSuchEntityException and HTTP 500 on
+// every request to www.extmag.com, first seen 2026-09-06.
+//
+// Removing such a host is worse than leaving it: `server_name` is built from
+// this same list, so the name would fall out of the project's block and land on
+// the shared proxy's default — answered with somebody else's certificate.
+//
+// So a host may now name its code explicitly: `nginx/hosts/<key>/code`. Two
+// hosts can then share one website — `www` served as `base` — which is the case
+// this exists for. Absent, the code is the key, exactly as before; nothing
+// written by any earlier version changes meaning.
 func GetHosts(data map[string]string) []map[string]string {
 	var hosts []map[string]string
 	sortedKeys := SortMap(data)
 	for _, key := range sortedKeys {
-		if strings.Contains(key, "/hosts/") && data[key] != "" {
-			items := strings.Split(key, "/")
-			hosts = append(hosts, map[string]string{"name": data[key], "code": items[len(items)-2]})
+		// Only the `name` leaf declares a host. This used to accept any key
+		// under `hosts/`, which was harmless while `name` was the only leaf
+		// there and became wrong the moment `code` joined it: the code key
+		// would have been read as a host of its own, named after the code and
+		// coded after the host.
+		if !strings.Contains(key, "/hosts/") || !strings.HasSuffix(key, "/name") || data[key] == "" {
+			continue
 		}
+
+		items := strings.Split(key, "/")
+		hostKey := items[len(items)-2]
+
+		code := hostKey
+		if declared := data[strings.TrimSuffix(key, "/name")+"/code"]; declared != "" {
+			code = declared
+		}
+
+		hosts = append(hosts, map[string]string{"name": data[key], "code": code})
 	}
 
 	return hosts

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -52,10 +52,29 @@
                     <secure>443</secure>
                     <internal>80</internal>
                 </port>
+                <!-- Each host is a key, a name, and optionally the website code it
+                     is served as.
+
+                     The key is the code by default, and on Magento that is not a
+                     convention: it reaches the application as MAGE_RUN_CODE. A
+                     host added under a key that names no website answers 500 to
+                     every request — measured on extmag.com, where `www` asked
+                     Magento for a website called "www" and got
+                     NoSuchEntityException.
+
+                     `code` is how two hosts share one website: www served as
+                     base. Removing the host instead is worse, because server_name
+                     is built from this same list — the name would fall out of the
+                     project's block and land on the shared proxy's default, with
+                     somebody else's certificate. -->
                 <!--<hosts>
                     <base>
                         <name>example.com</name>
                     </base>
+                    <www>
+                        <name>www.example.com</name>
+                        <code>base</code>
+                    </www>
                 </hosts>-->
                 <ssl>
                     <enabled>true</enabled>

--- a/src/helper/configs/hosts_test.go
+++ b/src/helper/configs/hosts_test.go
@@ -1,0 +1,77 @@
+package configs
+
+import "testing"
+
+// The key is the website code, and that is what makes this worth a test rather
+// than a comment: `nginx/hosts/<key>/name` reaches Magento as MAGE_RUN_CODE, so
+// a host added under a key that names no website answers 500 to every request.
+func TestHostCodeDefaultsToTheKey(t *testing.T) {
+	hosts := GetHosts(map[string]string{
+		"nginx/hosts/base/name": "extmag.com",
+	})
+
+	if len(hosts) != 1 {
+		t.Fatalf("hosts = %v, want one", hosts)
+	}
+	if hosts[0]["name"] != "extmag.com" || hosts[0]["code"] != "base" {
+		t.Errorf("host = %v, want name=extmag.com code=base", hosts[0])
+	}
+}
+
+// The case this was written for: www.extmag.com served by the website the bare
+// domain is served by. Before it, the only way to have www answer at all was to
+// name the key `base`, which the bare domain already used.
+func TestAHostCanNameTheWebsiteItShares(t *testing.T) {
+	hosts := GetHosts(map[string]string{
+		"nginx/hosts/base/name": "extmag.com",
+		"nginx/hosts/www/name":  "www.extmag.com",
+		"nginx/hosts/www/code":  "base",
+	})
+
+	if len(hosts) != 2 {
+		t.Fatalf("hosts = %v, want two", hosts)
+	}
+
+	byName := map[string]string{}
+	for _, host := range hosts {
+		byName[host["name"]] = host["code"]
+	}
+	if byName["extmag.com"] != "base" {
+		t.Errorf("extmag.com is served as %q, want base", byName["extmag.com"])
+	}
+	if byName["www.extmag.com"] != "base" {
+		t.Errorf("www.extmag.com is served as %q, want base — that is the whole feature", byName["www.extmag.com"])
+	}
+}
+
+// A code key is a property of a host, not a host. The loop used to accept any
+// key under hosts/, which was harmless while `name` was the only leaf and would
+// have turned every `code` into a phantom host the moment one existed: named
+// after the code, coded after the host, and put into server_name.
+func TestACodeKeyIsNotAHostOfItsOwn(t *testing.T) {
+	hosts := GetHosts(map[string]string{
+		"nginx/hosts/base/name": "extmag.com",
+		"nginx/hosts/www/name":  "www.extmag.com",
+		"nginx/hosts/www/code":  "base",
+	})
+
+	for _, host := range hosts {
+		if host["name"] == "base" {
+			t.Errorf("a code key was read as a host: %v", host)
+		}
+	}
+}
+
+// An empty code is not a code. Written out because the alternative — an empty
+// MAGE_RUN_CODE reaching the application — is the failure this feature exists
+// to remove, arriving through the feature itself.
+func TestAnEmptyCodeFallsBackToTheKey(t *testing.T) {
+	hosts := GetHosts(map[string]string{
+		"nginx/hosts/second/name": "second.extmag.com",
+		"nginx/hosts/second/code": "",
+	})
+
+	if len(hosts) != 1 || hosts[0]["code"] != "second" {
+		t.Errorf("hosts = %v, want the key as the code", hosts)
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.3"
+const Version = "4.2.4"


### PR DESCRIPTION
**The key has always been the code**, and on Magento that is not a naming convention: `nginx/hosts/<key>/name` becomes an entry in the vhost's `map $http_host $MAGE_RUN_CODE`, so the key reaches the application as the website code. A host added under `www` asks Magento for a website called "www" and gets `NoSuchEntityException` — measured on extmag.com, where every request to www.extmag.com answered 500 from 2026-09-06.

**Deleting the host is worse than leaving it.** `server_name` is built from the same list, so the name would fall out of the project's block and land on the shared proxy's default — answered with another project's certificate. So the host stays and names its code: `nginx/hosts/www/code = base`, two hosts sharing one website.

Absent, the code is the key. Nothing written by an earlier version changes meaning.

**A second fix rides with it:** the loop accepted any key under `hosts/`. Harmless while `name` was the only leaf; the moment `code` joined it, every code would have been read as a host of its own — named after the code, coded after the host, and written into `server_name`.

Proved by breaking it: with the explicit code ignored, `TestAHostCanNameTheWebsiteItShares` goes red.