### PR TITLE
Cache what the image builds download

### DIFF
--- a/.github/actions/apt-cache/action.yml
+++ b/.github/actions/apt-cache/action.yml
@@ -27,15 +27,22 @@ description: >
 runs:
   using: composite
   steps:
-    # Keyed on the Dockerfile snippets: a change to what gets installed is the
-    # moment the cache should start over. restore-keys falls back to the newest
-    # cache of any key, so a template edit costs one partial miss rather than a
-    # full one. Saved automatically when the job ends.
-    - uses: actions/cache@v4
+    # Restore only. actions/cache saves in its post step — and not when the job
+    # failed, which is the case this exists for: on the day the mirror is slow
+    # every shard fails on its first setup, nothing is saved, and the next run
+    # starts empty again. Measured over three runs of the first version, each
+    # printing "Cache not found for input keys". The save is a separate step in
+    # the workflow with `if: always()`.
+    #
+    # The key carries the run id so it never hits exactly; restore-keys pick
+    # the newest cache for these Dockerfile snippets, then the newest of any —
+    # a template edit costs one partial miss rather than a full one.
+    - uses: actions/cache/restore@v4
       with:
         path: ~/.squid-cache
-        key: squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}
+        key: squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}-${{ github.run_id }}
         restore-keys: |
+          squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}-
           squid-${{ runner.os }}-
 
     # squid runs as the runner's own user, with everything under its home: the

--- a/.github/actions/apt-cache/action.yml
+++ b/.github/actions/apt-cache/action.yml
@@ -93,7 +93,13 @@ runs:
         # its bridge and never reaches this chain; addresses inside the
         # private ranges are excluded as well, so a service published on the
         # runner is not caught either.
-        sudo iptables -t nat -A PREROUTING -p tcp --dport 80 \
-          -s 172.16.0.0/12 ! -d 172.16.0.0/12 ! -d 10.0.0.0/8 ! -d 192.168.0.0/16 \
-          -j REDIRECT --to-ports 3129
+        # One chain rather than one rule: iptables takes a single -d, so the
+        # private ranges are excluded one line each and the redirect is what
+        # remains.
+        sudo iptables -t nat -N SQUID
+        sudo iptables -t nat -A SQUID -d 172.16.0.0/12 -j RETURN
+        sudo iptables -t nat -A SQUID -d 10.0.0.0/8 -j RETURN
+        sudo iptables -t nat -A SQUID -d 192.168.0.0/16 -j RETURN
+        sudo iptables -t nat -A SQUID -p tcp -j REDIRECT --to-ports 3129
+        sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -s 172.16.0.0/12 -j SQUID
         echo "container HTTP on port 80 goes through squid; the cache holds $(du -sh ~/.squid-cache | cut -f1)"

