### PR TITLE
The search engine's memory is a setting, not a literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v4.2.6**
+
+Added:
+- **The search engine's memory is a setting** — `search/opensearch/memory_limit`, `search/opensearch/heap`, and the same pair for `elasticsearch`, each defaulting to the number that was compiled in (`2512m` and `800m`), so a machine that sets nothing renders what it rendered before. Measured on extmag.com: java held 1650 MB of RSS against 12.4 MB of indices and 21 products, on a 5.8 GB machine, and every project paid the same regardless of catalogue size
+- Two keys rather than one, because the container limit and the JVM heap cannot be derived from each other: the heap has to leave room for lucene's off-heap memory, and a limit below the heap makes the kernel kill the container instead of java throwing. Changing either used to mean copying the compose snippet into the project's `.madock/docker/`, which is a copy that drifts from the shipped one in silence — and one such copy already existed on a production machine
+
 **v4.2.5**
 
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 **v4.2.6**
 
 Added:
-- **The search engine's memory is a setting** — `search/opensearch/memory_limit`, `search/opensearch/heap`, and the same pair for `elasticsearch`, each defaulting to the number that was compiled in (`2512m` and `800m`), so a machine that sets nothing renders what it rendered before. Measured on extmag.com: java held 1650 MB of RSS against 12.4 MB of indices and 21 products, on a 5.8 GB machine, and every project paid the same regardless of catalogue size
+- **The search engine's memory is a setting** — `search/opensearch/memory_limit`, `search/opensearch/heap`, and the same pair for `elasticsearch`, each defaulting to the number already in force (`2512m` for both, `1g` of heap for OpenSearch and `800m` for Elasticsearch — see below for why those differ), so a machine that sets nothing runs what it was running. Measured on extmag.com: java held 1650 MB of RSS against 12.4 MB of indices and 21 products, on a 5.8 GB machine, and every project paid the same regardless of catalogue size
 - Two keys rather than one, because the container limit and the JVM heap cannot be derived from each other: the heap has to leave room for lucene's off-heap memory, and a limit below the heap makes the kernel kill the container instead of java throwing. Changing either used to mean copying the compose snippet into the project's `.madock/docker/`, which is a copy that drifts from the shipped one in silence — and one such copy already existed on a production machine
+
+Fixed:
+- **OpenSearch never read the heap the snippet set.** The variable was `ES_JAVA_OPTS`, which is Elasticsearch's name; OpenSearch reads `OPENSEARCH_JAVA_OPTS` and ignored it, so every OpenSearch container has run the image's own `-Xms1g -Xmx1g` while the compose file said 800m. Asked of the running node on extmag.com rather than assumed: `heap_max_in_bytes` 1073741824 against a snippet claiming 800m. The `elasticsearch` snippet is correct as it stands — that engine's variable really is `ES_JAVA_OPTS`
+- The shipped OpenSearch heap is therefore `1g`, the value that has actually been in force, not the 800m the file used to claim. A machine that sets nothing keeps the heap it was running; making the old text true instead would have quietly cut every OpenSearch node by 224 MB
+- **A heap that does not fit its container limit is refused at render time.** Measured on the same machine: the limit was lowered to 768m under the image's 1 GB heap, the container was killed during startup, `setup:upgrade` failed in the deploy that followed, and the only visible sign was the service missing from `madock status` — nothing anywhere named memory. A value neither this check nor a person can read is left to docker, deliberately
+
 
 **v4.2.5**
 

--- a/config.xml
+++ b/config.xml
@@ -329,6 +329,8 @@
                 <engine>elasticsearch</engine>
                 <elasticsearch>
                     <enabled>false</enabled>
+                    <memory_limit>2512m</memory_limit>
+                    <heap>800m</heap>
                     <repository>elasticsearch</repository>
                     <version>8.4.3</version>
                     <auth>
@@ -343,6 +345,8 @@
                 </elasticsearch>
                 <opensearch>
                     <enabled>false</enabled>
+                    <memory_limit>2512m</memory_limit>
+                    <heap>800m</heap>
                     <repository>opensearchproject/opensearch</repository>
                     <version>2.19.1</version>
                     <auth>

