### PR TITLE
Rotate the persisted logs, and let madock logs read them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+**v4.2.9**
+
+Added:
+- **The persisted logs are rotated**, so the files 4.2.8 started keeping cannot fill a disk. Copy-and-truncate rather than rename-and-signal: the writer is in another container and madock is not its parent, so there is no way to tell nginx or mysqld to reopen a file. Copying the contents aside and truncating in place leaves their file descriptors pointing at the same inode, which is the standard answer for containers — the cost is the window between the copy and the truncate, and the sizes are large enough that it is rare
+- **`madock logs:rotate`**, because rotation on start alone is rotation that never happens: a server starts a project once and leaves it running for months. `start` still rotates, which covers a laptop; a cron entry or a person covers the rest
+- **`madock logs --file`** reads the persisted files instead of the container's stream, with `--tail` for how much. The stream holds what happened since the container was created, so after a rebuild it is empty of everything worth having — which is exactly the state a production machine was in during an intrusion review
+- `logs/persist/keep` and `logs/persist/max_size` are read here; a size neither this code nor a person can read stops the rotation with a warning rather than inventing a threshold, because a guessed default means "rotate later than you asked" and is found as a full disk
+
 **v4.2.8**
 
 Added:

--- a/src/controller/general/logs/logs.go
+++ b/src/controller/general/logs/logs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/faradey/madock/v4/src/helper/configs"
 	"github.com/faradey/madock/v4/src/helper/docker"
 	"github.com/faradey/madock/v4/src/helper/logger"
+	"github.com/faradey/madock/v4/src/helper/logrotate"
 )
 
 func init() {
@@ -57,11 +58,50 @@ func Execute() {
 	}
 
 	projectName := configs.GetProjectName()
-	cmd := exec.Command("docker", "logs", docker.GetContainerName(projectConf, projectName, service))
+	container := docker.GetContainerName(projectConf, projectName, service)
+
+	// --file answers the question the stream cannot: what happened before the
+	// last rebuild. Docker keeps a container's output inside the container's own
+	// directory and deletes it with the container, which on a production machine
+	// meant three deploys erased the HTTP record of an intrusion. The services
+	// also write files into a volume, and this reads those.
+	if args.File {
+		showPersisted(container, args.Tail)
+
+		return
+	}
+
+	cmd := exec.Command("docker", "logs", container)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		logger.Fatal(err)
+	}
+}
+
+// showPersisted prints the tail of every persisted log the service has.
+//
+// One `sh -c` inside the container rather than a copy out to the host: the files
+// live in a volume, and the only thing guaranteed to be able to read a volume is
+// something that mounts it. Missing files are not an error — a project that has
+// only just started has written nothing yet, and saying "no such file" about
+// that would read as a fault.
+func showPersisted(container, tail string) {
+	if tail == "" {
+		tail = "200"
+	}
+
+	script := "cd " + logrotate.LogDir + " 2>/dev/null || { echo 'no persisted logs for this service yet'; exit 0; }; " +
+		"found=0; for f in *.log*; do [ -f \"$f\" ] || continue; found=1; " +
+		"echo \"--- $f ---\"; tail -n " + tail + " \"$f\"; done; " +
+		"[ \"$found\" = 1 ] || echo 'no persisted logs for this service yet'"
+
+	cmd := exec.Command("docker", "exec", container, "sh", "-c", script)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmtc.ErrorLn("Could not read the persisted logs of " + container + ": " + err.Error())
+		fmtc.ToDoLn("The container has to be running: this reads a volume, and a volume is readable only from inside.")
 	}
 }