--- a/.github/actions/apt-cache/action.yml
+++ b/.github/actions/apt-cache/action.yml
@@ -1,0 +1,84 @@
+name: Cache what the image builds download
+description: >
+  Puts a caching HTTP proxy on the runner and points every image build at it,
+  so the packages apt fetches inside a Dockerfile come from this runner's disk
+  on the second run instead of from an Ubuntu mirror on every run.
+
+  Why: on 2026-09-11 the nightly went red in five shards, and in each one only
+  the first test failed — on `madock setup`, past its deadline — while the rest
+  of the shard ran with setup at eight seconds. The build log named it:
+  archive.ubuntu.com handed over 144 MB in eleven minutes, nine times slower
+  than the day before. The image cache in images.txt cannot help there: it warms
+  the pulls, and this is apt inside our own Dockerfile, which every build runs.
+
+  How it reaches the builds without touching madock: the docker client injects
+  the proxies in ~/.docker/config.json into every build as http_proxy build
+  arguments — build only, under compose, so containers themselves are not
+  proxied and composer, npm and the tests' own HTTP are untouched. The proxy is
+  squid rather than apt-cacher-ng because a build also fetches things that are
+  not packages — the composer installer, ionCube, Node — and squid passes those
+  through while apt-cacher-ng refuses what it does not recognise. HTTPS goes
+  through as CONNECT and is not cached; apt's mirror is plain HTTP, which is the
+  half that matters.
+
+  Silent and harmless on a miss: the first run after the key changes pays the
+  mirror once and leaves the cache behind for the next.
+
+runs:
+  using: composite
+  steps:
+    # Keyed on the Dockerfile snippets: a change to what gets installed is the
+    # moment the cache should start over. restore-keys falls back to the newest
+    # cache of any key, so a template edit costs one partial miss rather than a
+    # full one. Saved automatically when the job ends.
+    - uses: actions/cache@v4
+      with:
+        path: ~/.squid-cache
+        key: squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}
+        restore-keys: |
+          squid-${{ runner.os }}-
+
+    # squid runs as the runner's own user, with everything under its home: the
+    # cache has to be readable by the user that saves it at the end of the job,
+    # and a directory owned by the `proxy` account is not.
+    - name: Start the proxy
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get install -y -qq squid >/dev/null
+        sudo systemctl stop squid 2>/dev/null || true
+        mkdir -p ~/.squid-cache ~/.squid-run
+        cat > ~/.squid-run/squid.conf <<EOF
+        http_port 3128
+        pid_filename $HOME/.squid-run/squid.pid
+        cache_log $HOME/.squid-run/cache.log
+        access_log $HOME/.squid-run/access.log
+        coredump_dir $HOME/.squid-run
+        cache_dir ufs $HOME/.squid-cache 2000 16 256
+        maximum_object_size 512 MB
+        cache_mem 128 MB
+        acl localnet src 172.16.0.0/12 10.0.0.0/8 192.168.0.0/16 127.0.0.0/8
+        http_access allow localnet
+        http_access deny all
+        refresh_pattern . 10080 100% 10080 override-expire ignore-no-cache ignore-no-store ignore-private
+        EOF
+        squid -f ~/.squid-run/squid.conf -z 2>/dev/null || true
+        squid -f ~/.squid-run/squid.conf
+        for i in 1 2 3 4 5; do
+          curl -s -o /dev/null -x http://127.0.0.1:3128 http://archive.ubuntu.com/ubuntu/ && break
+          sleep 1
+        done
+        curl -s -o /dev/null -w 'proxy answers %{http_code}\n' -x http://127.0.0.1:3128 http://archive.ubuntu.com/ubuntu/
+
+        # Builds run inside the daemon's default bridge, where the runner is
+        # the gateway. The client injects this into every build as http_proxy;
+        # the login that may already be in this file is kept.
+        gateway=$(docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}')
+        mkdir -p ~/.docker
+        if [ -f ~/.docker/config.json ]; then
+          jq --arg p "http://$gateway:3128" '.proxies.default.httpProxy = $p | .proxies.default.httpsProxy = $p' ~/.docker/config.json > ~/.docker/config.json.new
+        else
+          jq -n --arg p "http://$gateway:3128" '{proxies:{default:{httpProxy:$p, httpsProxy:$p}}}' > ~/.docker/config.json.new
+        fi
+        mv ~/.docker/config.json.new ~/.docker/config.json
+        echo "builds go through http://$gateway:3128; the cache holds $(du -sh ~/.squid-cache | cut -f1)"

--- a/.github/actions/apt-cache/action.yml
+++ b/.github/actions/apt-cache/action.yml
@@ -62,7 +62,11 @@ runs:
         http_access deny all
         refresh_pattern . 10080 100% 10080 override-expire ignore-no-cache ignore-no-store ignore-private
         EOF
-        squid -f ~/.squid-run/squid.conf -z 2>/dev/null || true
+        # -N with -z: in squid 5 and later the directory initialisation forks
+        # into the background like a normal start and leaves a live pid file,
+        # so the real start that follows refuses with "Squid is already
+        # running". Measured on the first run of this action.
+        squid -f ~/.squid-run/squid.conf -N -z 2>/dev/null || true
         squid -f ~/.squid-run/squid.conf
         for i in 1 2 3 4 5; do
           curl -s -o /dev/null -x http://127.0.0.1:3128 http://archive.ubuntu.com/ubuntu/ && break

--- a/.github/actions/apt-cache/action.yml
+++ b/.github/actions/apt-cache/action.yml
@@ -11,15 +11,21 @@ description: >
   than the day before. The image cache in images.txt cannot help there: it warms
   the pulls, and this is apt inside our own Dockerfile, which every build runs.
 