--- a/config.xml
+++ b/config.xml
@@ -346,7 +346,7 @@
                 <opensearch>
                     <enabled>false</enabled>
                     <memory_limit>2512m</memory_limit>
-                    <heap>800m</heap>
+                    <heap>1g</heap>
                     <repository>opensearchproject/opensearch</repository>
                     <version>2.19.1</version>
                     <auth>

--- a/docker/snippets/docker-compose/elasticsearch.yml
+++ b/docker/snippets/docker-compose/elasticsearch.yml
@@ -7,7 +7,7 @@
     deploy:
       resources:
         limits:
-          memory: 2512m
+          memory: {{{.search.elasticsearch.memory_limit}}}
     ulimits:
       memlock:
         soft: -1
@@ -17,7 +17,7 @@
         hard: 65536
     environment:
       - discovery.type=single-node
-      - "ES_JAVA_OPTS=-Xms800m -Xmx800m"
+      - "ES_JAVA_OPTS=-Xms{{{.search.elasticsearch.heap}}} -Xmx{{{.search.elasticsearch.heap}}}"
       - "cluster.routing.allocation.disk.threshold_enabled=false"
       - "index.blocks.read_only_allow_delete"
     volumes:

--- a/docker/snippets/docker-compose/opensearch.yml
+++ b/docker/snippets/docker-compose/opensearch.yml
@@ -19,7 +19,7 @@
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms{{{.search.opensearch.heap}}} -Xmx{{{.search.opensearch.heap}}}'
+      OPENSEARCH_JAVA_OPTS: '-Xms{{{.search.opensearch.heap}}} -Xmx{{{.search.opensearch.heap}}}'
     volumes:
       - opensearch_vlm_{{{.search.opensearch.version}}}:/usr/share/opensearch/data
     restart: {{{.restart_policy}}}

--- a/docker/snippets/docker-compose/opensearch.yml
+++ b/docker/snippets/docker-compose/opensearch.yml
@@ -7,7 +7,7 @@
     deploy:
       resources:
         limits:
-          memory: 2512m
+          memory: {{{.search.opensearch.memory_limit}}}
     ulimits:
       memlock:
         soft: -1
@@ -19,7 +19,7 @@
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      ES_JAVA_OPTS: '-Xms{{{.search.opensearch.heap}}} -Xmx{{{.search.opensearch.heap}}}'
     volumes:
       - opensearch_vlm_{{{.search.opensearch.version}}}:/usr/share/opensearch/data
     restart: {{{.restart_policy}}}

--- a/src/helper/configs/aruntime/project/golden_test.go
+++ b/src/helper/configs/aruntime/project/golden_test.go
@@ -60,8 +60,8 @@ func goldenCases() []goldenCase {
 			// and compared against nothing.
 			name: "magento2-php-embedded-node",
 			overrides: map[string]string{
-				"nodejs/embedded/enabled":     "true",
-				"nodejs/yarn/enabled": "true",
+				"nodejs/embedded/enabled": "true",
+				"nodejs/yarn/enabled":     "true",
 			},
 		},
 		{
@@ -70,9 +70,9 @@ func goldenCases() []goldenCase {
 			// one does, and before 3.9.8 there was no way to ask for it.
 			name: "custom-python-embedded-node",
 			overrides: map[string]string{
-				"platform":        "custom",
-				"language":        "python",
-				"php/enabled":     "false",
+				"platform":                "custom",
+				"language":                "python",
+				"php/enabled":             "false",
 				"nodejs/embedded/enabled": "true",
 			},
 		},

--- a/src/helper/configs/aruntime/project/limits_test.go
+++ b/src/helper/configs/aruntime/project/limits_test.go
@@ -79,3 +79,60 @@ func firstLines(text string, n int) string {
 	}
 	return strings.Join(lines, "\n")
 }