--- a/src/controller/general/logs/rotate.go
+++ b/src/controller/general/logs/rotate.go
@@ -1,0 +1,99 @@
+package logs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/faradey/madock/v4/src/command"
+	"github.com/faradey/madock/v4/src/helper/cli/fmtc"
+	"github.com/faradey/madock/v4/src/helper/configs"
+	"github.com/faradey/madock/v4/src/helper/docker"
+	"github.com/faradey/madock/v4/src/helper/logrotate"
+)
+
+func init() {
+	command.Register(&command.Definition{
+		Aliases:  []string{"logs:rotate"},
+		Handler:  RotateExecute,
+		Help:     "Rotate the persisted log files of this project's services",
+		Category: "general",
+	})
+}
+
+// rotatingServices are the ones that mount the log volume. Named rather than
+// discovered: asking docker which containers mount a volume costs a call per
+// service and answers the same thing every time, and a service added to the
+// list here is the same edit as adding the mount.
+var rotatingServices = []string{"nginx", "db"}
+
+// RotateExecute is `madock logs:rotate`, and it is also what `start` calls.
+//
+// It is a command of its own because rotation on start alone is rotation that
+// never happens on a machine whose projects are started once and left running —
+// which is every server. A person or a cron entry can ask for it directly.
+func RotateExecute() {
+	projectName := configs.GetProjectName()
+	projectConf := configs.GetProjectConfig(projectName)
+
+	for _, line := range RotateProject(projectName, projectConf) {
+		fmt.Println(line)
+	}
+}
+
+// RotateProject rotates every service that keeps files, and reports one line per
+// service that did something. It never fails the caller: rotation runs after a
+// successful start, and a project whose web server is up must not be reported as
+// broken because a log could not be copied.
+func RotateProject(projectName string, projectConf map[string]string) []string {
+	if projectConf["logs/persist/enabled"] != "true" {
+		return nil
+	}
+
+	maxSize, err := logrotate.ParseSize(projectConf["logs/persist/max_size"])
+	if err != nil {
+		fmtc.WarningLn("logs/persist/max_size: " + err.Error() + " — logs were not rotated")
+		return nil
+	}
+
+	keep, err := strconv.Atoi(projectConf["logs/persist/keep"])
+	if err != nil || keep < 1 {
+		fmtc.WarningLn("logs/persist/keep is not a number of files — logs were not rotated")
+		return nil
+	}
+
+	plan := logrotate.Plan{MaxSize: maxSize, Keep: keep}
+
+	var reported []string
+	for _, service := range rotatingServices {
+		container := docker.GetContainerName(projectConf, projectName, service)
+		out, err := logrotate.Rotate(container, plan)
+		if err != nil {
+			// A container that is not running is the ordinary case — a project
+			// with no database, a service switched off — and it is not worth a
+			// word. Anything else is, because a rotation that never runs is a
+			// disk that fills silently, which is what this exists to prevent.
+			if !containerAbsent(out) {
+				fmtc.WarningLn("could not rotate the logs of " + service + ": " + err.Error())
+			}
+			continue
+		}
+		if out != "" {
+			reported = append(reported, service+": "+out)
+		}
+	}
+
+	return reported
+}
+
+// containerAbsent recognises docker saying the container is not there, which is
+// the one failure that means nothing is wrong.
+func containerAbsent(out string) bool {
+	for _, sign := range []string{"No such container", "is not running"} {
+		if strings.Contains(out, sign) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/src/controller/general/logs/rotate_test.go
+++ b/src/controller/general/logs/rotate_test.go
@@ -1,0 +1,110 @@
+package logs
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/faradey/madock/v4/src/helper/logrotate"
+)
+
+// withRotate replaces the thing that talks to docker, so these tests measure
+// the decisions rather than a daemon.
+func withRotate(t *testing.T, fn func(container string, plan logrotate.Plan) (string, error)) *[]string {
+	t.Helper()
+
+	var seen []string
+	previous := logrotate.Rotate
+	logrotate.Rotate = func(container string, plan logrotate.Plan) (string, error) {
+		seen = append(seen, container)
+
+		return fn(container, plan)
+	}
+	t.Cleanup(func() { logrotate.Rotate = previous })
+
+	return &seen
+}
+
+func conf(extra map[string]string) map[string]string {
+	base := map[string]string{
+		"logs/persist/enabled":  "true",
+		"logs/persist/keep":     "7",
+		"logs/persist/max_size": "50M",
+		"container_name_prefix": "madock_",
+	}
+	for key, value := range extra {
+		base[key] = value
+	}
+
+	return base
+}
+
+// Off means nothing is asked of docker at all. A rotation that ran anyway would
+// create files in a project that decided it did not want them.
+func TestRotationDoesNothingWhenPersistenceIsOff(t *testing.T) {
+	seen := withRotate(t, func(string, logrotate.Plan) (string, error) { return "", nil })
+
+	RotateProject("someproject", conf(map[string]string{"logs/persist/enabled": "false"}))
+
+	if len(*seen) != 0 {
+		t.Errorf("rotation ran for a project with persistence off: %v", *seen)
+	}
+}
+
+// The numbers a project configured have to arrive at the plan, or rotation
+// happens at a size and a count nobody chose.
+func TestTheConfiguredNumbersReachThePlan(t *testing.T) {
+	var got logrotate.Plan
+	withRotate(t, func(_ string, plan logrotate.Plan) (string, error) {
+		got = plan
+
+		return "", nil
+	})
+
+	RotateProject("someproject", conf(map[string]string{"logs/persist/keep": "3", "logs/persist/max_size": "10M"}))
+
+	if got.Keep != 3 || got.MaxSize != 10<<20 {
+		t.Errorf("plan is keep=%d max=%d, expected 3 and 10M", got.Keep, got.MaxSize)
+	}
+}
+
+// A container that is not there is the ordinary case — a project without a
+// database, a service switched off — and it must not produce a warning, or the
+// warning that matters is lost among them.
+func TestAnAbsentContainerIsNotAComplaint(t *testing.T) {
+	withRotate(t, func(container string, _ logrotate.Plan) (string, error) {
+		return "Error response from daemon: No such container: " + container, errors.New("exit status 1")
+	})
+
+	if lines := RotateProject("someproject", conf(nil)); len(lines) != 0 {
+		t.Errorf("an absent container was reported as work done: %v", lines)
+	}
+}
+
+// Both services that mount the volume are asked, and the names are the ones
+// docker knows.
+func TestEveryServiceThatKeepsFilesIsRotated(t *testing.T) {
+	seen := withRotate(t, func(string, logrotate.Plan) (string, error) { return "", nil })
+
+	RotateProject("someproject", conf(nil))
+
+	joined := strings.Join(*seen, " ")
+	for _, want := range []string{"madock_someproject-nginx-1", "madock_someproject-db-1"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("%s was never rotated, only: %v", want, *seen)
+		}
+	}
+}
+
+// A size nobody can read stops the rotation rather than inventing a threshold:
+// a guessed default here means "rotate later than you asked", which is found as
+// a full disk.
+func TestAnUnreadableSizeStopsTheRotation(t *testing.T) {
+	seen := withRotate(t, func(string, logrotate.Plan) (string, error) { return "", nil })
+
+	RotateProject("someproject", conf(map[string]string{"logs/persist/max_size": "enormous"}))
+
+	if len(*seen) != 0 {
+		t.Errorf("rotation ran with an unreadable threshold: %v", *seen)
+	}
+}