-  How it reaches the builds without touching madock: the docker client injects
-  the proxies in ~/.docker/config.json into every build as http_proxy build
-  arguments — build only, under compose, so containers themselves are not
-  proxied and composer, npm and the tests' own HTTP are untouched. The proxy is
+  How it reaches the builds without touching madock, and without touching the
+  containers either: the runner redirects every plain-HTTP connection leaving a
+  container for the outside world into squid, in intercept mode. No proxy
+  variable anywhere. The first version put a proxy into ~/.docker/config.json,
+  and the docker client handed that not only to builds but — under compose — to
+  the service containers too: Shopware's install then asked OpenSearch over
+  `http://opensearch:9200`, the request went to squid, squid could not reach a
+  compose network, and the install died with ServiceUnavailableHttpException.
+  Traffic between containers never leaves their bridge, so the redirect below
+  cannot see it; only what is bound for a public address is caught.
+
   squid rather than apt-cacher-ng because a build also fetches things that are
-  not packages — the composer installer, ionCube, Node — and squid passes those
-  through while apt-cacher-ng refuses what it does not recognise. HTTPS goes
-  through as CONNECT and is not cached; apt's mirror is plain HTTP, which is the
-  half that matters.
+  not packages — the composer installer, ionCube, Node — and squid passes
+  through what it does not cache. HTTPS is not touched at all: it is not port
+  80. apt's mirror is plain HTTP, which is the half that matters.
 
   Silent and harmless on a miss: the first run after the key changes pays the
   mirror once and leaves the cache behind for the next.
@@ -57,6 +63,7 @@ runs:
         mkdir -p ~/.squid-cache ~/.squid-run
         cat > ~/.squid-run/squid.conf <<EOF
         http_port 3128
+        http_port 3129 intercept
         pid_filename $HOME/.squid-run/squid.pid
         cache_log $HOME/.squid-run/cache.log
         access_log $HOME/.squid-run/access.log
@@ -81,15 +88,12 @@ runs:
         done
         curl -s -o /dev/null -w 'proxy answers %{http_code}\n' -x http://127.0.0.1:3128 http://archive.ubuntu.com/ubuntu/
 
-        # Builds run inside the daemon's default bridge, where the runner is
-        # the gateway. The client injects this into every build as http_proxy;
-        # the login that may already be in this file is kept.
-        gateway=$(docker network inspect bridge -f '{{(index .IPAM.Config 0).Gateway}}')
-        mkdir -p ~/.docker
-        if [ -f ~/.docker/config.json ]; then
-          jq --arg p "http://$gateway:3128" '.proxies.default.httpProxy = $p | .proxies.default.httpsProxy = $p' ~/.docker/config.json > ~/.docker/config.json.new
-        else
-          jq -n --arg p "http://$gateway:3128" '{proxies:{default:{httpProxy:$p, httpsProxy:$p}}}' > ~/.docker/config.json.new
-        fi
-        mv ~/.docker/config.json.new ~/.docker/config.json
-        echo "builds go through http://$gateway:3128; the cache holds $(du -sh ~/.squid-cache | cut -f1)"
+        # Every plain-HTTP connection from a container to a public address
+        # is redirected into squid. Container-to-container traffic stays on
+        # its bridge and never reaches this chain; addresses inside the
+        # private ranges are excluded as well, so a service published on the
+        # runner is not caught either.
+        sudo iptables -t nat -A PREROUTING -p tcp --dport 80 \
+          -s 172.16.0.0/12 ! -d 172.16.0.0/12 ! -d 10.0.0.0/8 ! -d 192.168.0.0/16 \
+          -j REDIRECT --to-ports 3129
+        echo "container HTTP on port 80 goes through squid; the cache holds $(du -sh ~/.squid-cache | cut -f1)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,12 @@ jobs:
           fi
           printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
 
+      # Between the login and the images on purpose: the login writes
+      # ~/.docker/config.json and this step adds to that file rather than
+      # replacing it.
+      - name: Cache what the image builds download
+        uses: ./.github/actions/apt-cache
+
       - name: Load the warmed images
         uses: ./.github/actions/load-images
 
@@ -318,6 +324,15 @@ jobs:
         run: |
           set -o pipefail
           ./test/e2e/e2e.sh run-local -run '${{ matrix.run }}' | tee shard.log