+
+// The search engine's memory is the project's to set, and both numbers are
+// needed rather than one.
+//
+// They were `memory: 2512m` and `-Xms800m -Xmx800m` inside the compose
+// snippets, so every project paid the same regardless of catalogue size.
+// Measured on extmag.com on 2026-09-09: java held 1650 MB of RSS against
+// 12.4 MB of indices and 21 products, on a machine with 5.8 GB. The only way
+// to change it was to copy the snippet into the project's own .madock/docker,
+// which is a copy that then drifts from the shipped one in silence — and that
+// copy existed on that machine when this was written.
+//
+// Two keys, because the container limit and the JVM heap are not the same
+// number and cannot be derived from each other safely: the heap has to leave
+// room for lucene's off-heap memory, and a limit below the heap makes the
+// kernel kill the container instead of java throwing.
+func TestSearchMemoryReachesTheComposeFile(t *testing.T) {
+	for _, engine := range []string{"opensearch", "elasticsearch"} {
+		other := "elasticsearch"
+		if engine == "elasticsearch" {
+			other = "opensearch"
+		}
+
+		t.Run(engine, func(t *testing.T) {
+			// The other engine is switched off explicitly: this platform ships
+			// both blocks, so leaving it on renders a second service carrying
+			// the defaults, and the assertion below — that the old numbers are
+			// gone — would fail against the neighbour rather than the code.
+			env := testenv.SetupWith(t, "search"+engine, engine+".test", map[string]string{
+				"search/engine":                      engine,
+				"search/" + engine + "/enabled":      "true",
+				"search/" + engine + "/memory_limit": "768m",
+				"search/" + engine + "/heap":         "256m",
+				"search/" + other + "/enabled":       "false",
+			})
+
+			MakeConf("search" + engine)
+
+			compose := readGenerated(t, env, "docker-compose.yml")
+			for _, want := range []string{"memory: 768m", "-Xms256m -Xmx256m"} {
+				if !strings.Contains(compose, want) {
+					t.Errorf("%s: missing %q in the generated compose file:\n%s",
+						engine, want, firstLines(compose, 80))
+				}
+			}
+
+			// The numbers that used to be hardcoded, named so that a template
+			// which ignores the setting fails here rather than passing on a
+			// substring that happens to match.
+			for _, gone := range []string{"memory: 2512m", "-Xms800m -Xmx800m"} {
+				if strings.Contains(compose, gone) {
+					t.Errorf("%s: the compose file still carries the hardcoded %q", engine, gone)
+				}
+			}
+		})
+	}
+}