--- a/src/controller/general/start/start.go
+++ b/src/controller/general/start/start.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/faradey/madock/v4/src/command"
+	"github.com/faradey/madock/v4/src/controller/general/logs"
 	"github.com/faradey/madock/v4/src/controller/platform"
 	"github.com/faradey/madock/v4/src/helper/cli/arg_struct"
 	"github.com/faradey/madock/v4/src/helper/cli/attr"
@@ -46,6 +47,18 @@ func ExecuteWith(args *arg_struct.ControllerGeneralStart) {
 
 		handler := platform.GetOrDefault(platformName)
 		handler.Start(projectName, args.WithChown, projectConf)
+
+		// Rotation runs here rather than on a schedule, because madock has no
+		// scheduler of its own on the host: the crontab it installs lives in the
+		// PHP container, and the logs live in a volume that container does not
+		// mount. A start is the one moment something is guaranteed to run.
+		//
+		// It is not enough on its own — a server starts a project once and
+		// leaves it up for months — which is why `madock logs:rotate` exists as
+		// a command a person or a cron entry can call.
+		for _, line := range logs.RotateProject(projectName, projectConf) {
+			fmt.Println(line)
+		}
 
 		elapsed := time.Since(startTime).Round(time.Second)
 		fmt.Println("")

--- a/src/helper/cli/arg_struct/args.go
+++ b/src/helper/cli/arg_struct/args.go
@@ -121,6 +121,11 @@ type ControllerGeneralLogs struct {
 	// container logs. The flag stays: it is what the rest of the commands use.
 	Name    string `arg:"positional" help:"Service name; the same thing --service takes"`
 	Service string `arg:"-s,--service" help:"Service name (php, nginx, db, etc.)"`
+	// The container's stream holds what happened since the container was
+	// created, and a rebuild creates a new one. --file reads what the service
+	// wrote to the persisted log instead, which is the copy that survives.
+	File bool   `arg:"-f,--file" help:"Read the persisted log files instead of the container's stream"`
+	Tail string `arg:"--tail" help:"With --file: how many lines from the end of each file (default 200)"`
 }
 
 type ControllerGeneralPatch struct {

--- a/src/helper/logrotate/logrotate.go
+++ b/src/helper/logrotate/logrotate.go
@@ -1,0 +1,123 @@
+// Package logrotate keeps the persisted container logs from growing without end.
+//
+// The logs live in a volume mounted at /var/log/madock, written by nginx and by
+// the database. Nothing inside those images rotates them: the official nginx
+// image ships no logrotate, MariaDB rotates nothing of its own, and the crontab
+// madock installs runs in the PHP container, which is not where these files are.
+// Left alone the access log of a busy site fills a disk, and the first anyone
+// hears of it is a machine that has stopped.
+//
+// The rotation is copy-and-truncate, and that is the one decision worth stating.
+// Ordinary rotation renames the file and asks the writer to reopen it — a signal
+// this cannot send, because the process is in another container and madock is
+// not its parent. Copying the contents aside and truncating the file in place
+// leaves the writer's file descriptor pointing at the same inode, so nginx and
+// mysqld go on writing without being told anything. The cost is the window
+// between the copy and the truncate: a line written in it is lost. That is the
+// standard trade for containers, and it is the reason the sizes here are large
+// enough that rotation is rare.
+package logrotate
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// LogDir is where the services write, inside every container that mounts the
+// volume.
+const LogDir = "/var/log/madock"
+
+// Plan is what a rotation would do, with the numbers a project configured.
+type Plan struct {
+	// MaxSize is the size a file has to reach before it is rotated, in bytes.
+	MaxSize int64
+	// Keep is how many rotated copies survive. The oldest goes when a new one
+	// arrives.
+	Keep int
+}
+
+// Script renders the shell a container runs to rotate its own logs.
+//
+// POSIX sh and nothing else: it runs in the nginx image and in the MariaDB one,
+// and the only tools both are guaranteed to have are the ones in this text. No
+// `find -size`, no `stat -c` — busybox and coreutils disagree about both.
+//
+// The order matters and is the whole of the correctness here: the oldest copy
+// is dropped first, the rest shift up, the live file is copied to `.1` and only
+// then truncated. Truncating before the copy would lose everything the file
+// held; shifting after the copy would overwrite `.1` with itself.
+func (p Plan) Script() string {
+	keep := p.Keep
+	if keep < 1 {
+		keep = 1
+	}
+
+	return strings.Join([]string{
+		"set -e",
+		"cd " + LogDir + " 2>/dev/null || exit 0",
+		"for f in *.log; do",
+		"  [ -f \"$f\" ] || continue",
+		// wc -c rather than stat: the two images disagree about stat's flags,
+		// and a rotation that fails on one of them is a log that grows for ever
+		// on that one.
+		"  size=$(wc -c < \"$f\")",
+		"  [ \"$size\" -ge " + strconv.FormatInt(p.MaxSize, 10) + " ] || continue",
+		"  i=" + strconv.Itoa(keep),
+		"  while [ \"$i\" -gt 1 ]; do",
+		"    prev=$((i-1))",
+		"    [ -f \"$f.$prev\" ] && mv \"$f.$prev\" \"$f.$i\"",
+		"    i=$prev",
+		"  done",
+		"  cp \"$f\" \"$f.1\"",
+		// The truncate. `: >` rather than rm: the writer holds this inode open,
+		// and deleting the file would leave it writing into space nobody can
+		// read until the container restarts — the exact failure this package
+		// exists to avoid, arrived at from the other direction.
+		"  : > \"$f\"",
+		"done",
+	}, "\n")
+}
+
+// ParseSize reads a size the way a person writes it in configuration: 50M, 1G,
+// 512K, or a bare number of bytes.
+//
+// An unreadable value is an error rather than a default, because the default
+// here is "rotate later than you asked" — silent, and discovered as a full disk.
+func ParseSize(value string) (int64, error) {
+	text := strings.TrimSpace(strings.ToUpper(value))
+	if text == "" {
+		return 0, fmt.Errorf("empty size")
+	}
+
+	multiplier := int64(1)
+	switch {
+	case strings.HasSuffix(text, "K"), strings.HasSuffix(text, "KB"):
+		multiplier = 1 << 10
+	case strings.HasSuffix(text, "M"), strings.HasSuffix(text, "MB"):
+		multiplier = 1 << 20
+	case strings.HasSuffix(text, "G"), strings.HasSuffix(text, "GB"):
+		multiplier = 1 << 30
+	}
+	text = strings.TrimRight(text, "KMGB")
+
+	amount, err := strconv.ParseFloat(strings.TrimSpace(text), 64)
+	if err != nil || amount <= 0 {
+		return 0, fmt.Errorf("%q is not a size: expected something like 50M or 1G", value)
+	}
+
+	return int64(amount * float64(multiplier)), nil
+}
+
+// Rotate runs the plan inside one container and reports what the shell said.
+//
+// Failures are returned rather than fatal for the caller to decide: rotation
+// runs after `start`, and a project whose web server is up must not be reported
+// as broken because a log file could not be copied.
+var Rotate = func(container string, plan Plan) (string, error) {
+	cmd := exec.Command("docker", "exec", container, "sh", "-c", plan.Script())
+	out, err := cmd.CombinedOutput()
+
+	return string(out), err
+}

--- a/src/helper/logrotate/logrotate_test.go
+++ b/src/helper/logrotate/logrotate_test.go
@@ -1,0 +1,89 @@
+package logrotate
+
+import (
+	"strings"
+	"testing"
+)
+
+// The order inside the script is the whole of its correctness, and it is easy
+// to get wrong in a way that reads fine: truncating before copying loses
+// everything the file held, and shifting the numbered copies after the copy
+// overwrites `.1` with itself.
+func TestTheScriptCopiesBeforeItTruncates(t *testing.T) {
+	script := Plan{MaxSize: 1 << 20, Keep: 3}.Script()
+
+	copyAt := strings.Index(script, `cp "$f" "$f.1"`)
+	truncateAt := strings.Index(script, `: > "$f"`)
+	shiftAt := strings.Index(script, `mv "$f.$prev" "$f.$i"`)
+
+	if copyAt < 0 || truncateAt < 0 || shiftAt < 0 {
+		t.Fatalf("the script lost one of its three steps:\n%s", script)
+	}
+	if !(shiftAt < copyAt && copyAt < truncateAt) {
+		t.Errorf("the steps are out of order — shift %d, copy %d, truncate %d:\n%s",
+			shiftAt, copyAt, truncateAt, script)
+	}
+}
+
+// Truncation in place, never deletion. The writer holds the inode open, so
+// removing the file would leave nginx writing into space nobody can read until
+// the container restarts — the same disappearance this whole feature exists to
+// stop, reached from the other side.
+func TestTheScriptNeverDeletesTheLiveFile(t *testing.T) {
+	script := Plan{MaxSize: 1 << 20, Keep: 3}.Script()
+
+	if strings.Contains(script, `rm "$f"`) || strings.Contains(script, "rm -f \"$f\"") {
+		t.Errorf("the live log is deleted rather than truncated:\n%s", script)
+	}
+}
+
+// The size a project configured has to reach the comparison, or rotation
+// happens at some number nobody chose.
+func TestTheConfiguredSizeReachesTheScript(t *testing.T) {
+	script := Plan{MaxSize: 52428800, Keep: 7}.Script()
+
+	if !strings.Contains(script, "52428800") {
+		t.Errorf("the threshold is missing from the script:\n%s", script)
+	}
+	if !strings.Contains(script, "i=7") {
+		t.Errorf("the number of copies to keep is missing:\n%s", script)
+	}
+}
+
+// Keep must never be zero: the loop would shift nothing and `cp` would write
+// `.1` over a copy that is still the newest, so the rotation would silently
+// keep exactly one generation whatever was asked for.
+func TestKeepIsAtLeastOne(t *testing.T) {
+	if script := (Plan{MaxSize: 100, Keep: 0}).Script(); !strings.Contains(script, "i=1") {
+		t.Errorf("keep=0 did not fall back to one copy:\n%s", script)
+	}
+}
+
+func TestParseSizeReadsWhatPeopleWrite(t *testing.T) {
+	for value, want := range map[string]int64{
+		"50M":  50 << 20,
+		"50MB": 50 << 20,
+		"1G":   1 << 30,
+		"512K": 512 << 10,
+		"1024": 1024,
+	} {
+		got, err := ParseSize(value)
+		if err != nil {
+			t.Errorf("%q: %v", value, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("%q read as %d, want %d", value, got, want)
+		}
+	}
+}
+
+// An unreadable size is an error, not a default. A default here means "rotate
+// later than you asked", which is silent and is discovered as a full disk.
+func TestParseSizeRefusesWhatItCannotRead(t *testing.T) {
+	for _, value := range []string{"", "big", "-5M", "0"} {
+		if _, err := ParseSize(value); err == nil {
+			t.Errorf("%q was accepted as a size", value)
+		}
+	}
+}

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.8"
+const Version = "4.2.9"


### PR DESCRIPTION
4.2.8 started keeping log files in a volume; without rotation they fill a disk, and the first anyone hears of that is a machine that has stopped.

**Copy-and-truncate, not rename-and-signal.** Ordinary rotation renames the file and asks the writer to reopen it — a signal this cannot send, because the process is in another container and madock is not its parent. Copying the contents aside and truncating in place leaves nginx's and mysqld's descriptors pointing at the same inode. The cost is the window between copy and truncate, and the thresholds are large enough that rotation is rare.

The script is POSIX sh and uses `wc -c` rather than `stat`: it runs in both the nginx image and the MariaDB one, and those disagree about stat's flags — a rotation that fails on one is a log that grows for ever on that one.

**`madock logs:rotate`** exists because rotation on start alone never happens on a server: a project is started once and left up for months. `start` still rotates, which covers a laptop.

**`madock logs --file [--tail N]`** reads the persisted copies. The container's stream holds only what happened since the container was created, so after a rebuild it is empty of everything worth having — the exact state a production machine was in during an intrusion review.

A size neither the code nor a person can read stops the rotation with a warning instead of inventing a threshold: a guessed default means "rotate later than you asked", and that is found as a full disk.

Proved by breaking it: removing the copy step turns `TestTheScriptCopiesBeforeItTruncates` red.