+
+      # The only evidence the download cache does anything: a proxy that
+      # answers but never hits is a runner doing more work for the same result.
+      - name: How the download cache did
+        if: always()
+        run: |
+          hits=$(grep -c 'TCP_\(HIT\|MEM_HIT\|REFRESH_UNMODIFIED\)' ~/.squid-run/access.log 2>/dev/null || true)
+          misses=$(grep -c 'TCP_MISS' ~/.squid-run/access.log 2>/dev/null || true)
+          echo "download cache: ${hits:-0} hits, ${misses:-0} misses, $(du -sh ~/.squid-cache 2>/dev/null | cut -f1) on disk"
 
 
       # The other half of computing the split: this shard was given a number of
@@ -440,11 +455,26 @@ jobs:
           fi
           printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
 
+      # Between the login and the images on purpose: the login writes
+      # ~/.docker/config.json and this step adds to that file rather than
+      # replacing it.
+      - name: Cache what the image builds download
+        uses: ./.github/actions/apt-cache
+
       - name: Load the warmed images
         uses: ./.github/actions/load-images
 
       - name: Install Shopware and Medusa for real
         run: ./test/e2e/e2e.sh run-local --platforms -run 'TestMagentoInstallsAndAnswers|TestShopwareInstallsAndAnswers|TestMedusaInstallsAndAnswers'
+
+      # The only evidence the download cache does anything: a proxy that
+      # answers but never hits is a runner doing more work for the same result.
+      - name: How the download cache did
+        if: always()
+        run: |
+          hits=$(grep -c 'TCP_\(HIT\|MEM_HIT\|REFRESH_UNMODIFIED\)' ~/.squid-run/access.log 2>/dev/null || true)
+          misses=$(grep -c 'TCP_MISS' ~/.squid-run/access.log 2>/dev/null || true)
+          echo "download cache: ${hits:-0} hits, ${misses:-0} misses, $(du -sh ~/.squid-cache 2>/dev/null | cut -f1) on disk"
 
       - name: Images this job actually used
         if: always()
@@ -504,6 +534,12 @@ jobs:
       # The output is the entire point of this job, so the log is kept whatever
       # happens: the probe prints the upgrade-info file, the schema names and the
       # account list, and a failed run whose log was thrown away costs a night.
+      # Between the login and the images on purpose: the login writes
+      # ~/.docker/config.json and this step adds to that file rather than
+      # replacing it.
+      - name: Cache what the image builds download
+        uses: ./.github/actions/apt-cache
+
       - name: Load the warmed images
         uses: ./.github/actions/load-images
 
@@ -511,6 +547,15 @@ jobs:
         run: |
           set -o pipefail
           ./test/e2e/e2e.sh run-local --quarantined -run 'TestSecondDatabaseIsItsOwnDatabase' | tee quarantine.log
+
+      # The only evidence the download cache does anything: a proxy that
+      # answers but never hits is a runner doing more work for the same result.
+      - name: How the download cache did
+        if: always()
+        run: |
+          hits=$(grep -c 'TCP_\(HIT\|MEM_HIT\|REFRESH_UNMODIFIED\)' ~/.squid-run/access.log 2>/dev/null || true)
+          misses=$(grep -c 'TCP_MISS' ~/.squid-run/access.log 2>/dev/null || true)
+          echo "download cache: ${hits:-0} hits, ${misses:-0} misses, $(du -sh ~/.squid-cache 2>/dev/null | cut -f1) on disk"
 
       # The same guard the shards carry, and here it matters more. `-run` with a
       # name that matches nothing — a rename, a test finally deleted — makes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,25 @@ jobs:
           misses=$(grep -c 'TCP_MISS' ~/.squid-run/access.log 2>/dev/null || true)
           echo "download cache: ${hits:-0} hits, ${misses:-0} misses, $(du -sh ~/.squid-cache 2>/dev/null | cut -f1) on disk"
 
+      # Saved whether the job passed or not — see the shard job.
+      - name: Keep the download cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.squid-cache
+          key: squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}-${{ github.run_id }}-${{ github.job }}
+
+      # Saved whether the job passed or not — a failed first setup on a slow
+      # mirror is exactly the run whose downloads are worth keeping. One shard
+      # saves; the packages are the same in all of them, and eight copies a
+      # run would push everything else out of the cache quota.
+      - name: Keep the download cache
+        if: always() && matrix.shard == 1
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.squid-cache
+          key: squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}-${{ github.run_id }}
+
 
       # The other half of computing the split: this shard was given a number of
       # tests, and it has to have run that many. A regex that matches nothing —