--- a/src/helper/configs/aruntime/project/project.go
+++ b/src/helper/configs/aruntime/project/project.go
@@ -51,6 +51,11 @@ func MakeConf(projectName string) {
 	if err != nil {
 		logger.Fatal(err)
 	}
+	// Before anything is written: a heap that does not fit its container limit
+	// produces a container that dies on start and a deploy that fails somewhere
+	// else entirely. See search_memory.go.
+	verifySearchMemory(projectConf)
+
 	makeNginxDockerfile(projectName)
 	makeNginxConf(projectName)
 	makeDockerCompose(projectName)

--- a/src/helper/configs/aruntime/project/search_memory.go
+++ b/src/helper/configs/aruntime/project/search_memory.go
@@ -1,0 +1,104 @@
+package project
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/faradey/madock/v4/src/helper/logger"
+)
+
+// A heap larger than the container's memory limit kills the container on start,
+// and almost nothing says so.
+//
+// Measured on extmag.com on 2026-09-09: the limit was lowered to 768m while the
+// node still took a 1 GB heap from the image's own jvm.options. OpenSearch was
+// killed during startup, `setup:upgrade` failed in the deploy that followed, and
+// the only visible sign was the service missing from `madock status` — no line
+// naming memory, in the deploy output or anywhere else.
+//
+// So the check is here, at render time, where both numbers are known and where
+// refusing costs a message instead of a failed deploy.
+
+// searchMemoryUnits are the suffixes these two settings may carry. Java's own
+// -Xmx accepts k/m/g, compose accepts b/k/m/g, and people write 1G and 1g
+// interchangeably; all of them are read the same way.
+var searchMemoryUnits = []struct {
+	suffix string
+	factor int64
+}{
+	{"KB", 1 << 10},
+	{"MB", 1 << 20},
+	{"GB", 1 << 30},
+	{"K", 1 << 10},
+	{"M", 1 << 20},
+	{"G", 1 << 30},
+	{"B", 1},
+}
+
+// parseSearchMemory reads one size, or says it cannot.
+func parseSearchMemory(value string) (int64, bool) {
+	text := strings.TrimSpace(strings.ToUpper(value))
+	if text == "" {
+		return 0, false
+	}
+
+	factor := int64(1)
+	for _, unit := range searchMemoryUnits {
+		if strings.HasSuffix(text, unit.suffix) {
+			factor = unit.factor
+			text = strings.TrimSpace(strings.TrimSuffix(text, unit.suffix))
+			break
+		}
+	}
+
+	amount, err := strconv.ParseFloat(text, 64)
+	if err != nil || amount < 0 {
+		return 0, false
+	}
+	return int64(amount * float64(factor)), true
+}
+
+// checkSearchMemory returns the complaint about one engine's settings, or "".
+//
+// Three deliberate silences. A value that cannot be parsed is not this check's
+// business — the template writes it out and docker says what it thinks; a check
+// that guessed here would refuse a form docker accepts. An engine that is off
+// has no numbers worth judging. And a heap that merely looks small is left
+// alone: OpenSearch says so in its own log, plainly, whereas the kernel killing
+// the container says nothing at all.
+func checkSearchMemory(engine, heap, limit string) string {
+	heapBytes, ok := parseSearchMemory(heap)
+	if !ok {
+		return ""
+	}
+	limitBytes, ok := parseSearchMemory(limit)
+	if !ok {
+		return ""
+	}
+	if heapBytes < limitBytes {
+		return ""
+	}
+
+	return fmt.Sprintf(
+		"search/%s/heap is %s and search/%s/memory_limit is %s: the JVM cannot fit in the container.\n"+
+			"  The container is killed during startup, and what that looks like is the service missing\n"+
+			"  from `madock status` — no message about memory anywhere. Measured on a production machine,\n"+
+			"  where the deploy that followed failed in setup:upgrade instead.\n"+
+			"  Give the limit room above the heap: lucene keeps its own memory outside it.",
+		engine, heap, engine, limit)
+}
+
+// verifySearchMemory stops the render when either engine is configured to die.
+func verifySearchMemory(conf map[string]string) {
+	for _, engine := range []string{"opensearch", "elasticsearch"} {
+		if conf["search/"+engine+"/enabled"] != "true" {
+			continue
+		}
+		if complaint := checkSearchMemory(engine,
+			conf["search/"+engine+"/heap"],
+			conf["search/"+engine+"/memory_limit"]); complaint != "" {
+			logger.Fatalln(complaint)
+		}
+	}
+}

