### PR TITLE
Wait for a database to finish initialising before stopping or recreating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v4.2.17**
+
+Fixed:
+- **A database recreated while it was still initialising was left half-made — the "MariaDB directory already full on a fresh project" that could never be reproduced.** The image initialises its data directory on the first start: a temporary server, the account SQL, a stop, a real start. `setup` starts the containers and that sequence begins; a `rebuild`, a `stop` or a `start` after `config:set` within the next ten seconds took the container down in the middle of it. The directory then had the `mysql` schema — so the next start skipped initialisation — and whichever accounts the script had reached: root@localhost with a password, no root@'%', and every `db:execute` answering `ERROR 1130 (HY000): Host '…' is not allowed to connect` for as long as the volume lived. It did not reproduce on a developer machine because there the initialisation finishes before anyone types the next command; CI and a person on a new server are slower. Reproduced on purpose in a VM — setup, then rebuild at once — and it fails every time without the fix. madock now waits for the entrypoint's own "init process done" before stopping or recreating a database container, three minutes at most, and says so while it waits
+
 **v4.2.16**
 
 Fixed:

--- a/src/helper/docker/dbinit.go
+++ b/src/helper/docker/dbinit.go
@@ -1,0 +1,99 @@
+package docker
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/faradey/madock/v4/src/helper/cli/fmtc"
+	"github.com/faradey/madock/v4/src/helper/configs"
+)
+
+// A database image initialises its data directory on the first start: it
+// brings up a temporary server, runs the account and schema SQL against it,
+// stops it, and only then starts for real. That sequence is not transactional.
+// A container recreated in the middle of it — `setup`, a `config:set`, and a
+// `start` within the same ten seconds, which is what every test does and what
+// a person does on a new server — leaves a data directory that has the `mysql`
+// schema, so the next start skips initialisation, and has whichever accounts
+// the script had reached. Measured in CI on 2026-09-11: root@localhost with a
+// password, no root@'%', and the project's own `db:execute` answering
+// `ERROR 1130 (HY000): Host '172.20.0.4' is not allowed to connect` for as long
+// as the volume lives. That is the "MariaDB directory already full on a fresh
+// project" that was struck off the backlog as unreproducible.
+//
+// The fix is to not do that: before a database container is stopped or
+// recreated, wait for its initialisation to finish. The entrypoints say so in
+// their own logs, and those are the markers matched below.
+
+// dbServices are the services whose images initialise a data directory.
+var dbServices = []string{"db", "db2"}
+
+// dbInitTimeout bounds the wait. Initialisation is ten to thirty seconds on a
+// laptop; a container stuck longer than this is not initialising, it is
+// broken, and holding the command hostage to it helps nobody.
+const dbInitTimeout = 3 * time.Minute
+
+// initInProgress reads a database container's log and reports whether the
+// image is still between "started initialising" and "done".
+//
+// MariaDB and MySQL print "Temporary server started" and later
+// "init process done"; PostgreSQL prints "init process complete". A log with
+// none of the start markers is a container that found its directory already
+// initialised, which is the common case and not a wait.
+func initInProgress(log string) bool {
+	started := strings.Contains(log, "Temporary server started") ||
+		strings.Contains(log, "Initializing database files") ||
+		strings.Contains(log, "initializing database")
+	if !started {
+		return false
+	}
+
+	done := strings.Contains(log, "init process done") ||
+		strings.Contains(log, "init process complete") ||
+		strings.Contains(log, "Temporary server stopped")
+
+	return !done
+}
+
+// containerLog is replaceable so the wait can be exercised without a daemon.
+var containerLog = func(container string) string {
+	out, err := exec.Command("docker", "logs", "--tail", "300", container).CombinedOutput()
+	if err != nil {
+		return ""
+	}
+
+	return string(out)
+}
+
+// WaitForDatabaseInit blocks until no database container of the project is
+// mid-initialisation, or the timeout passes.
+//
+// Called before anything that stops or recreates the project's containers. A
+// container that does not exist, or whose log cannot be read, is not waited
+// for: the point is to avoid interrupting work in progress, not to invent it.
+func WaitForDatabaseInit(projectName string) {
+	projectConf := configs.GetProjectConfig(projectName)
+	deadline := time.Now().Add(dbInitTimeout)
+	said := false
+
+	for _, service := range dbServices {
+		if service == "db2" && projectConf["db2/enabled"] != "true" {
+			continue
+		}
+		container := GetContainerName(projectConf, projectName, service)
+
+		for initInProgress(containerLog(container)) {
+			if !said {
+				fmtc.ToDoLn("Waiting for " + service + " to finish initialising its data directory before touching it")
+				said = true
+			}
+			if time.Now().After(deadline) {
+				fmtc.WarningLn(service + " is still initialising after " + dbInitTimeout.String() + " — going ahead; check its log if the database refuses connections afterwards")
+
+				return
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}
+}

--- a/src/helper/docker/dbinit_test.go
+++ b/src/helper/docker/dbinit_test.go
@@ -1,0 +1,72 @@
+package docker
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestInitInProgressReadsTheEntrypointsOwnMarkers pins the three log shapes
+// the wait decides on.
+//
+// The middle one is the case this exists for: a MariaDB entrypoint that has
+// started its temporary server and not yet said it is done. Recreating that
+// container leaves a data directory with the `mysql` schema — so the next start
+// skips initialisation — and whichever accounts the script had reached.
+// Measured in CI on 2026-09-11: root@localhost with a password, no root@'%',
+// and `db:execute` answering ERROR 1130 for as long as the volume lived.
+func TestInitInProgressReadsTheEntrypointsOwnMarkers(t *testing.T) {
+	cases := []struct {
+		name string
+		log  string
+		want bool
+	}{
+		{"found an initialised directory, started straight away",
+			"[Entrypoint]: MariaDB upgrade not required\n[Note] mariadbd: ready for connections.\n", false},
+		{"mid-initialisation",
+			"[Entrypoint]: Initializing database files\n[Entrypoint]: Temporary server started.\n", true},
+		{"initialisation finished",
+			"[Entrypoint]: Temporary server started.\n[Entrypoint]: Temporary server stopped\n[Entrypoint]: MariaDB init process done. Ready for start up.\n", false},
+		{"postgres mid-initialisation",
+			"initializing database system\nselecting default max_connections ... 100\n", true},
+		{"postgres finished",
+			"initializing database system\nPostgreSQL init process complete; ready for start up.\n", false},
+		{"no log at all", "", false},
+	}
+
+	for _, c := range cases {
+		if got := initInProgress(c.log); got != c.want {
+			t.Errorf("%s: initInProgress = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestTheWaitEndsWhenTheEntrypointSaysDone drives the wait with a log that
+// finishes on the third read, and asserts it neither returns early nor waits
+// for the timeout.
+func TestTheWaitEndsWhenTheEntrypointSaysDone(t *testing.T) {
+	reads := 0
+	orig := containerLog
+	containerLog = func(container string) string {
+		reads++
+		if !strings.Contains(container, "-db-1") {
+			t.Errorf("asked about %s, which is not the database", container)
+		}
+		if reads < 3 {
+			return "[Entrypoint]: Temporary server started.\n"
+		}
+
+		return "[Entrypoint]: Temporary server started.\n[Entrypoint]: MariaDB init process done.\n"
+	}
+	t.Cleanup(func() { containerLog = orig })
+
+	started := time.Now()
+	WaitForDatabaseInit("waitproject")
+
+	if reads < 3 {
+		t.Errorf("the wait gave up after %d reads while the entrypoint was still initialising", reads)
+	}
+	if time.Since(started) > 30*time.Second {
+		t.Errorf("the wait ran to its timeout although the entrypoint said done on the third read")
+	}
+}

--- a/src/helper/docker/docker.go
+++ b/src/helper/docker/docker.go
@@ -88,6 +88,8 @@ func UpWithBuild(projectName string, withChown bool) {
 // files), it falls back to scanning docker by the compose project
 // label so orphan containers/volumes/networks/images still get cleaned.
 func Down(projectName string, withVolumes bool) {
+	WaitForDatabaseInit(projectName)
+
 	pp := paths.NewProjectPaths(projectName)
 	composeFile := pp.DockerCompose()
 	composeFileOS := pp.DockerComposeOverride()
@@ -288,6 +290,8 @@ func parseComposePS(psOutput []byte) []ServiceState {
 // without recreating or rebuilding anything — which is what a snapshot needs:
 // the data directory has to be quiet, not gone.
 func Stop(projectName string) error {
+	WaitForDatabaseInit(projectName)
+
 	pp := paths.NewProjectPaths(projectName)
 	composeFile := pp.DockerCompose()
 	if !paths.IsFileExist(composeFile) {
@@ -495,6 +499,10 @@ func UpProjectWithBuildRefresh(projectName string, withChown bool) {
 }
 
 func upProjectWithBuild(projectName string, withChown bool, refresh bool) {
+	// --force-recreate below stops whatever is running, and a database that is
+	// still initialising must not be stopped: see dbinit.go.
+	WaitForDatabaseInit(projectName)
+
 	var err error
 	globalComposer := paths.ComposerDir()
 	if !paths.IsFileExist(globalComposer) {

--- a/src/version/version.go
+++ b/src/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is the current madock release version.
 // Used by migration system for semver comparison.
-const Version = "4.2.16"
+const Version = "4.2.17"

--- a/test/e2e/dbinit_test.go
+++ b/test/e2e/dbinit_test.go
@@ -1,0 +1,62 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRecreatingADatabaseWaitsForItsInitialisation is the "MariaDB directory
+// already full on a fresh project" case, reproduced on purpose.
+//
+// `setup` starts the containers, and the database image begins initialising
+// its data directory: a temporary server, the account SQL, a stop, a real
+// start. `rebuild` a second later took that container down in the middle of
+// it. The data directory then had the `mysql` schema — so the next start
+// skipped initialisation — and whichever accounts the script had reached:
+// root@localhost with a password, no root@'%'. Every `db:execute` after that
+// answered ERROR 1130, for as long as the volume lived.
+//
+// It was struck off the backlog as unreproducible because a developer machine
+// finishes initialising before anyone can type the next command. CI, and a
+// person on a new server following the README, are slower than that. Measured
+// in CI on 2026-09-11 in two tests that do setup, config:set and start within
+// the same ten seconds.
+func TestRecreatingADatabaseWaitsForItsInitialisation(t *testing.T) {
+	p := newProject(t, "e2edbinit")
+	p.run(5*time.Minute, "setup", "-y",
+		"--platform=custom",
+		"--language=none",
+		"--hosts=e2edbinit.test",
+	)
+
+	// No pause here, deliberately: the rebuild has to land while the
+	// database is still initialising, which is the whole reproduction.
+	p.run(20*time.Minute, "rebuild")
+
+	// The account the image creates last is root@'%', and it is the one every
+	// madock command connects as. If the initialisation was interrupted this
+	// answers 1130 on every attempt, and the harness gives that a minute.
+	if out := p.query("SELECT 1"); !strings.Contains(out, "1") {
+		t.Errorf("the database does not answer after a rebuild that followed setup at once:\n%s", out)
+	}
+
+	// The log of the container that survived must show a completed
+	// initialisation or none at all — never a start that found a directory
+	// the previous container had half-written.
+	log := p.run(2*time.Minute, "logs", "-s", "db")
+	if strings.Contains(log, "Starting crash recovery") {
+		t.Errorf("the database recovered a directory the previous container left half-written — the rebuild did not wait:\n%s", tail(log, 30))
+	}
+}
+
+func tail(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
The "MariaDB directory already full on a fresh project", struck off the backlog as unreproducible, has a mechanism. The image initialises its data directory on the first start — temporary server, account SQL, stop, real start — and that is not transactional. `setup` starts the containers and the sequence begins; a `rebuild`, a `stop`, or a `start` after `config:set` within the next ten seconds takes the container down in the middle of it. The directory then has the `mysql` schema, so the next start skips initialisation, and whichever accounts the script had reached: root@localhost with a password, no root@'%'. Every `db:execute` after that answers `ERROR 1130` for as long as the volume lives.

Measured in CI on 2026-09-11 in two tests that do exactly that. Reproduced on purpose in a VM — setup, then rebuild at once — and it fails every time without the fix.

`Down`, `Stop` and the force-recreate path now wait for the entrypoint's own "init process done" (MariaDB, MySQL) or "init process complete" (PostgreSQL), three minutes at most.

Proved by breaking it twice: inverting the marker check fails four unit cases; turning the wait into a no-op fails the e2e reproduction with `ERROR 1130`.