@@ -476,6 +495,14 @@ jobs:
           misses=$(grep -c 'TCP_MISS' ~/.squid-run/access.log 2>/dev/null || true)
           echo "download cache: ${hits:-0} hits, ${misses:-0} misses, $(du -sh ~/.squid-cache 2>/dev/null | cut -f1) on disk"
 
+      # Saved whether the job passed or not — see the shard job.
+      - name: Keep the download cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.squid-cache
+          key: squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}-${{ github.run_id }}-${{ github.job }}
+
       - name: Images this job actually used
         if: always()
         run: docker image ls --format '{{.Repository}}:{{.Tag}}' | sort -u
@@ -556,6 +583,14 @@ jobs:
           hits=$(grep -c 'TCP_\(HIT\|MEM_HIT\|REFRESH_UNMODIFIED\)' ~/.squid-run/access.log 2>/dev/null || true)
           misses=$(grep -c 'TCP_MISS' ~/.squid-run/access.log 2>/dev/null || true)
           echo "download cache: ${hits:-0} hits, ${misses:-0} misses, $(du -sh ~/.squid-cache 2>/dev/null | cut -f1) on disk"
+
+      # Saved whether the job passed or not — see the shard job.
+      - name: Keep the download cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.squid-cache
+          key: squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}-${{ github.run_id }}-${{ github.job }}
 
       # The same guard the shards carry, and here it matters more. `-run` with a
       # name that matches nothing — a rename, a test finally deleted — makes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,14 +334,6 @@ jobs:
           misses=$(grep -c 'TCP_MISS' ~/.squid-run/access.log 2>/dev/null || true)
           echo "download cache: ${hits:-0} hits, ${misses:-0} misses, $(du -sh ~/.squid-cache 2>/dev/null | cut -f1) on disk"
 
-      # Saved whether the job passed or not — see the shard job.
-      - name: Keep the download cache
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.squid-cache
-          key: squid-${{ runner.os }}-${{ hashFiles('docker/snippets/dockerfile/**') }}-${{ github.run_id }}-${{ github.job }}
-
       # Saved whether the job passed or not — a failed first setup on a slow
       # mirror is exactly the run whose downloads are worth keeping. One shard
       # saves; the packages are the same in all of them, and eight copies a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,9 +309,6 @@ jobs:
           fi
           printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
 
-      # Between the login and the images on purpose: the login writes
-      # ~/.docker/config.json and this step adds to that file rather than
-      # replacing it.
       - name: Cache what the image builds download
         uses: ./.github/actions/apt-cache
 
@@ -466,9 +463,6 @@ jobs:
           fi
           printf '%s' "$REGISTRY_TOKEN" | docker login -u "$REGISTRY_USER" --password-stdin
 
-      # Between the login and the images on purpose: the login writes
-      # ~/.docker/config.json and this step adds to that file rather than
-      # replacing it.
       - name: Cache what the image builds download
         uses: ./.github/actions/apt-cache
 
@@ -553,9 +547,6 @@ jobs:
       # The output is the entire point of this job, so the log is kept whatever
       # happens: the probe prints the upgrade-info file, the schema names and the
       # account list, and a failed run whose log was thrown away costs a night.
-      # Between the login and the images on purpose: the login writes
-      # ~/.docker/config.json and this step adds to that file rather than
-      # replacing it.
       - name: Cache what the image builds download
         uses: ./.github/actions/apt-cache
 


### PR DESCRIPTION
The nightly of 2026-09-11 went red in five shards, and in each one only the first test failed — on `madock setup`, past its deadline — while the rest of the shard ran with setup at eight seconds. The build log named it: `archive.ubuntu.com` handed over 144 MB in eleven minutes, nine times slower than the day before. The image cache from `images.txt` cannot reach that: it warms the pulls, and this is apt inside our own Dockerfile.

A caching proxy (squid) on the runner, reached through the `proxies` entry of `~/.docker/config.json` — the client hands it to every build as `http_proxy`, and to builds only under compose. Its cache directory rides on `actions/cache`, keyed on the Dockerfile snippets.

Each e2e job prints hits and misses at the end. The first run is all misses by construction; the second run is the measurement — this PR will be closed and reopened once to get it.