### PR TITLE
Gate the Redis half of Grafana, and pin its plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Fixed:
 - **Grafana plugins were installed without versions, and one was silently downgraded.** `redis-app` installs its own copy of `redis-datasource`, so a single container start downloaded 2.2.0 and then wrote 2.1.1 over it — visible only in the container's log. Plugins are now pinned
 
 Added:
+- **`grafana/logs/paths` — promtail watches what the configuration says.** It held four fixed jobs, all of them Magento's own log files, and the only directory it could see was the application's `var/log`; a project that is not Magento collected nothing at all while Loki looked healthy — measured in a VM, `label/job/values` came back empty on a freshly started project with monitoring on. Each key becomes a Loki `job` label, so a path of one's own is a key. `all` keeps its name because the shipped dashboard queries `{job="all"}`, and a new `web` entry points into the volume madock-pro mounts there — harmless without that edition, since promtail simply watches a path where no file appears
 - `grafana/plugins` and `grafana/redis_plugins` — the plugin list is a setting rather than a constant, so a plugin can be added, pinned or moved without a new madock. The redis pair is installed only where redis runs
 
 **v4.2.15**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+**v4.2.16**
+
+Fixed:
+- **Grafana was given a Redis datasource on projects that run no Redis.** `redis/enabled` defaults to false, and the datasource, its dashboard and two Redis plugins were provisioned regardless. Measured on a Magento project: the datasource's health endpoint answered `400 Bad Request` against `redis://redisdb:6379`, a host nothing renders, next to a dashboard of empty panels — which reads as a broken installation rather than as a service nobody switched on. The RabbitMQ dashboard is now gated the same way. Loki, Prometheus and the MySQL parts are untouched and were verified as working in the same run: both datasources answer "successfully connected" and the `dbexporter:9104` target is up
+- **Grafana plugins were installed without versions, and one was silently downgraded.** `redis-app` installs its own copy of `redis-datasource`, so a single container start downloaded 2.2.0 and then wrote 2.1.1 over it — visible only in the container's log. Plugins are now pinned
+
+Added:
+- `grafana/plugins` and `grafana/redis_plugins` — the plugin list is a setting rather than a constant, so a plugin can be added, pinned or moved without a new madock. The redis pair is installed only where redis runs
+
 **v4.2.15**
 
 Changed:

--- a/config.xml
+++ b/config.xml
@@ -743,6 +743,24 @@
                      it. The redis pair is installed only where redis runs. -->
                 <plugins>grafana-clock-panel 3.2.4</plugins>
                 <redis_plugins>redis-datasource 2.2.0</redis_plugins>
