### PR TITLE
The optional PHP extensions installed nothing and said success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+**v4.2.10**
+
+Fixed:
+- **The optional PHP extensions reported success and installed nothing.** Each line in that block ran `apt-get install … || true` in its own layer, while the `apt-get update` belonged to the layer above — so on a cached build they ran against whatever index that layer had left behind, and `|| true` swallowed the result. Measured on the Magento stand: a full rebuild exited 0, every service came up, and `php -r extension_loaded('ldap')` printed 0 with nothing in `mods-available` and no dpkg entry. The same hole covered `opcache`, `xmlrpc` and `memcached` — opcache above all, since without it every request recompiles and nothing says so
+- Each optional install now refreshes the index first, `ldap` verifies itself with `php -m` immediately afterwards, and the fallback is `|| echo "madock: <package> is not available in this index"` rather than `|| true`. A package this image could not get is said out loud where somebody would see it
+- **An end-to-end test asks the running container, not the Dockerfile.** The rendered line was correct throughout — reading it was how the hole stayed open — so the test starts a PHP project and reads `php -m`, matching whole lines so a substring cannot report a hole as filled
+
 **v4.2.9**
 
 Added:

--- a/docker/snippets/dockerfile/php/header
+++ b/docker/snippets/dockerfile/php/header
@@ -57,25 +57,45 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php{{{.ph
     php{{{.php.version}}}-ssh2 \
     php{{{.php.version}}}-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php{{{.php.version}}}-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php{{{.php.version}}}-opcache \
+    || echo "madock: php{{{.php.version}}}-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php{{{.php.version}}}-ldap || true
-RUN apt-get install -y php{{{.php.version}}}-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php{{{.php.version}}}-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php{{{.php.version}}}-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php{{{.php.version}}}-xmlrpc \
+    || echo "madock: php{{{.php.version}}}-xmlrpc is not available in this index"
 
 {{{- if .memcached.enabled}}}
 # Pulled in only while the memcached service is enabled — it is the one extension
 # with a service behind it. ondrej lags a release or two behind for the newest PHP
 # versions, so a hard failure here would break the image for everyone else.
-RUN apt-get install -y php{{{.php.version}}}-memcached || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php{{{.php.version}}}-memcached \
+    || echo "madock: php{{{.php.version}}}-memcached is not available in this index"
 {{{- end}}}
 
 SHELL ["/bin/bash", "-c"]

--- a/docker/snippets/dockerfile/php/withoutXdebug
+++ b/docker/snippets/dockerfile/php/withoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php{{{.php.v
     php{{{.php.version}}}-imagick \
     php{{{.php.version}}}-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php{{{.php.version}}}-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php{{{.php.version}}}-opcache \
+    || echo "madock: php{{{.php.version}}}-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php{{{.php.version}}}-ldap || true
-RUN apt-get install -y php{{{.php.version}}}-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php{{{.php.version}}}-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php{{{.php.version}}}-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php{{{.php.version}}}-xmlrpc \
+    || echo "madock: php{{{.php.version}}}-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "{{{.php.version}}}" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-shopify/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-shopify/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-sylius/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-sylius/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/ctx/php.Dockerfile
+++ b/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/ctx/php.Dockerfile
@@ -57,19 +57,37 @@ RUN apt-get -y --allow-releaseinfo-change update && apt-get install -y php8.4-bc
     php8.4-ssh2 \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc was dropped
 # from PHP core in 8.0 and may be missing in newer ondrej builds). Install
 # each in its own line so a missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/ctx/php.DockerfileWithoutXdebug
+++ b/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/ctx/php.DockerfileWithoutXdebug
@@ -42,19 +42,37 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y php8.4-bcmat
     php8.4-imagick \
     php8.4-redis
 
-# Optional packages: not all PHP versions ship them as separate packages
+# Optional packages: not all PHP versions ship them as separate packages.
+#
+# Each line refreshes the index first, and that is not belt and braces: the
+# install above is a separate layer, so on a cached build these run against
+# whatever index that layer left behind — which apt may consider expired, and
+# which predates any package added to the PPA since. Measured on the Magento
+# stand 2026-09-10: the image built green, `apt-cache policy php8.4-ldap`
+# printed nothing inside the container, and the extension was simply absent.
+#
+# And `|| echo` rather than `|| true`: the failure above was invisible precisely
+# because the line swallowed it. A package this image could not get is now said
+# out loud in the build output, which is the only place anybody would look.
 # (e.g. php8.5-opcache is bundled into php8.5-common, php-xmlrpc may be
 # missing in newer ondrej builds). Install each in its own line so a
 # missing package does not abort the build.
-RUN apt-get install -y php8.4-opcache || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-opcache \
+    || echo "madock: php8.4-opcache is not available in this index"
 # ldap is here rather than in the hard list above for the same reason as the two
 # beside it: a package missing for one PHP version would abort the whole image,
 # and this one is needed by a minority of projects — an application that
 # authenticates against a directory. Without it there is nowhere to test LDAP at
 # all: `ext-ldap` appears in no madock image, measured 2026-09-09 across the
 # whole docker/ tree.
-RUN apt-get install -y php8.4-ldap || true
-RUN apt-get install -y php8.4-xmlrpc || true
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-ldap \
+    && php -m | grep -qi '^ldap$' \
+    || echo "madock: php8.4-ldap is not available in this index — LDAP will not work in this image"
+RUN apt-get -y --allow-releaseinfo-change update \
+    && apt-get install -y php8.4-xmlrpc \
+    || echo "madock: php8.4-xmlrpc is not available in this index"
 
 SHELL ["/bin/bash", "-c"]
 RUN IFS='.' read major minor patch <<< "8.4" \

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.9"
+const Version = "4.2.10"

--- a/test/e2e/php_extensions_test.go
+++ b/test/e2e/php_extensions_test.go
@@ -1,0 +1,65 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTheOptionalExtensionsAreActuallyInTheImage asks the interpreter, which is
+// the only witness that counts.
+//
+// The optional block in the PHP Dockerfile installs each package on its own line
+// so that one missing package cannot abort the image. Until 2026-09-10 each line
+// ended in `|| true`, and that is exactly how a package that never installed
+// looked like a package that did: the build was green, the extension was absent,
+// and nothing anywhere said so. Measured on the Magento stand — a full rebuild
+// exited 0, every service came up, and `php -r extension_loaded('ldap')` printed
+// 0 with no file in mods-available and no dpkg entry.
+//
+// The cause was the layer: the long install above runs `apt-get update` in its
+// own RUN, and these lines ran against whatever index that cached layer had left
+// behind. Each refreshes the index now, and says out loud what it could not get.
+//
+// So this test does not read the Dockerfile — a rendered line proves nothing,
+// which was the whole lesson. It asks the running container what it loaded.
+func TestTheOptionalExtensionsAreActuallyInTheImage(t *testing.T) {
+	p := newProject(t, "e2ephpext")
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=php",
+		"--hosts=e2ephpext.test",
+	)
+
+	p.run(25*time.Minute, "start")
+
+	loaded := p.run(3*time.Minute, "cli", "php", "-m")
+
+	// ldap is the one this test was written for: an application that
+	// authenticates against a directory had nowhere to run without it.
+	if !containsExtension(loaded, "ldap") {
+		t.Errorf("ldap is not loaded in the image — the install line reported success and did nothing:\n%s", loaded)
+	}
+
+	// opcache and xmlrpc share the same block and shared the same `|| true`, so
+	// they shared the same hole. opcache in particular is not optional in any
+	// practical sense: without it every request recompiles.
+	if !containsExtension(loaded, "Zend OPcache") && !containsExtension(loaded, "opcache") {
+		t.Errorf("opcache is not loaded — the same silent failure, on the extension that costs the most:\n%s", loaded)
+	}
+}
+
+// containsExtension matches a line of `php -m` output exactly, because a
+// substring match would find "ldap" inside another name and report a hole as
+// filled — the failure this test exists to catch, wearing a different hat.
+func containsExtension(output, name string) bool {
+	for _, line := range strings.Split(output, "\n") {
+		if strings.EqualFold(strings.TrimSpace(line), name) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Each line in the optional block ran `apt-get install … || true` in its own layer, while the `apt-get update` belonged to the layer above it. On a cached build they therefore ran against whatever index that layer had left behind, and `|| true` swallowed the result.

Measured on the Magento stand: a full `madock rebuild` exited 0, every service came up, and `php -r extension_loaded('ldap')` printed 0 — nothing in `mods-available`, no dpkg entry, and `apt-cache policy php8.4-ldap` printing nothing at all inside the container.

The same hole covered `opcache`, `xmlrpc` and `memcached`. opcache is the expensive one: without it every request recompiles, and nothing anywhere says so.

Each optional install now refreshes the index first, `ldap` verifies itself with `php -m` immediately after installing, and the fallback is `|| echo "madock: <package> is not available in this index"` instead of `|| true`.

**The test asks the running container, not the Dockerfile.** The rendered line was correct the whole time — reading it is how this survived — so `TestTheOptionalExtensionsAreActuallyInTheImage` starts a PHP project and reads `php -m`, matching whole lines so a substring cannot report a hole as filled.

Proved by breaking it: removing the install line turns that test red in the VM, and restoring it green.