### PR TITLE
Write the architecture down, and fix the layer that ran backwards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *
 !/main.go
+!/.go-arch-lint.yml
 !/LICENSE
 !/README.md
 !/install.sh

--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -1,0 +1,167 @@
+version: 3
+workdir: .
+
+allow:
+  # Import-level rules only.
+  #
+  # The deep scan follows method calls and injections, and this codebase is
+  # built on registries: a controller registers its handler with `info`, a
+  # platform registers its versions with `model/versions`, a hook registers with
+  # `command`. By imports the registry depends on nobody, which is the whole
+  # point of the pattern; by injection every registrant flows into it, and the
+  # scan reports that as a dependency the wrong way round. Left on, the file
+  # would have to grant the registry a dependency on everything that registers —
+  # which is the opposite of what the layering says, written down as if it were
+  # true.
+  deepScan: false
+  depOnAnyVendor: true
+
+# The layers, and the one rule that matters: a model does not reach for a
+# helper.
+#
+# `src/model/versions/magento2` imported `helper/paths` to find composer.json,
+# while `helper/preset` and `helper/setup/tools` import that model — a layer
+# looking both ways. Go does not refuse it, since it is not a cycle between
+# packages, and that is precisely why it survived: nothing complained, and the
+# next helper the model reached for would have closed the loop for real.
+#
+# The unattached directories below are not violations, they are the parts of
+# this tree nobody has had reason to draw yet. A component that is not declared
+# is reported, which is the point — the file says what the tree is, and a new
+# directory has to be placed deliberately.
+
+components:
+  command:
+    in: src/command/**
+  controller:
+    in: src/controller/**
+  helper:
+    in: src/helper/**
+  version:
+    in: src/version/**
+  model:
+    in: src/model/**
+  migration:
+    in: src/migration/**
+  setup:
+    in: src/setup/**
+  tools:
+    in: tools/**
+  info:
+    in: src/info/**
+  embedded-assets:
+    in:
+      - docker/**
+      - scripts/**
+  app:
+    in: src/app/**
+  tests:
+    in: test/**
+  main:
+    in: .
+
+deps:
+  command:
+    mayDependOn:
+      - info
+      - embedded-assets
+      - model
+      - helper
+      - version
+  controller:
+    mayDependOn:
+      - info
+      - embedded-assets
+      - model
+      - migration
+      - setup
+      - command
+      - controller
+      - helper
+      - version
+  helper:
+    mayDependOn:
+      - info
+      - embedded-assets
+      - model
+      - migration
+      - setup
+      - helper
+      - version
+      - command
+  version:
+    anyVendorDeps: true
+  # No helper here, deliberately: this is the inversion the file exists for, and
+  # a test file counts as an import — the agreement test that keeps the run
+  # directory in step lives in `helper/paths` for exactly that reason.
+  model:
+    mayDependOn:
+      - version
+      - model
+  migration:
+    mayDependOn:
+      - helper
+      - version
+      - model
+      - migration
+  setup:
+    mayDependOn:
+      - info
+      - embedded-assets
+      - helper
+      - version
+      - model
+      - controller
+      - command
+  tools:
+    mayDependOn:
+      - helper
+      - version
+      - model
+  # The command registry's own descriptions: a leaf, and it must stay one.
+  info:
+    anyVendorDeps: true
+  # The embedded template and script trees. They carry a single `embed.go` each
+  # and depend on nothing; declaring them keeps `check` quiet about files that
+  # are not code so much as cargo.
+  # Their tests render the templates they carry, which is the one thing those
+  # trees legitimately reach for.
+  embedded-assets:
+    mayDependOn:
+      - helper
+    anyVendorDeps: true
+  app:
+    mayDependOn:
+      - info
+      - embedded-assets
+      - model
+      - migration
+      - setup
+      - command
+      - controller
+      - helper
+      - version
+  tests:
+    mayDependOn:
+      - info
+      - embedded-assets
+      - model
+      - migration
+      - setup
+      - app
+      - command
+      - controller
+      - helper
+      - version
+  main:
+    mayDependOn:
+      - info
+      - embedded-assets
+      - model
+      - migration
+      - setup
+      - app
+      - command
+      - controller
+      - helper
+      - version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+**v4.2.15**
+
+Changed:
+- **A model no longer reaches into a helper.** `model/versions/magento2` read `composer.json` through `helper/paths`, while `helper/preset` and `helper/setup/tools` import that same model — a layer looking both ways. Go refuses only real cycles, so nothing ever complained, which is why it survived. The path now comes from a replaceable `magento2.ComposerJSON`, defaulting to `MADOCK_RUN_DIR` or the working directory; the answer is the same and a test in `helper/paths` holds the two spellings together, so the duplicated environment name cannot drift
+- **The layers are written down and checked.** `.go-arch-lint.yml` declares fourteen components and what each may import, so the next inversion is caught where it is introduced rather than years later. Two of its optional linters stay off on purpose and the file says why: the deep scan reads our registry callbacks backwards, and the vendor rule belongs to the edition that has vendor rules to enforce
+
 **v4.2.14**
 
 Changed:

--- a/src/helper/paths/composer_path_agreement_test.go
+++ b/src/helper/paths/composer_path_agreement_test.go
@@ -1,0 +1,44 @@
+package paths_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/faradey/madock/v4/src/helper/paths"
+	"github.com/faradey/madock/v4/src/model/versions/magento2"
+)
+
+// The production code in `model/versions/magento2` reads MADOCK_RUN_DIR itself
+// rather than asking `helper/paths`, because that import is what made a model
+// depend on a helper that depends on models. This test keeps the two answers in
+// step.
+//
+// It lives here rather than beside the code it checks, and the architecture
+// check is why: a model may not import a helper, and a test file counts. Here
+// the direction is helper → model, which is the way the layers run.
+//
+// If `paths` ever learns another way to find the run directory, this goes red
+// rather than the version detection quietly reading the wrong composer.json.
+func TestTheComposerPathAgreesWithTheRunDirectory(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MADOCK_RUN_DIR", dir)
+
+	if got, want := magento2.ComposerJSON(), paths.GetRunDirPath()+"/composer.json"; got != want {
+		t.Errorf("composer.json read from %q, while the run directory says %q", got, want)
+	}
+}
+
+// And with no environment variable at all, both fall back to the working
+// directory.
+func TestWithoutTheEnvironmentBothFallBackToTheWorkingDirectory(t *testing.T) {
+	t.Setenv("MADOCK_RUN_DIR", "")
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := magento2.ComposerJSON(); got != wd+"/composer.json" {
+		t.Errorf("composer.json read from %q, expected %q", got, wd+"/composer.json")
+	}
+}

--- a/src/model/versions/magento2/version.go
+++ b/src/model/versions/magento2/version.go
@@ -5,9 +5,42 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/faradey/madock/v4/src/helper/paths"
 	"github.com/faradey/madock/v4/src/model/versions"
 )
+
+// This package decides which tool versions a Magento release wants, and until
+// 2026-09-10 it also went and found the release — reading `composer.json` from
+// the run directory, which meant importing `helper/paths` from a model.
+//
+// That is a layer looking both ways: `helper/preset` and `helper/setup/tools`
+// import this package, and this package imported a helper. Not a cycle Go would
+// refuse, which is exactly why it survived — nothing complains, and the next
+// helper this reaches for is the one that closes the loop for real.
+//
+// The reading now happens through a variable the caller may replace, defaulting
+// to the working directory. The package still answers the same question; it no
+// longer knows how the project is laid out on disk.
+
+// ComposerJSON is where the Magento edition and version are read from when the
+// caller does not name a version. Replaceable so that a caller with its own idea
+// of the project's root — or a test — can say so.
+var ComposerJSON = func() string {
+	// MADOCK_RUN_DIR by hand, and the duplication is deliberate: reading it
+	// through `helper/paths` is the import this change removes. The name is
+	// pinned by a test that asks `paths.GetRunDirPath` for the same answer, so
+	// the two cannot drift apart quietly — which is the only way a duplicated
+	// constant hurts.
+	if dir := strings.TrimSpace(os.Getenv("MADOCK_RUN_DIR")); dir != "" {
+		return dir + "/composer.json"
+	}
+
+	dir, err := os.Getwd()
+	if err != nil {
+		return "composer.json"
+	}
+
+	return dir + "/composer.json"
+}
 
 func init() {
 	versions.RegisterProvider("magento2", GetVersions)
@@ -42,7 +75,7 @@ func GetVersions(ver string) versions.ToolsVersions {
 }
 
 func getMagentoVersion() (edition, version string) {
-	composerPath := paths.GetRunDirPath() + "/composer.json"
+	composerPath := ComposerJSON()
 	txt, err := os.ReadFile(composerPath)
 	if err == nil {
 		re := regexp.MustCompile(`(?is)"magento/product-(community|enterprise)-edition".*?:.*?"[^0-9]*?([\.0-9]{5,}?(-p.*?|))"`)

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.14"
+const Version = "4.2.15"


### PR DESCRIPTION
`.go-arch-lint.yml` declares the fourteen components this tree already has and what each may import. Running it found one inversion: `model/versions/magento2` imported `helper/paths` to locate `composer.json`, while `helper/preset` and `helper/setup/tools` import that model. Go refuses only real cycles, so nothing ever complained.

The path now comes from `magento2.ComposerJSON`, a replaceable var reading `MADOCK_RUN_DIR` or the working directory. An agreement test in `helper/paths` asks both sides for the same answer so the duplicated environment name cannot drift; it lives there rather than next to the code it covers because a test file is an import too, and the rule counts it.

Proved by breaking it — restoring the old import reports `Component model shouldn't depend on .../helper/paths` at `version.go:8` and nothing else.

`deepScan` and the vendor linter stay off, each with its reason in the file: the deep scan follows the registry callbacks and reports the dependency the wrong way round, and vendor rules belong to the edition that has vendors to constrain.