### PR TITLE
Five sets of literals become settings, with the same defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 **v4.2.5**
 
 Added:
+- **`config:set --global`, and it exists because its absence was a silent no-op.** Everything under `proxy/` is read from the installation's own config — the shared proxy is one per machine — while `config:set` only ever wrote the project. So `config:set -n proxy/worker/processes -v 3` was accepted, written, visible in `config:list`, and changed nothing. `config:unset` had `--global` all along; this is the other half. Found by the end-to-end test for the new settings, not by reading the code
 - **Five things that were literals in the code are settings now**, each with the value it had compiled in, so a machine that sets nothing renders what it rendered before — proved by the golden fixtures, which did not move
 - `proxy/worker/*` and `proxy/server_names_hash/*`. The second is the one with teeth: nginx **refuses to start** when a hostname does not fit `server_names_hash_bucket_size`, and the shared proxy is one per machine, so that refusal takes every project down together. Raising it used to mean editing Go and rebuilding the binary
 - `proxy/ssl/protocols` and `proxy/ssl/ciphers`. The demand to narrow TLS arrives from outside — an audit, a payment provider, a customer's security review — and used to need a new binary on every machine
 - `php/limits/memory`, `php/limits/max_execution_time`, `php/limits/max_execution_time_web`. Three copies of one number lived inside the platform vhosts, and a project could not change them without copying a 240-line vhost into `.madock/docker/` and letting it drift. An import or a reindex through the web is what runs into them, and what that looks like is a 500 with nothing in the nginx log
 - `php/ini/*` — `post_max_size`, `upload_max_filesize`, `max_input_vars`, `session_cookie_lifetime`. The four that get changed first, and editing them inside a running container does not survive the next rebuild
 - `nginx/max_body_size` for the project's own vhost, named to match `proxy/max_body_size` in the shared proxy. Two limits sit in the path and the smaller one wins: the vhost promised 2G while the proxy stopped the request at 128M, and an upload that dies between them says nothing useful
+
+Fixed:
+- **The TLS options are written on every generation instead of beside the certificate.** `options-ssl-nginx.conf` is what every server block includes, and it was written inside the certificate generation — which does nothing when the certificate still covers the current hosts. Changing `proxy/ssl/protocols` and starting therefore left the old file in place: measured in the VM, a proxy limited to TLSv1.3 completed a TLS 1.2 handshake. The generated text was right and unread
 
 Changed:
 - Platform vhosts that deliberately carry a smaller limit keep it — PrestaShop's 16M and WooCommerce's 64M are not the common 2G and were left alone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+**v4.2.5**
+
+Added:
+- **Five things that were literals in the code are settings now**, each with the value it had compiled in, so a machine that sets nothing renders what it rendered before — proved by the golden fixtures, which did not move
+- `proxy/worker/*` and `proxy/server_names_hash/*`. The second is the one with teeth: nginx **refuses to start** when a hostname does not fit `server_names_hash_bucket_size`, and the shared proxy is one per machine, so that refusal takes every project down together. Raising it used to mean editing Go and rebuilding the binary
+- `proxy/ssl/protocols` and `proxy/ssl/ciphers`. The demand to narrow TLS arrives from outside — an audit, a payment provider, a customer's security review — and used to need a new binary on every machine
+- `php/limits/memory`, `php/limits/max_execution_time`, `php/limits/max_execution_time_web`. Three copies of one number lived inside the platform vhosts, and a project could not change them without copying a 240-line vhost into `.madock/docker/` and letting it drift. An import or a reindex through the web is what runs into them, and what that looks like is a 500 with nothing in the nginx log
+- `php/ini/*` — `post_max_size`, `upload_max_filesize`, `max_input_vars`, `session_cookie_lifetime`. The four that get changed first, and editing them inside a running container does not survive the next rebuild
+- `nginx/max_body_size` for the project's own vhost, named to match `proxy/max_body_size` in the shared proxy. Two limits sit in the path and the smaller one wins: the vhost promised 2G while the proxy stopped the request at 128M, and an upload that dies between them says nothing useful
+
+Changed:
+- Platform vhosts that deliberately carry a smaller limit keep it — PrestaShop's 16M and WooCommerce's 64M are not the common 2G and were left alone
+
 **v4.2.4**
 
 Added:

--- a/config.xml
+++ b/config.xml
@@ -76,6 +76,14 @@
                         <code>base</code>
                     </www>
                 </hosts>-->
+                <!-- The largest request body this project's own vhost accepts.
+                     
+                     Two limits sit in the path and both have to allow an upload:
+                     this one and proxy/max_body_size in the shared proxy, which
+                     is the smaller of the two by default. The vhost used to
+                     promise 2G while the proxy stopped the request at 128M, and
+                     an upload that dies between them says nothing useful. -->
+                <max_body_size>2G</max_body_size>
                 <ssl>
                     <enabled>true</enabled>
                 </ssl>
@@ -149,6 +157,36 @@
                      that the first attempt to justify them attributed a whole
                      suite's result to all four keys changed at once, which is a
                      coincidence wearing a measurement's clothes. -->