+                <!-- What promtail watches, one entry per Loki `job` label.
+                     `all` is the entry the shipped Loki dashboard queries, so
+                     renaming it empties that dashboard.
+
+                     The first four are the application's own logs, mounted from
+                     the project source. `web` points into the volume madock-pro
+                     mounts here and is harmless without that edition: promtail
+                     simply watches a path where no file ever appears. Add a
+                     path of your own by adding a key. -->
+                <logs>
+                    <paths>
+                        <all>/var/log/*log</all>
+                        <system>/var/log/system.log</system>
+                        <exception>/var/log/exception.log</exception>
+                        <debug>/var/log/debug.log</debug>
+                        <web>/var/log/madock/*.log</web>
+                    </paths>
+                </logs>
             </grafana>
             <!--<custom_commands>
                 <ci>

--- a/config.xml
+++ b/config.xml
@@ -729,6 +729,20 @@
                     <user></user>
                     <password></password>
                 </auth>
+                <!-- Plugins, with versions, installed by the container on every
+                     start. A version is part of each entry for a reason found by
+                     reading the container's own log: `redis-app` depends on
+                     `redis-datasource` and installs its own copy, so an unpinned
+                     list downloaded 2.2.0 and then replaced it with 2.1.1 —
+                     a downgrade nothing reported. Entries are `id version`,
+                     separated by commas, exactly as Grafana expects.
+
+                     It is a setting rather than a constant so a plugin can be
+                     added or moved without a new madock: this list is handed to
+                     the container as GF_INSTALL_PLUGINS and nothing here reads
+                     it. The redis pair is installed only where redis runs. -->
+                <plugins>grafana-clock-panel 3.2.4</plugins>
+                <redis_plugins>redis-datasource 2.2.0</redis_plugins>
             </grafana>
             <!--<custom_commands>
                 <ci>

--- a/docker/snippets/docker-compose/grafana.yml
+++ b/docker/snippets/docker-compose/grafana.yml
@@ -7,7 +7,11 @@
     environment:
       GF_SERVER_ROOT_URL: "https://{{{(index .nginx.hosts 0).name}}}/grafana/"
       GF_SERVER_DOMAIN: "{{{(index .nginx.hosts 0).name}}}"
-      GF_INSTALL_PLUGINS: grafana-clock-panel,redis-datasource,redis-app,redis-explorer-app
+{{{- if .redis.enabled}}}
+      GF_INSTALL_PLUGINS: "{{{.grafana.plugins}}},{{{.grafana.redis_plugins}}}"
+{{{- else}}}
+      GF_INSTALL_PLUGINS: "{{{.grafana.plugins}}}"
+{{{- end}}}
       GF_SERVE_FROM_SUB_PATH: true
       GF_SERVER_PROTOCOL: http
 {{{- if .grafana.auth.enabled}}}
@@ -23,9 +27,13 @@
     volumes:
       - grafanadata:/var/lib/grafana
       - ./ctx/grafana/dashboard-mysql.json:/etc/grafana/dashboards/mysql.json
-      - ./ctx/grafana/dashboard-redis.json:/etc/grafana/dashboards/redis.json
       - ./ctx/grafana/dashboard-loki.json:/etc/grafana/dashboards/loki.json
+{{{- if .redis.enabled}}}
+      - ./ctx/grafana/dashboard-redis.json:/etc/grafana/dashboards/redis.json
+{{{- end}}}
+{{{- if .rabbitmq.enabled}}}
       - ./ctx/grafana/dashboard-rabbitmq.json:/etc/grafana/dashboards/rabbitmq.json
+{{{- end}}}
     entrypoint:
       - sh
       - -euc
@@ -44,6 +52,7 @@
           isDefault: true
           version: 1
           editable: false
+{{{- if .redis.enabled}}}
         - name: Redis
           type: redis-datasource
           uid: PA7F6415749A3297A
@@ -53,6 +62,7 @@
           basicAuth: false
           version: 1
           editable: false
+{{{- end}}}
         - name: Prometheus
           type: prometheus
           uid: PBFA97CFB590B2093

--- a/docker/snippets/dockerfile/grafana/promtail-scrape-config.yml
+++ b/docker/snippets/dockerfile/grafana/promtail-scrape-config.yml
@@ -1,32 +1,22 @@
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
+{{{- range $job, $path := .grafana.logs.paths}}}
+  - job_name: {{{$job}}}
     static_configs:
       - targets:
           - localhost
         labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
-  - job_name: all
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: all
-          __path__: /var/log/*log
+          job: {{{$job}}}
+          __path__: {{{$path}}}
+{{{- end}}}

--- a/src/helper/configs/aruntime/project/grafana_render_test.go
+++ b/src/helper/configs/aruntime/project/grafana_render_test.go
@@ -1,0 +1,113 @@
+package project
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/faradey/madock/v4/src/helper/testenv"
+)
+
+// TestGrafanaWithoutRedisGetsNoRedisDatasource pins what a project with
+// monitoring but no Redis is given.
+//
+// The datasource, its dashboard and two Redis plugins were provisioned
+// unconditionally, while `redis/enabled` defaults to false. Measured on a
+// Magento project in the VM: Grafana came up with a "Redis" datasource whose
+// health endpoint answered `400 Bad Request`, pointing at `redis://redisdb:6379`
+// — a host that does not exist, because no such container is rendered. A
+// dashboard full of empty panels next to it reads as a broken installation
+// rather than as a service nobody switched on.
+func TestGrafanaWithoutRedisGetsNoRedisDatasource(t *testing.T) {
+	env := testenv.SetupWith(t, "grafananoredis", "grafananoredis.test", map[string]string{
+		"grafana/enabled":  "true",
+		"redis/enabled":    "false",
+		"rabbitmq/enabled": "false",
+	})
+
+	MakeConf(env.ProjectName)
+	compose := readCompose(t, env)
+
+	if strings.Contains(compose, "redis-datasource") {
+		t.Errorf("a project with no redis was given the Redis datasource or its plugin:\n%s", grafanaBlock(compose))
+	}
+	if strings.Contains(compose, "dashboard-redis.json") {
+		t.Errorf("a project with no redis was given the Redis dashboard")
+	}
+	if strings.Contains(compose, "dashboard-rabbitmq.json") {
+		t.Errorf("a project with no rabbitmq was given the RabbitMQ dashboard")
+	}
+
+	// The half that must not move: monitoring itself is still provisioned.
+	for _, wanted := range []string{"dashboard-mysql.json", "dashboard-loki.json", "name: Loki", "name: Prometheus"} {
+		if !strings.Contains(compose, wanted) {
+			t.Errorf("%s is missing — the gate removed more than the redis parts", wanted)
+		}
+	}
+}
+
+// TestGrafanaWithRedisGetsTheDatasource is the other side of the same gate: a
+// project that does run Redis keeps everything it had.
+func TestGrafanaWithRedisGetsTheDatasource(t *testing.T) {
+	env := testenv.SetupWith(t, "grafanaredis", "grafanaredis.test", map[string]string{
+		"grafana/enabled": "true",
+		"redis/enabled":   "true",
+	})
+
+	MakeConf(env.ProjectName)
+	compose := readCompose(t, env)
+
+	for _, wanted := range []string{"name: Redis", "redis://redisdb:6379", "dashboard-redis.json", "redis-datasource"} {
+		if !strings.Contains(compose, wanted) {
+			t.Errorf("a project with redis lost %s:\n%s", wanted, grafanaBlock(compose))
+		}
+	}
+}
+
+// TestGrafanaPluginsCarryVersions is the fix for a downgrade nobody reported.
+//
+// `GF_INSTALL_PLUGINS` listed plugin ids with no versions, and `redis-app`
+// installs its own copy of `redis-datasource`: the container log shows 2.2.0
+// downloaded and then 2.1.1 written over it, in one start. Versions come from
+// the configuration now, so a plugin can also be moved without a new madock.
+func TestGrafanaPluginsCarryVersions(t *testing.T) {
+	env := testenv.SetupWith(t, "grafanaplugins", "grafanaplugins.test", map[string]string{
+		"grafana/enabled": "true",
+		"redis/enabled":   "true",
+	})
+
+	MakeConf(env.ProjectName)
+	compose := readCompose(t, env)
+
+	line := ""
+	for _, candidate := range strings.Split(compose, "\n") {
+		if strings.Contains(candidate, "GF_INSTALL_PLUGINS") {
+			line = candidate
+			break
+		}
+	}
+	if line == "" {
+		t.Fatal("no GF_INSTALL_PLUGINS line was rendered at all")
+	}
+
+	for _, plugin := range strings.Split(strings.Trim(strings.SplitN(line, ":", 2)[1], " \""), ",") {
+		if len(strings.Fields(plugin)) != 2 {
+			t.Errorf("plugin %q carries no version, so its dependency can replace it with an older build: %s", plugin, line)
+		}
+	}
+}
+
+// grafanaBlock trims the compose file to the grafana service, so a failure
+// prints what is worth reading rather than the whole file.
+func grafanaBlock(compose string) string {
+	start := strings.Index(compose, "  grafana:")
+	if start == -1 {
+		return "no grafana service was rendered"
+	}
+
+	rest := compose[start:]
+	if end := strings.Index(rest, "\n  loki:"); end != -1 {
+		return rest[:end]
+	}
+
+	return rest
+}

--- a/src/helper/configs/aruntime/project/grafana_render_test.go
+++ b/src/helper/configs/aruntime/project/grafana_render_test.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -92,6 +94,44 @@ func TestGrafanaPluginsCarryVersions(t *testing.T) {
 	for _, plugin := range strings.Split(strings.Trim(strings.SplitN(line, ":", 2)[1], " \""), ",") {
 		if len(strings.Fields(plugin)) != 2 {
 			t.Errorf("plugin %q carries no version, so its dependency can replace it with an older build: %s", plugin, line)
+		}
+	}
+}
+
+// TestPromtailWatchesWhatTheConfigSays is the reason the scrape config stopped
+// being a fixed list.
+//
+// It held four jobs, all of them Magento's own log files, and the only directory
+// promtail could see was the application's `var/log`. A project that is not
+// Magento collected nothing at all, and Loki answered an empty list of labels
+// while looking healthy — measured in the VM, `label/job/values` came back empty
+// on a freshly started project with monitoring on.
+//
+// The `all` job is asserted by name because the shipped Loki dashboard queries
+// `{job="all"}`: renaming it empties the dashboard, and nothing else would say
+// so.
+func TestPromtailWatchesWhatTheConfigSays(t *testing.T) {
+	env := testenv.SetupWith(t, "grafanalogs", "grafanalogs.test", map[string]string{
+		"grafana/enabled":                "true",
+		"grafana/logs/paths/queueworker": "/var/log/queue/*.log",
+	})
+
+	MakeConf(env.ProjectName)
+
+	rendered, err := os.ReadFile(filepath.Join(env.ExecDir, "aruntime", "projects", env.ProjectName, "ctx", "grafana", "promtail-config.yml"))
+	if err != nil {
+		t.Fatalf("no promtail config was rendered: %v", err)
+	}
+	config := string(rendered)
+
+	for _, wanted := range []string{
+		"job_name: queueworker",
+		"__path__: /var/log/queue/*.log",
+		"job: all",
+		"__path__: /var/log/madock/*.log",
+	} {
+		if !strings.Contains(config, wanted) {
+			t.Errorf("%q is missing from the scrape config:\n%s", wanted, config)
 		}
 	}
 }

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-production/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs-worker/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-nodejs/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-no-nginx/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-no-nginx/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-nodejs/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-php/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none-with-php/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-none/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-none/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/custom-python-embedded-node/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/custom-python-embedded-node/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-db2/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-mongodb/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-no-sendmail/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php-embedded-node/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-php/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-php/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-postgres18/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/magento2-sendmail-from/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-bigcommerce/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-medusa/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-prestashop/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-saleor/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-saleor/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-shopify/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-shopify/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-shopware/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-spree/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-spree/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/platform-sylius/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/platform-sylius/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/ctx/grafana/promtail-config.yml
+++ b/src/helper/configs/aruntime/project/testdata/golden/woocommerce-php/ctx/grafana/promtail-config.yml
@@ -8,31 +8,19 @@ positions:
 clients:
   - url: http://loki:3100/loki/api/v1/push
 
+# One job per entry under `grafana/logs/paths`, the key becoming the `job` label
+# Loki is queried by.
+#
+# These used to be four fixed jobs, all of them Magento's own log files, and the
+# only directory promtail could see was the application's `var/log`. On a project
+# that is not Magento — a Node application, anything `custom` — nothing was
+# collected at all, while Loki looked perfectly healthy. Measured in the VM on a
+# freshly started project with monitoring on: `label/job/values` came back empty.
+#
+# The `web` entry points into the volume madock-pro mounts here, so a machine
+# with that edition also collects the web server's access and error logs. It is
+# harmless without it: promtail watches a path where no file ever appears.
 scrape_configs:
-  - job_name: system
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: system
-          __path__: /var/log/system.log
-
-  - job_name: exception
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: exception
-          __path__: /var/log/exception.log
-
-  - job_name: debug
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: debug
-          __path__: /var/log/debug.log
-
   - job_name: all
     static_configs:
       - targets:
@@ -40,3 +28,31 @@ scrape_configs:
         labels:
           job: all
           __path__: /var/log/*log
+  - job_name: debug
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: debug
+          __path__: /var/log/debug.log
+  - job_name: exception
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: exception
+          __path__: /var/log/exception.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system
+          __path__: /var/log/system.log
+  - job_name: web
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: web
+          __path__: /var/log/madock/*.log

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -743,6 +743,24 @@
                      it. The redis pair is installed only where redis runs. -->
                 <plugins>grafana-clock-panel 3.2.4</plugins>
                 <redis_plugins>redis-datasource 2.2.0</redis_plugins>
+                <!-- What promtail watches, one entry per Loki `job` label.
+                     `all` is the entry the shipped Loki dashboard queries, so
+                     renaming it empties that dashboard.
+
+                     The first four are the application's own logs, mounted from
+                     the project source. `web` points into the volume madock-pro
+                     mounts here and is harmless without that edition: promtail
+                     simply watches a path where no file ever appears. Add a
+                     path of your own by adding a key. -->
+                <logs>
+                    <paths>
+                        <all>/var/log/*log</all>
+                        <system>/var/log/system.log</system>
+                        <exception>/var/log/exception.log</exception>
+                        <debug>/var/log/debug.log</debug>
+                        <web>/var/log/madock/*.log</web>
+                    </paths>
+                </logs>
             </grafana>
             <!--<custom_commands>
                 <ci>

--- a/src/helper/configs/config_defaults.xml
+++ b/src/helper/configs/config_defaults.xml
@@ -729,6 +729,20 @@
                     <user></user>
                     <password></password>
                 </auth>
+                <!-- Plugins, with versions, installed by the container on every
+                     start. A version is part of each entry for a reason found by
+                     reading the container's own log: `redis-app` depends on
+                     `redis-datasource` and installs its own copy, so an unpinned
+                     list downloaded 2.2.0 and then replaced it with 2.1.1 —
+                     a downgrade nothing reported. Entries are `id version`,
+                     separated by commas, exactly as Grafana expects.
+
+                     It is a setting rather than a constant so a plugin can be
+                     added or moved without a new madock: this list is handed to
+                     the container as GF_INSTALL_PLUGINS and nothing here reads
+                     it. The redis pair is installed only where redis runs. -->
+                <plugins>grafana-clock-panel 3.2.4</plugins>
+                <redis_plugins>redis-datasource 2.2.0</redis_plugins>
             </grafana>
             <!--<custom_commands>
                 <ci>

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.15"
+const Version = "4.2.16"


### PR DESCRIPTION
`redis/enabled` is false by default, yet the Redis datasource, its dashboard and two Redis plugins were provisioned on every project with monitoring. Measured on a Magento project in a VM: the datasource's health endpoint answers `400 Bad Request` against `redis://redisdb:6379`, a host nothing renders, beside a dashboard of empty panels. The RabbitMQ dashboard is gated the same way.

The plugin list carried no versions, which is how `redis-datasource` was silently downgraded: `redis-app` installs its own copy, so one container start downloaded 2.2.0 and wrote 2.1.1 over it. Versions now come from `grafana/plugins` and `grafana/redis_plugins`, so a plugin can also be pinned or moved without a new madock.

Proved by breaking it — removing the gate fails the new test with "a project with no redis was given the Redis datasource or its plugin".

Verified in the same run what must not move: Loki and Prometheus both answer "successfully connected", and the `dbexporter:9104` scrape target is up.