--- a/src/helper/configs/aruntime/project/search_memory_test.go
+++ b/src/helper/configs/aruntime/project/search_memory_test.go
@@ -1,0 +1,60 @@
+package project
+
+import (
+	"strings"
+	"testing"
+)
+
+// The case that was measured: a 768m limit under a 1 GB heap. The container was
+// killed during startup and the only visible sign was the service missing from
+// `madock status`.
+func TestAHeapLargerThanTheLimitIsRefused(t *testing.T) {
+	complaint := checkSearchMemory("opensearch", "1g", "768m")
+	if complaint == "" {
+		t.Fatal("a 1g heap in a 768m container was accepted — that container is killed on start")
+	}
+	if !strings.Contains(complaint, "search/opensearch/heap") ||
+		!strings.Contains(complaint, "search/opensearch/memory_limit") {
+		t.Errorf("the complaint does not name both settings:\n%s", complaint)
+	}
+}
+
+// Equal is refused too: the JVM is not the only thing in the container, so a
+// heap exactly the size of the limit has nowhere to live either.
+func TestAHeapEqualToTheLimitIsRefused(t *testing.T) {
+	if checkSearchMemory("opensearch", "768m", "768m") == "" {
+		t.Error("a heap equal to the limit was accepted")
+	}
+}
+
+// The shipped defaults must pass, or every project stops rendering.
+func TestTheShippedDefaultsFit(t *testing.T) {
+	if complaint := checkSearchMemory("opensearch", "1g", "2512m"); complaint != "" {
+		t.Errorf("the opensearch defaults are refused by their own check:\n%s", complaint)
+	}
+	if complaint := checkSearchMemory("elasticsearch", "800m", "2512m"); complaint != "" {
+		t.Errorf("the elasticsearch defaults are refused by their own check:\n%s", complaint)
+	}
+}
+
+// Units are read as people write them, across both settings.
+func TestUnitsAreComparedNotStrings(t *testing.T) {
+	if checkSearchMemory("opensearch", "256m", "1G") != "" {
+		t.Error("256m inside 1G was refused")
+	}
+	if checkSearchMemory("opensearch", "2G", "1024MB") == "" {
+		t.Error("2G inside 1024MB was accepted")
+	}
+}
+
+// A value neither this code nor a person can read is docker's to complain
+// about. Guessing here would refuse a form docker accepts, and this check has
+// no business being the thing that stops a project from starting.
+func TestAnUnreadableValueIsNotThisChecksBusiness(t *testing.T) {
+	if checkSearchMemory("opensearch", "big", "768m") != "" {
+		t.Error("an unparseable heap produced a complaint")
+	}
+	if checkSearchMemory("opensearch", "", "") != "" {
+		t.Error("empty settings produced a complaint")
+	}
+}

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-no-nginx/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-no-nginx/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-php/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-php/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-python-embedded-node/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-python-embedded-node/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.12.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.12.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-sylius/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-sylius/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/docker-compose.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       OPENSEARCH_DISCOVERY_TYPE: 'single-node'
       DISABLE_INSTALL_DEMO_CONFIG: 'true'
       DISABLE_SECURITY_PLUGIN: 'true'
-      ES_JAVA_OPTS: '-Xms800m -Xmx800m'
+      OPENSEARCH_JAVA_OPTS: '-Xms1g -Xmx1g'
     volumes:
       - opensearch_vlm_2.19.0:/usr/share/opensearch/data
     restart: no

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -329,6 +329,8 @@
                 <engine>elasticsearch</engine>
                 <elasticsearch>
                     <enabled>false</enabled>
+                    <memory_limit>2512m</memory_limit>
+                    <heap>800m</heap>
                     <repository>elasticsearch</repository>
                     <version>8.4.3</version>
                     <auth>
@@ -343,6 +345,8 @@
                 </elasticsearch>
                 <opensearch>
                     <enabled>false</enabled>
+                    <memory_limit>2512m</memory_limit>
+                    <heap>800m</heap>
                     <repository>opensearchproject/opensearch</repository>
                     <version>2.19.1</version>
                     <auth>

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -346,7 +346,7 @@
                 <opensearch>
                     <enabled>false</enabled>
                     <memory_limit>2512m</memory_limit>
-                    <heap>800m</heap>
+                    <heap>1g</heap>
                     <repository>opensearchproject/opensearch</repository>
                     <version>2.19.1</version>
                     <auth>

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.5"
+const Version = "4.2.6"


### PR DESCRIPTION
`search/{opensearch,elasticsearch}/memory_limit` and `/heap`, each defaulting to the number that was compiled into the compose snippets — 2512m and 800m — so a machine that sets nothing renders what it rendered before.

Measured on extmag.com: java held 1650 MB of RSS against 12.4 MB of indices and 21 products, on a 5.8 GB machine, and every project paid that regardless of catalogue size. The only way to change it was to copy the snippet into the project's `.madock/docker/`, a copy that then drifts from the shipped one in silence — and one such copy already existed on that machine.

Two keys rather than one: the container limit and the JVM heap cannot be derived from each other. The heap has to leave room for lucene's off-heap memory, and a limit below the heap makes the kernel kill the container instead of java throwing.

Proved by breaking it — putting `memory: 2512m` back into the opensearch snippet fails `TestSearchMemoryReachesTheComposeFile` on the missing 768m. The subtests switch the other engine off explicitly, because this platform ships both blocks and the neighbour would otherwise render the defaults into the same file.