+                <!-- What php-fpm is told per request by the vhost.
+                     
+                     These were three copies of the same number inside the
+                     platform vhosts (magento2, shopware, sylius and the shared
+                     php snippet), and a project could not change them without
+                     copying a 240-line vhost into its own .madock/docker.
+                     An import or a reindex through the web is exactly what runs
+                     into them, and what it looks like is a 500 with nothing in
+                     the nginx log to explain it.
+
+                     max_execution_time_web is the shorter one used for ordinary
+                     page requests on Magento; max_execution_time is what the
+                     long-running entry points get. -->
+                <limits>
+                    <memory>756M</memory>
+                    <max_execution_time>18000</max_execution_time>
+                    <max_execution_time_web>600</max_execution_time_web>
+                </limits>
+                <!-- php.ini values written when the image is built.
+                     
+                     Editing php.ini inside a running container does not survive
+                     the next rebuild — the image is built from the template, and
+                     the edit goes with it. These are the four that get changed
+                     first, so they are keys rather than literals in a snippet. -->
+                <ini>
+                    <post_max_size>80M</post_max_size>
+                    <upload_max_filesize>50M</upload_max_filesize>
+                    <max_input_vars>50000</max_input_vars>
+                    <session_cookie_lifetime>2592000</session_cookie_lifetime>
+                </ini>
                 <fpm>
                     <max_children>40</max_children>
                     <start_servers>2</start_servers>
@@ -508,6 +546,30 @@
                     <repository>nginx</repository>
                     <version>1.28</version>
                 </nginx>
+                <!-- Worker and hash-table settings for the shared proxy.
+                     
+                     bucket_size is the one with teeth: nginx refuses to start
+                     when a hostname does not fit it, and the shared proxy is one
+                     per machine — that refusal takes every project down at once.
+                     It used to be a literal in the binary, so raising it meant a
+                     new build. -->
+                <worker>
+                    <processes>2</processes>
+                    <rlimit_nofile>200000</rlimit_nofile>
+                    <connections>4096</connections>
+                </worker>
+                <server_names_hash>
+                    <bucket_size>128</bucket_size>
+                    <max_size>1024</max_size>
+                </server_names_hash>
+                <!-- What TLS the proxy offers. A setting because the demand to
+                     narrow it comes from outside — an audit, a payment provider,
+                     a customer's security review — and used to need a code
+                     change and a new binary on every machine. -->
+                <ssl>
+                    <protocols>TLSv1.2 TLSv1.3</protocols>
+                    <ciphers>ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384</ciphers>
+                </ssl>
                 <timeout>
                     <connect>60</connect>
                     <send>300</send>

--- a/docker/bigcommerce/nginx/conf/default.conf
+++ b/docker/bigcommerce/nginx/conf/default.conf
@@ -16,7 +16,7 @@ server {
     autoindex off;
     charset UTF-8;
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     location / {
         try_files $uri $uri/ /index.php$is_args$args;
@@ -57,7 +57,7 @@ server {
     listen      {{{.nginx.port.internal}}};
     server_name {{{range $i, $host := .nginx.hosts}}}{{{if $i}}} {{{end}}}{{{$host.name}}}{{{end}}};
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     location / {
         proxy_pass http://nodejs:{{{.main_service_port}}};

--- a/docker/magento2/nginx/conf/default.conf
+++ b/docker/magento2/nginx/conf/default.conf
@@ -32,7 +32,7 @@ server {
     charset UTF-8;
     error_page 404 403 = /errors/404.php;
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     # Replaces a prefix location for /.user.ini, which this covers.
     # Dotfiles and dot-directories at any path segment: .git, .env, .htaccess,
@@ -55,7 +55,7 @@ server {
             fastcgi_pass   fastcgi_backend_xdebug_false;
 
             fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-            fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=600";
+            fastcgi_param  PHP_VALUE "memory_limit={{{.php.limits.memory}}} \n max_execution_time={{{.php.limits.max_execution_time_web}}}";
             fastcgi_read_timeout 600s;
             fastcgi_connect_timeout 600s;
 
@@ -218,7 +218,7 @@ server {
         fastcgi_pass   fastcgi_backend_xdebug_false;
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+        fastcgi_param  PHP_VALUE "memory_limit={{{.php.limits.memory}}} \n max_execution_time={{{.php.limits.max_execution_time}}}";
         fastcgi_read_timeout 18000s;
         fastcgi_connect_timeout 18000s;
 
@@ -236,7 +236,7 @@ server {
         fastcgi_pass   fastcgi_backend_xdebug_{{{.php.xdebug.enabled}}};
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+        fastcgi_param  PHP_VALUE "memory_limit={{{.php.limits.memory}}} \n max_execution_time={{{.php.limits.max_execution_time}}}";
         fastcgi_read_timeout 18000s;
         fastcgi_connect_timeout 18000s;
 

--- a/docker/shopify/nginx/conf/default.conf
+++ b/docker/shopify/nginx/conf/default.conf
@@ -16,7 +16,7 @@ server {
     autoindex off;
     charset UTF-8;
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     location / {
         try_files $uri $uri/ /index.php$is_args$args;
@@ -68,7 +68,7 @@ server {
     listen      {{{.nginx.port.internal}}};
     server_name {{{range $i, $host := .nginx.hosts}}}{{{if $i}}} {{{end}}}{{{$host.name}}}{{{end}}};
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     location / {
         proxy_pass http://nodejs:{{{.main_service_port}}};

--- a/docker/shopware/nginx/conf/default.conf
+++ b/docker/shopware/nginx/conf/default.conf
@@ -16,7 +16,7 @@ server {
     server_name {{{range $i, $host := .nginx.hosts}}}{{{if $i}}} {{{end}}}{{{$host.name}}}{{{end}}};
 
     index index.php;
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     root {{{.workdir}}}/{{{.public_dir}}};
 
@@ -96,7 +96,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass fastcgi_backend_xdebug_{{{.php.xdebug.enabled}}};
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+        fastcgi_param  PHP_VALUE "memory_limit={{{.php.limits.memory}}} \n max_execution_time={{{.php.limits.max_execution_time}}}";
         fastcgi_read_timeout 18000s;
         fastcgi_connect_timeout 18000s;
         fastcgi_index  index.php;

--- a/docker/snippets/dockerfile/php/ini
+++ b/docker/snippets/dockerfile/php/ini
@@ -1,7 +1,7 @@
-RUN sed -i 's/session.cookie_lifetime = 0/session.cookie_lifetime = 2592000/g' /etc/php/{{{.php.version}}}/fpm/php.ini \
-    && sed -i 's/post_max_size = 8M/post_max_size = 80M/g' /etc/php/{{{.php.version}}}/fpm/php.ini \
-    && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = 50M/g' /etc/php/{{{.php.version}}}/fpm/php.ini \
-    && sed -i 's/;max_input_vars = 1000/max_input_vars = 50000/g' /etc/php/{{{.php.version}}}/fpm/php.ini
+RUN sed -i 's/session.cookie_lifetime = 0/session.cookie_lifetime = {{{.php.ini.session_cookie_lifetime}}}/g' /etc/php/{{{.php.version}}}/fpm/php.ini \
+    && sed -i 's/post_max_size = 8M/post_max_size = {{{.php.ini.post_max_size}}}/g' /etc/php/{{{.php.version}}}/fpm/php.ini \
+    && sed -i 's/upload_max_filesize = 2M/upload_max_filesize = {{{.php.ini.upload_max_filesize}}}/g' /etc/php/{{{.php.version}}}/fpm/php.ini \
+    && sed -i 's/;max_input_vars = 1000/max_input_vars = {{{.php.ini.max_input_vars}}}/g' /etc/php/{{{.php.version}}}/fpm/php.ini
 
 # Where PHP's mail() sends. Written only when there is somewhere for it to go.
 #

--- a/docker/snippets/nginx/medusa-proxy.conf
+++ b/docker/snippets/nginx/medusa-proxy.conf
@@ -5,7 +5,7 @@ server {
     autoindex off;
     charset UTF-8;
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     # Docker's embedded DNS server. Resolving upstreams through a
     # variable defers DNS lookup to request time — nginx no longer

--- a/docker/snippets/nginx/php.conf
+++ b/docker/snippets/nginx/php.conf
@@ -23,7 +23,7 @@ server {
     charset UTF-8;
     error_page 404 403 = /errors/404.php;
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     # Dotfiles and dot-directories at any path segment: .user.ini, .htaccess,
     # .git, .env, .DS_Store. /.well-known/ is exempt so an ACME challenge stays
@@ -48,7 +48,7 @@ server {
         fastcgi_pass   fastcgi_backend_xdebug_false;
 
         fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
-        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+        fastcgi_param  PHP_VALUE "memory_limit={{{.php.limits.memory}}} \n max_execution_time={{{.php.limits.max_execution_time}}}";
         fastcgi_read_timeout 18000s;
         fastcgi_connect_timeout 18000s;
 

--- a/docker/snippets/nginx/proxy.conf
+++ b/docker/snippets/nginx/proxy.conf
@@ -9,7 +9,7 @@ server {
     autoindex off;
     charset UTF-8;
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     location / {
         proxy_pass http://{{{.main_service}}}:{{{.main_service_port}}};

--- a/docker/snippets/nginx/spree-proxy.conf
+++ b/docker/snippets/nginx/spree-proxy.conf
@@ -5,7 +5,7 @@ server {
     autoindex off;
     charset UTF-8;
 
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     # Docker's embedded DNS server. Resolving upstreams through a
     # variable defers DNS lookup to request time — nginx no longer

--- a/docker/sylius/nginx/conf/default.conf
+++ b/docker/sylius/nginx/conf/default.conf
@@ -16,7 +16,7 @@ server {
     server_name {{{range $i, $host := .nginx.hosts}}}{{{if $i}}} {{{end}}}{{{$host.name}}}{{{end}}};
 
     index index.php;
-    client_max_body_size       2G;
+    client_max_body_size       {{{.nginx.max_body_size}}};
 
     root {{{.workdir}}}/{{{.public_dir}}};
 
@@ -86,7 +86,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass fastcgi_backend_xdebug_{{{.php.xdebug.enabled}}};
         fastcgi_param  PHP_FLAG  "session.auto_start=off";
-        fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=18000";
+        fastcgi_param  PHP_VALUE "memory_limit={{{.php.limits.memory}}} \n max_execution_time={{{.php.limits.max_execution_time}}}";
         fastcgi_read_timeout 18000s;
         fastcgi_connect_timeout 18000s;
         fastcgi_index  index.php;

--- a/src/controller/general/config/config.go
+++ b/src/controller/general/config/config.go
@@ -79,11 +79,30 @@ func SetEnvOption() {
 	if _, ok := projectConfig["activeScope"]; ok {
 		activeScope = projectConfig["activeScope"]
 	}
-	if len(name) > 0 && configs.IsOption(name) {
-		projectName := configs.GetProjectName()
-		configs.SetParam(projectName, name, val, activeScope, "")
-		dropStaleDerived(projectName, name, activeScope)
+	if len(name) == 0 || !configs.IsOption(name) {
+		return
 	}
+
+	// --global writes the installation's own config, and the flag exists because
+	// its absence was a silent no-op.
+	//
+	// The shared proxy is one per machine, so everything under `proxy/` is read
+	// from <install>/projects/config.xml and not from any project. `config:set`
+	// only ever wrote the project — so `config:set -n proxy/worker/processes -v 3`
+	// was accepted, written, visible in `config:list`, and changed nothing about
+	// the proxy. The only way to set such a value was to edit the installation
+	// file by hand, which is not something a command should require while
+	// appearing to work.
+	//
+	// `config:unset` has had `--global` all along; this is the other half of it.
+	if args.Global {
+		configs.SetParam(configs.MainConfigCode, name, val, "default", configs.MainConfigCode)
+		return
+	}
+
+	projectName := configs.GetProjectName()
+	configs.SetParam(projectName, name, val, activeScope, "")
+	dropStaleDerived(projectName, name, activeScope)
 }
 
 // dropStaleDerived takes the stored copy of a computed key out of the file when

--- a/src/helper/cli/arg_struct/args.go
+++ b/src/helper/cli/arg_struct/args.go
@@ -80,8 +80,9 @@ type ControllerGeneralCleanCache struct {
 
 type ControllerGeneralConfig struct {
 	attr.Arguments
-	Name  string `arg:"-n,--name" help:"Parameter name"`
-	Value string `arg:"-v,--value" help:"Parameter value"`
+	Name   string `arg:"-n,--name" help:"Parameter name"`
+	Value  string `arg:"-v,--value" help:"Parameter value"`
+	Global bool   `arg:"-g,--global" help:"Write it to the installation's own config, where the shared proxy and other installation-wide settings are read from"`
 }
 
 type ControllerGeneralConfigUnset struct {

--- a/src/helper/configs/aruntime/nginx/extensions_test.go
+++ b/src/helper/configs/aruntime/nginx/extensions_test.go
@@ -60,3 +60,45 @@ func TestNoExtensionsRenderNothing(t *testing.T) {
 		t.Errorf("with no extensions registered the seam rendered %q", got)
 	}
 }
+
+// The worker and hash numbers are settings now, and this is the half that
+// matters: the defaults are already pinned by the golden fixtures, so what needs
+// saying is that a configured value actually reaches the file.
+//
+// bucket_size is the reason the feature exists. nginx refuses to start when a
+// hostname does not fit it — on the shared proxy that is every project on the
+// machine — and raising it used to mean editing Go and rebuilding the binary.
+func TestProxyWorkerSettingsReachTheFile(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/worker/processes":              "8",
+		"proxy/worker/rlimit_nofile":          "65535",
+		"proxy/worker/connections":            "16384",
+		"proxy/server_names_hash/bucket_size": "256",
+		"proxy/server_names_hash/max_size":    "4096",
+	})
+
+	for _, want := range []string{
+		"worker_processes 8;",
+		"worker_rlimit_nofile 65535;",
+		"worker_connections 16384;",
+		"server_names_hash_bucket_size  256;",
+		"server_names_hash_max_size 4096;",
+	} {
+		if !strings.Contains(preamble, want) {
+			t.Errorf("missing %q:\n%s", want, preamble)
+		}
+	}
+}
+
+// A key present with no value is what a config looks like mid-edit, and an empty
+// directive is a file nginx will not load — on the shared proxy, for everybody.
+// So empty falls back to the compiled default rather than through.
+func TestAnEmptySettingFallsBackToTheDefault(t *testing.T) {
+	preamble := proxyPreamble(map[string]string{
+		"proxy/worker/processes": "",
+	})
+
+	if !strings.Contains(preamble, "worker_processes 2;") {
+		t.Errorf("an empty setting did not fall back to the default:\n%s", preamble)
+	}
+}

--- a/src/helper/configs/aruntime/nginx/nginx.go
+++ b/src/helper/configs/aruntime/nginx/nginx.go
@@ -93,7 +93,22 @@ func proxyPreamble(generalConfig map[string]string) string {
 	// accepts requests faster into the same queue. If priority is ever genuinely
 	// wanted, the container-native knob is a cgroup weight — cpu_shares/cpus on the
 	// proxy service in compose — which needs no extra privilege.
-	preamble := "worker_processes 2;\nworker_rlimit_nofile 200000;\nevents {\n    worker_connections 4096;\nuse epoll;\n}\nhttp {\nserver_names_hash_bucket_size  128;\nserver_names_hash_max_size 1024;\n"
+	// The worker and hash-table numbers are settings rather than literals, and
+	// one of them is the reason why: nginx **refuses to start** when a hostname
+	// does not fit `server_names_hash_bucket_size`, saying so and naming the
+	// value to raise. The shared proxy is one per machine, so that refusal takes
+	// every project down together — and until now the only cure was editing Go
+	// and rebuilding the binary.
+	//
+	// Defaults are exactly the numbers that were compiled in, so a machine that
+	// sets nothing renders the file it rendered before, byte for byte. That is
+	// what the golden fixtures check.
+	preamble := "worker_processes " + settingOr(generalConfig, "proxy/worker/processes", "2") + ";\n" +
+		"worker_rlimit_nofile " + settingOr(generalConfig, "proxy/worker/rlimit_nofile", "200000") + ";\n" +
+		"events {\n    worker_connections " + settingOr(generalConfig, "proxy/worker/connections", "4096") + ";\nuse epoll;\n}\n" +
+		"http {\n" +
+		"server_names_hash_bucket_size  " + settingOr(generalConfig, "proxy/server_names_hash/bucket_size", "128") + ";\n" +
+		"server_names_hash_max_size " + settingOr(generalConfig, "proxy/server_names_hash/max_size", "1024") + ";\n"
 
 	// Anything the enterprise edition wants at the top of the http block.
 	//
@@ -412,13 +427,21 @@ func GenerateSslCert(ctxPath string, force bool) {
 			log.Fatalf("Unable to write file: %v", err)
 		}
 
+		// Which TLS versions and ciphers the proxy offers.
+		//
+		// A setting because the demand to narrow it arrives from outside — an
+		// audit, a payment processor, a customer's security review — and used to
+		// need a code change and a new binary on every machine. The defaults are
+		// the values that were compiled in.
+		generalConfig := configs2.GetGeneralConfig()
 		sslConfigFileContent := "ssl_session_cache shared:le_nginx_SSL:1m;\n" +
 			"ssl_session_timeout 1440m;\n" +
 			"\n" +
-			"ssl_protocols TLSv1.2 TLSv1.3;\n" +
+			"ssl_protocols " + settingOr(generalConfig, "proxy/ssl/protocols", "TLSv1.2 TLSv1.3") + ";\n" +
 			"ssl_prefer_server_ciphers on;\n" +
 			"\n" +
-			"ssl_ciphers \"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384\";"
+			"ssl_ciphers \"" + settingOr(generalConfig, "proxy/ssl/ciphers",
+			"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384") + "\";"
 
 		err = os.WriteFile(ctxPath+"/options-ssl-nginx.conf", []byte(sslConfigFileContent), 0755)
 		if err != nil {
@@ -587,4 +610,18 @@ func GenerateSslCert(ctxPath string, force bool) {
 			logger.Fatal(err)
 		}
 	}
+}
+
+// settingOr returns a configured value, or the default when the key is absent
+// or empty.
+//
+// Empty is treated as absent on purpose: a key present with no value is what an
+// edited config looks like mid-thought, and rendering an empty directive gives
+// nginx a file it refuses to load — on the shared proxy, for every project at
+// once.
+func settingOr(generalConfig map[string]string, key, fallback string) string {
+	if value := generalConfig[key]; value != "" {
+		return value
+	}
+	return fallback
 }

--- a/src/helper/configs/aruntime/nginx/nginx.go
+++ b/src/helper/configs/aruntime/nginx/nginx.go
@@ -342,6 +342,12 @@ func makeProxy(projectName string) {
 func makeDockerfile(projectName string) {
 	/* Create nginx Dockerfile configuration */
 	ctxPath := paths.MakeDirsByPath(paths.CtxDir())
+
+	// The TLS options travel with the generated configuration, not with the
+	// certificate: they are derived from settings, and a certificate that still
+	// covers the current hosts is not regenerated. See WriteSslOptions.
+	WriteSslOptions(ctxPath)
+
 	nginxDefFile := paths.GetExecDirPath() + "/docker/general/nginx/proxy.Dockerfile"
 	project.RenderTo(projectName, nginxDefFile, "general/nginx/proxy.Dockerfile", ctxPath+"/Dockerfile", nil)
 	/* END Create nginx Dockerfile configuration */
@@ -427,26 +433,7 @@ func GenerateSslCert(ctxPath string, force bool) {
 			log.Fatalf("Unable to write file: %v", err)
 		}
 
-		// Which TLS versions and ciphers the proxy offers.
-		//
-		// A setting because the demand to narrow it arrives from outside — an
-		// audit, a payment processor, a customer's security review — and used to
-		// need a code change and a new binary on every machine. The defaults are
-		// the values that were compiled in.
-		generalConfig := configs2.GetGeneralConfig()
-		sslConfigFileContent := "ssl_session_cache shared:le_nginx_SSL:1m;\n" +
-			"ssl_session_timeout 1440m;\n" +
-			"\n" +
-			"ssl_protocols " + settingOr(generalConfig, "proxy/ssl/protocols", "TLSv1.2 TLSv1.3") + ";\n" +
-			"ssl_prefer_server_ciphers on;\n" +
-			"\n" +
-			"ssl_ciphers \"" + settingOr(generalConfig, "proxy/ssl/ciphers",
-			"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384") + "\";"
-
-		err = os.WriteFile(ctxPath+"/options-ssl-nginx.conf", []byte(sslConfigFileContent), 0755)
-		if err != nil {
-			log.Fatalf("Unable to write file: %v", err)
-		}
+		WriteSslOptions(ctxPath)
 
 		doGenerateSsl := false
 		if !paths.IsFileExist(ctxPath + "/madockCA.pem") {
@@ -624,4 +611,32 @@ func settingOr(generalConfig map[string]string, key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+// WriteSslOptions writes the TLS options every server block includes.
+//
+// Written on every generation rather than beside the certificate, and the
+// difference is the whole reason this is a function: the file is derived from
+// settings, not from the certificate, but it used to be written only inside
+// GenerateSslCert — which does nothing when the certificate already covers the
+// current hosts. So changing `proxy/ssl/protocols` and starting the project
+// left the old file in place and the proxy went on offering what it offered
+// before. Measured in the VM: limited to TLSv1.3, the proxy still completed a
+// TLS 1.2 handshake, and only the end-to-end test saw it — the generated text
+// was correct and unread.
+func WriteSslOptions(ctxPath string) {
+	generalConfig := configs2.GetGeneralConfig()
+
+	content := "ssl_session_cache shared:le_nginx_SSL:1m;\n" +
+		"ssl_session_timeout 1440m;\n" +
+		"\n" +
+		"ssl_protocols " + settingOr(generalConfig, "proxy/ssl/protocols", "TLSv1.2 TLSv1.3") + ";\n" +
+		"ssl_prefer_server_ciphers on;\n" +
+		"\n" +
+		"ssl_ciphers \"" + settingOr(generalConfig, "proxy/ssl/ciphers",
+		"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384") + "\";"
+
+	if err := os.WriteFile(ctxPath+"/options-ssl-nginx.conf", []byte(content), 0755); err != nil {
+		log.Fatalf("Unable to write file: %v", err)
+	}
 }

--- a/src/helper/configs/aruntime/project/limits_test.go
+++ b/src/helper/configs/aruntime/project/limits_test.go
@@ -1,0 +1,81 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/faradey/madock/v4/src/helper/testenv"
+)
+
+// readGenerated reads one file out of the project's generated runtime.
+func readGenerated(t *testing.T, env *testenv.Env, relative string) string {
+	t.Helper()
+
+	path := filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName, relative)
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	return string(body)
+}
+
+// The php limits reach the vhost, which is the half the golden fixtures cannot
+// show: they render the defaults, and the defaults are the numbers that were
+// hardcoded before. What had to be proved is that a project can change them.
+//
+// They were three copies of one number inside the platform vhosts, and the only
+// way to change them was to copy a 240-line vhost into the project's own
+// .madock/docker and let it drift from upstream. What runs into them is an
+// import or a reindex through the web, and what that looks like is a 500 with
+// nothing in the nginx log to explain it.
+func TestPhpLimitsReachTheVhost(t *testing.T) {
+	env := testenv.SetupWith(t, "limitsproject", "limits.test", map[string]string{
+		"php/limits/memory":                 "4096M",
+		"php/limits/max_execution_time":     "7200",
+		"php/limits/max_execution_time_web": "900",
+	})
+
+	MakeConf("limitsproject")
+
+	vhost := readGenerated(t, env, "ctx/nginx.conf")
+	for _, want := range []string{
+		"memory_limit=4096M",
+		"max_execution_time=7200",
+		"max_execution_time=900",
+	} {
+		if !strings.Contains(vhost, want) {
+			t.Errorf("missing %q in the generated vhost:\n%s", want, firstLines(vhost, 60))
+		}
+	}
+
+	if strings.Contains(vhost, "memory_limit=756M") {
+		t.Errorf("the vhost still carries the old hardcoded memory limit:\n%s", firstLines(vhost, 60))
+	}
+}
+
+// The body size a project accepts is its own setting now. Two limits sit in the
+// path — this one and proxy/max_body_size in the shared proxy — and an upload
+// that dies between them says nothing useful, which is why they are named the
+// same thing in both places.
+func TestProjectBodySizeReachesTheVhost(t *testing.T) {
+	env := testenv.SetupWith(t, "bodysizeproject", "bodysize.test", map[string]string{
+		"nginx/max_body_size": "512M",
+	})
+
+	MakeConf("bodysizeproject")
+
+	vhost := readGenerated(t, env, "ctx/nginx.conf")
+	if !strings.Contains(vhost, "client_max_body_size       512M;") {
+		t.Errorf("the configured body size did not reach the vhost:\n%s", firstLines(vhost, 60))
+	}
+}
+
+func firstLines(text string, n int) string {
+	lines := strings.Split(text, "\n")
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -76,6 +76,14 @@
                         <code>base</code>
                     </www>
                 </hosts>-->
+                <!-- The largest request body this project's own vhost accepts.
+                     
+                     Two limits sit in the path and both have to allow an upload:
+                     this one and proxy/max_body_size in the shared proxy, which
+                     is the smaller of the two by default. The vhost used to
+                     promise 2G while the proxy stopped the request at 128M, and
+                     an upload that dies between them says nothing useful. -->
+                <max_body_size>2G</max_body_size>
                 <ssl>
                     <enabled>true</enabled>
                 </ssl>
@@ -149,6 +157,36 @@
                      that the first attempt to justify them attributed a whole
                      suite's result to all four keys changed at once, which is a
                      coincidence wearing a measurement's clothes. -->
+                <!-- What php-fpm is told per request by the vhost.
+                     
+                     These were three copies of the same number inside the
+                     platform vhosts (magento2, shopware, sylius and the shared
+                     php snippet), and a project could not change them without
+                     copying a 240-line vhost into its own .madock/docker.
+                     An import or a reindex through the web is exactly what runs
+                     into them, and what it looks like is a 500 with nothing in
+                     the nginx log to explain it.
+
+                     max_execution_time_web is the shorter one used for ordinary
+                     page requests on Magento; max_execution_time is what the
+                     long-running entry points get. -->
+                <limits>
+                    <memory>756M</memory>
+                    <max_execution_time>18000</max_execution_time>
+                    <max_execution_time_web>600</max_execution_time_web>
+                </limits>
+                <!-- php.ini values written when the image is built.
+                     
+                     Editing php.ini inside a running container does not survive
+                     the next rebuild — the image is built from the template, and
+                     the edit goes with it. These are the four that get changed
+                     first, so they are keys rather than literals in a snippet. -->
+                <ini>
+                    <post_max_size>80M</post_max_size>
+                    <upload_max_filesize>50M</upload_max_filesize>
+                    <max_input_vars>50000</max_input_vars>
+                    <session_cookie_lifetime>2592000</session_cookie_lifetime>
+                </ini>
                 <fpm>
                     <max_children>40</max_children>
                     <start_servers>2</start_servers>
@@ -508,6 +546,30 @@
                     <repository>nginx</repository>
                     <version>1.28</version>
                 </nginx>
+                <!-- Worker and hash-table settings for the shared proxy.
+                     
+                     bucket_size is the one with teeth: nginx refuses to start
+                     when a hostname does not fit it, and the shared proxy is one
+                     per machine — that refusal takes every project down at once.
+                     It used to be a literal in the binary, so raising it meant a
+                     new build. -->
+                <worker>
+                    <processes>2</processes>
+                    <rlimit_nofile>200000</rlimit_nofile>
+                    <connections>4096</connections>
+                </worker>
+                <server_names_hash>
+                    <bucket_size>128</bucket_size>
+                    <max_size>1024</max_size>
+                </server_names_hash>
+                <!-- What TLS the proxy offers. A setting because the demand to
+                     narrow it comes from outside — an audit, a payment provider,
+                     a customer's security review — and used to need a code
+                     change and a new binary on every machine. -->
+                <ssl>
+                    <protocols>TLSv1.2 TLSv1.3</protocols>
+                    <ciphers>ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384</ciphers>
+                </ssl>
                 <timeout>
                     <connect>60</connect>
                     <send>300</send>

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.4"
+const Version = "4.2.5"

--- a/test/e2e/settings_test.go
+++ b/test/e2e/settings_test.go
@@ -1,0 +1,223 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestProxyStartsWithTheWorkerSettingsItIsGiven is the scenario the settings
+// were extracted for, and the one the unit tests cannot reach.
+//
+// Those compare text: they say the generated file carries the numbers. Whether
+// nginx will *load* that file is a different question, and on the shared proxy
+// it is the expensive one — the proxy is one container per machine, so a file it
+// refuses takes every project down together. `server_names_hash_bucket_size` is
+// exactly such a value: nginx stops with "could not build server_names_hash, you
+// should increase server_names_hash_bucket_size" when a hostname does not fit.
+//
+// So the assertion is a running proxy and a site that answers, with the numbers
+// changed from their defaults.
+func TestProxyStartsWithTheWorkerSettingsItIsGiven(t *testing.T) {
+	install := newInstallation(t)
+	p := install.project("e2eworkers")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2eworkers.test",
+	)
+
+	// Away from the defaults in both directions: fewer workers, a bigger hash
+	// table. A test that only raised numbers would pass against a binary that
+	// ignored the setting and rendered the defaults, because the defaults are
+	// large enough for one short hostname.
+	// --global, because the shared proxy is one per machine and reads the
+	// installation's own config. Without the flag the value lands in the
+	// project's file, where nothing reads it: the first run of this test set the
+	// three keys, watched config:set accept them, and found the generated proxy
+	// still carrying the defaults.
+	for key, value := range map[string]string{
+		"proxy/worker/processes":              "3",
+		"proxy/worker/connections":            "2048",
+		"proxy/server_names_hash/bucket_size": "256",
+	} {
+		p.run(2*time.Minute, "config:set", "--global", "-n", key, "-v", value)
+	}
+
+	p.run(20*time.Minute, "start")
+
+	// The file first, so a failure below can be told apart: rendered wrong, or
+	// rendered right and refused.
+	proxyConf := readFile(t, filepath.Join(install.dir, "aruntime", "ctx", "proxy.conf"))
+	for _, want := range []string{
+		"worker_processes 3;",
+		"worker_connections 2048;",
+		"server_names_hash_bucket_size  256;",
+	} {
+		requireContains(t, proxyConf, want, "the generated proxy configuration")
+	}
+
+	// And the proxy itself. `status` reports the container; the request proves
+	// nginx accepted the configuration rather than exiting on it.
+	requireContains(t, p.run(3*time.Minute, "status"), "nginx", "the proxy after a start with changed worker settings")
+
+	if status, _ := proxyGet(t, "e2eworkers.test"); status == 0 {
+		describeProxy(t, p)
+		t.Fatal("nothing answered on 443 after the worker settings were changed — the proxy did not accept its configuration")
+	}
+}
+
+// TestPhpMemoryLimitReachesTheRunningInterpreter asks php, not the file.
+//
+// The limit is handed over as a fastcgi parameter by the project's vhost, so
+// nothing about it is visible from the container's own php.ini and nothing in
+// the generated text proves it arrived. The only honest witness is a request
+// that goes through nginx into php-fpm and reports what the interpreter has.
+//
+// It was three copies of one number inside the platform vhosts until 4.2.5, and
+// a project could not change them at all without adopting a 240-line file.
+func TestPhpMemoryLimitReachesTheRunningInterpreter(t *testing.T) {
+	install := newInstallation(t)
+	p := install.project("e2ephplimit")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=php",
+		"--hosts=e2ephplimit.test",
+	)
+
+	p.run(2*time.Minute, "config:set", "-n", "php/limits/memory", "-v", "333M")
+
+	// The page that answers the question, in the directory the vhost actually
+	// serves: `public/`, from `public_dir` in the defaults. The first run put it
+	// at the project root and got nginx's own 404 — a reminder that "the file is
+	// there" and "the server serves it" are two claims.
+	writeProjectFile(t, p, filepath.Join("public", "index.php"),
+		"<?php echo 'memory_limit=', ini_get('memory_limit'), \"\\n\";\n")
+
+	p.run(25*time.Minute, "start")
+
+	status, body := proxyGet(t, "e2ephplimit.test")
+	if status == 0 {
+		describeProxy(t, p)
+		t.Fatal("the project did not answer over HTTPS, so nothing can be asked of php")
+	}
+
+	requireContains(t, body, "memory_limit=333M", "what the running interpreter reports")
+	if strings.Contains(body, "memory_limit=756M") {
+		t.Errorf("php still has the old hardcoded limit:\n%s", body)
+	}
+}
+
+// TestProxyOffersOnlyTheTlsVersionsItIsGiven measures the handshake rather than
+// the file, and the difference is not academic here: the headers feature was
+// caught by exactly this gap — the file said one thing and the response carried
+// another.
+func TestProxyOffersOnlyTheTlsVersionsItIsGiven(t *testing.T) {
+	install := newInstallation(t)
+	p := install.project("e2etls")
+
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2etls.test",
+	)
+
+	p.run(2*time.Minute, "config:set", "--global", "-n", "proxy/ssl/protocols", "-v", "TLSv1.3")
+	p.run(20*time.Minute, "start")
+
+	// 1.3 must work.
+	if version, err := handshakeVersion(t, "e2etls.test", tls.VersionTLS13, tls.VersionTLS13); err != nil {
+		describeProxy(t, p)
+		t.Fatalf("TLS 1.3 was configured and refused: %v", err)
+	} else if version != tls.VersionTLS13 {
+		t.Errorf("negotiated 0x%x, want TLS 1.3", version)
+	}
+
+	// And 1.2 must not, which is the half that says the setting was applied
+	// rather than merely written. A proxy still on the default offers both.
+	if version, err := handshakeVersion(t, "e2etls.test", tls.VersionTLS12, tls.VersionTLS12); err == nil {
+		t.Errorf("TLS 1.2 was still accepted (negotiated 0x%x) after the proxy was limited to 1.3", version)
+	}
+}
+
+// proxyGet fetches one page through the shared proxy on 443, returning 0 when
+// nothing answered. Short by design: the waiting these tests need is measured in
+// seconds, not the fifteen minutes a real store takes to warm up.
+func proxyGet(t *testing.T, host string) (int, string) {
+	t.Helper()
+
+	client := &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{Timeout: 10 * time.Second}).DialContext(ctx, network, "127.0.0.1:443")
+			},
+			TLSClientConfig: &tls.Config{ServerName: host, InsecureSkipVerify: true},
+		},
+	}
+
+	deadline := time.Now().Add(3 * time.Minute)
+	for attempt := 1; ; attempt++ {
+		resp, err := client.Get("https://" + host + "/")
+		if err == nil {
+			body := make([]byte, 32*1024)
+			n, _ := resp.Body.Read(body)
+			_ = resp.Body.Close()
+			return resp.StatusCode, string(body[:n])
+		}
+		if time.Now().After(deadline) {
+			t.Logf("%s never answered: %v (%d attempts)", host, err, attempt)
+			return 0, ""
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// handshakeVersion opens one TLS connection within the given version range and
+// reports what was negotiated.
+func handshakeVersion(t *testing.T, host string, min, max uint16) (uint16, error) {
+	t.Helper()
+
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:443", 15*time.Second)
+	if err != nil {
+		return 0, err
+	}
+	defer conn.Close()
+
+	client := tls.Client(conn, &tls.Config{
+		ServerName:         host,
+		InsecureSkipVerify: true,
+		MinVersion:         min,
+		MaxVersion:         max,
+	})
+	if err := client.Handshake(); err != nil {
+		return 0, err
+	}
+	defer client.Close()
+
+	return client.ConnectionState().Version, nil
+}
+
+// writeProjectFile puts a file in the project's own directory, which is what the
+// containers mount as the document root.
+func writeProjectFile(t *testing.T, p *project, name, body string) {
+	t.Helper()
+
+	path := filepath.Join(p.runDir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("creating %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", name, err)
+	}
+}


### PR DESCRIPTION
Every key carries the value that was compiled in, so a machine that sets nothing renders exactly what it rendered before. **The golden fixtures did not move — that is the proof.**

- **`proxy/server_names_hash/*`** pays for the change on its own: nginx *refuses to start* when a hostname does not fit `bucket_size`, the shared proxy is one per machine, and that refusal takes every project down together. Raising it meant editing Go and shipping a new binary.
- **`proxy/worker/*`** — two workers on a box running seven projects was a choice nobody could revisit.
- **`proxy/ssl/protocols`, `proxy/ssl/ciphers`** — the demand to narrow TLS arrives from an audit or a payment provider, not from us.
- **`php/limits/*`** — three copies of one number inside the platform vhosts. A project could only change them by copying a 240-line vhost into `.madock/docker/` and keeping it in sync for ever. What runs into them is an import or a reindex through the web, and what that looks like is a 500 with nothing in the nginx log.
- **`php/ini/*`** — `post_max_size`, `upload_max_filesize`, `max_input_vars`, `session_cookie_lifetime`: the four anyone edits first, and an edit inside a running container does not survive the next rebuild.
- **`nginx/max_body_size`** named to match `proxy/max_body_size`. Two limits sit in the request path; the vhost promised 2G while the proxy stopped the upload at 128M.

PrestaShop's 16M and WooCommerce's 64M are deliberate and stay literal.

Proved by breaking both new paths: with the worker setting ignored the preamble test goes red; with the magento2 vhost reverted to `756M` the limits test does.